### PR TITLE
feat: 메뉴 계층 구조 조회 API 추가

### DIFF
--- a/src/main/java/com/academy/mapper/MenuMapper.java
+++ b/src/main/java/com/academy/mapper/MenuMapper.java
@@ -1,0 +1,15 @@
+package com.academy.mapper;
+
+import java.util.ArrayList;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.json.simple.JSONObject;
+
+import com.academy.menu.service.MenuVO;
+
+@Mapper
+public interface MenuMapper {
+
+    public ArrayList<JSONObject> selectMenuList(MenuVO menuVO);
+
+}

--- a/src/main/java/com/academy/menu/MenuApi.java
+++ b/src/main/java/com/academy/menu/MenuApi.java
@@ -1,0 +1,35 @@
+package com.academy.menu;
+
+import java.util.HashMap;
+
+import org.json.simple.JSONObject;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.academy.common.CORSFilter;
+import com.academy.menu.service.MenuService;
+import com.academy.menu.service.MenuVO;
+
+@RestController
+@RequestMapping("/api/menu")
+public class MenuApi extends CORSFilter {
+
+    private MenuService menuService;
+
+    public MenuApi(MenuService menuService) {
+        this.menuService = menuService;
+    }
+
+    @GetMapping(value = "/getMenuTree")
+    public JSONObject getMenuTree(@ModelAttribute("MenuVO") MenuVO menuVO) throws Exception {
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        jsonObject.put("menuTree", menuService.getMenuHierarchy(menuVO));
+
+        JSONObject jObject = new JSONObject(jsonObject);
+        return jObject;
+    }
+
+}

--- a/src/main/java/com/academy/menu/service/MenuService.java
+++ b/src/main/java/com/academy/menu/service/MenuService.java
@@ -1,0 +1,78 @@
+package com.academy.menu.service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.json.simple.JSONObject;
+import org.springframework.stereotype.Service;
+
+import com.academy.mapper.MenuMapper;
+
+@Service
+public class MenuService {
+
+    private MenuMapper menuMapper;
+
+    public MenuService(MenuMapper menuMapper) {
+        this.menuMapper = menuMapper;
+    }
+
+    /**
+     * 메뉴를 계층구조로 반환한다. (root부터 하위 노드까지 중첩된 구조)
+     * 반환 타입은 ArrayList<JSONObject>로 프론젝트 관례에 맞춘다.
+     */
+    public ArrayList<JSONObject> getMenuHierarchy(MenuVO menuVO) {
+        ArrayList<JSONObject> flat = menuMapper.selectMenuList(menuVO);
+
+        // build map of id -> node
+        Map<Integer, JSONObject> map = new HashMap<>();
+        List<JSONObject> roots = new ArrayList<>();
+
+        for (JSONObject obj : flat) {
+            // normalize fields and ensure children array
+            JSONObject node = new JSONObject();
+            Integer id = ((Number) obj.get("menu_no")).intValue();
+            node.put("menuNo", id);
+            node.put("menuId", obj.get("menu_id"));
+            node.put("menuTitle", obj.get("menu_title"));
+            node.put("menuUrl", obj.get("menu_url"));
+            node.put("menuIcon", obj.get("menu_icon"));
+            node.put("menuUpperId", obj.get("menu_upper_id"));
+            node.put("menuDepth", obj.get("menu_depth"));
+            node.put("isUse", obj.get("is_use"));
+            node.put("children", new ArrayList<JSONObject>());
+
+            map.put(id, node);
+        }
+
+        for (JSONObject node : map.values()) {
+            Object parentObj = node.get("menuUpperId");
+            int parentId = 0;
+            if (parentObj != null) {
+                try {
+                    parentId = ((Number) parentObj).intValue();
+                } catch (Exception e) {
+                    parentId = Integer.parseInt(String.valueOf(parentObj));
+                }
+            }
+            if (parentId == 0) {
+                roots.add(node);
+            } else {
+                JSONObject parent = map.get(parentId);
+                if (parent != null) {
+                    @SuppressWarnings("unchecked")
+                    ArrayList<JSONObject> children = (ArrayList<JSONObject>) parent.get("children");
+                    children.add(node);
+                } else {
+                    // Orphan node; treat as root
+                    roots.add(node);
+                }
+            }
+        }
+
+        return new ArrayList<>(roots);
+    }
+
+}

--- a/src/main/java/com/academy/menu/service/MenuVO.java
+++ b/src/main/java/com/academy/menu/service/MenuVO.java
@@ -1,0 +1,35 @@
+package com.academy.menu.service;
+
+import com.academy.common.CommonVO;
+
+public class MenuVO extends CommonVO {
+
+    private int menuNo;
+    private int menuUpperId;
+    private String isUse;
+
+    public int getMenuNo() {
+        return menuNo;
+    }
+
+    public void setMenuNo(int menuNo) {
+        this.menuNo = menuNo;
+    }
+
+    public int getMenuUpperId() {
+        return menuUpperId;
+    }
+
+    public void setMenuUpperId(int menuUpperId) {
+        this.menuUpperId = menuUpperId;
+    }
+
+    public String getIsUse() {
+        return isUse;
+    }
+
+    public void setIsUse(String isUse) {
+        this.isUse = isUse;
+    }
+
+}

--- a/src/main/resources/mapper/menu.xml
+++ b/src/main/resources/mapper/menu.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.academy.mapper.MenuMapper">
+
+    <!-- 전체 메뉴 조회 (flat list). acm_menu_mst 테이블을 기반으로 필요한 컬럼을 반환 -->
+    <select id="selectMenuList" resultType="org.json.simple.JSONObject" parameterType="com.academy.menu.service.MenuVO">
+        SELECT menu_no, menu_id, menu_title, menu_type, menu_icon, menu_url, menu_exact, menu_target,
+               menu_breadcrumbs, menu_external, menu_left, menu_path, menu_element, menu_layout,
+               menu_upper_id, menu_depth, is_use
+        FROM acm_menu_mst
+        WHERE 1=1
+        <if test="isUse != null and isUse != ''">
+            AND is_use = #{isUse}
+        </if>
+        ORDER BY menu_upper_id, menu_sort
+    </select>
+
+</mapper>


### PR DESCRIPTION
메뉴 정보를 동적으로 렌더링하기 위해 계층화된 메뉴 데이터를 제공하는 API를 추가합니다.

주요 변경 사항:
- GET /api/menu/getMenuTree 엔드포인트를 통해 메뉴 트리 구조를 JSON 형식으로 반환합니다.
- DB에서 플랫(flat)한 메뉴 목록을 조회한 후, 서비스 레이어에서 이를 트리 구조로 가공하여 반환하는 로직을 구현했습니다.
- 메뉴 기능 관련 MVC 컴포넌트(Api, Service, VO) 및 MyBatis 매퍼(Java, XML)를 추가했습니다.