### PR TITLE
refactor: replace LectureService interface with a direct implementation

### DIFF
--- a/src/main/java/com/academy/lecture/LectureApi.java
+++ b/src/main/java/com/academy/lecture/LectureApi.java
@@ -28,7 +28,7 @@ import com.academy.book.service.BookService;
 import com.academy.lecture.service.LectureService;
 import com.academy.lecture.service.SubjectService;
 import com.academy.lecture.service.TeacherService;
-import com.academy.productOrder.service.ProductOrderService;
+import com.academy.productorder.service.ProductOrderService;
 
 @RestController
 @RequestMapping("/api/lecture")
@@ -44,7 +44,6 @@ public class LectureApi extends CORSFilter {
 	private SubjectService subjectService;
 	private ProductOrderService productOrderService;
 
-	@Autowired
 	public LectureApi(BookService bookservice, LectureService lectureservice,
 			TeacherService teacherservice, CmmUseService cmmUseService,
 			SubjectService subjectService, ProductOrderService productOrderService) {

--- a/src/main/java/com/academy/lecture/service/LectureService.java
+++ b/src/main/java/com/academy/lecture/service/LectureService.java
@@ -3,144 +3,288 @@ package com.academy.lecture.service;
 import java.util.HashMap;
 import java.util.List;
 
-public interface LectureService {
+import org.springframework.stereotype.Service;
 
-	List<HashMap<String, String>> lectureList(HashMap<String, String> params);
+import com.academy.mapper.LectureMapper;
 
-	List<HashMap<String, String>> oldFreeToNewFree(HashMap<String, String> params);
+/**
+ * Lecture Service
+ * LoginService 패턴 적용 - ServiceImpl 없이 @Service 클래스로 직접 구현
+ */
+@Service
+public class LectureService {
 
-	int lectureListCount(HashMap<String, String> params);
+	private LectureMapper lectureMapper;
 
-	List<HashMap<String, String>> bookList(HashMap<String, String> params);
+	public LectureService(LectureMapper lectureMapper) {
+		this.lectureMapper = lectureMapper;
+	}
 
-	int bookListCount(HashMap<String, String> params);
+	public List<HashMap<String, String>> lectureList(HashMap<String, String> params) {
+		return lectureMapper.lectureList(params);
+	}
 
-	List<HashMap<String, String>> getBridgeLeccodeSeq(HashMap<String, String> params);// 삭제대상
+	public List<HashMap<String, String>> oldFreeToNewFree(HashMap<String, String> params) {
+		return lectureMapper.oldFreeToNewFree(params);
+	}
 
-	List<HashMap<String, String>> getJongLeccodeSeq(HashMap<String, String> params); // 삭제대상
+	public int lectureListCount(HashMap<String, String> params) {
+		return lectureMapper.lectureListCount(params);
+	}
 
-	List<HashMap<String, String>> getLeccode(HashMap<String, String> params); // 삭제대상
+	public List<HashMap<String, String>> bookList(HashMap<String, String> params) {
+		return lectureMapper.bookList(params);
+	}
 
-	List<HashMap<String, String>> getBridgeLeccode(HashMap<String, String> params);//삭제대상
+	public int bookListCount(HashMap<String, String> params) {
+		return lectureMapper.bookListCount(params);
+	}
 
-	List<HashMap<String, String>> BridgeLeccode(HashMap<String, String> params);
+	public List<HashMap<String, String>> getBridgeLeccodeSeq(HashMap<String, String> params) {
+		return lectureMapper.getBridgeLeccodeSeq(params);
+	}
 
-	void lectureInsert(HashMap<String, String> params);
+	public List<HashMap<String, String>> getJongLeccodeSeq(HashMap<String, String> params) {
+		return lectureMapper.getJongLeccodeSeq(params);
+	}
 
-	void lectureBridgeInsert(HashMap<String, String> params);
+	public List<HashMap<String, String>> getLeccode(HashMap<String, String> params) {
+		return lectureMapper.getLeccode(params);
+	}
 
-	void lectureBookInsert(HashMap<String, String> params);
+	public List<HashMap<String, String>> getBridgeLeccode(HashMap<String, String> params) {
+		return lectureMapper.getBridgeLeccode(params);
+	}
 
-	void lectureBookInsert2(HashMap<String, String> params);
+	public List<HashMap<String, String>> BridgeLeccode(HashMap<String, String> params) {
+		return lectureMapper.BridgeLeccode(params);
+	}
 
-	List<HashMap<String, String>> lectureViewList(HashMap<String, String> params);
+	public void lectureInsert(HashMap<String, String> params) {
+		lectureMapper.lectureInsert(params);
+	}
 
-	List<HashMap<String, String>> lectureView(HashMap<String, String> params);
+	public void lectureBridgeInsert(HashMap<String, String> params) {
+		lectureMapper.lectureBridgeInsert(params);
+	}
 
-	List<HashMap<String, String>> lectureViewBookList(HashMap<String, String> params);
+	public void lectureBookInsert(HashMap<String, String> params) {
+		lectureMapper.lectureBookInsert(params);
+	}
 
-	void lectureBookDelete(HashMap<String, String> params);
+	public void lectureBookInsert2(HashMap<String, String> params) {
+		lectureMapper.lectureBookInsert2(params);
+	}
 
-	void lectureUpdate(HashMap<String, String> params);
+	public List<HashMap<String, String>> lectureViewList(HashMap<String, String> params) {
+		return lectureMapper.lectureViewList(params);
+	}
 
-	void Modify_Lecture_On_Off(HashMap<String, String> params);
+	public List<HashMap<String, String>> lectureView(HashMap<String, String> params) {
+		return lectureMapper.lectureView(params);
+	}
 
-	void lectureIsUseUpdate(HashMap<String, String> params);
+	public List<HashMap<String, String>> lectureViewBookList(HashMap<String, String> params) {
+		return lectureMapper.lectureViewBookList(params);
+	}
 
-	void lectureDelete(HashMap<String, String> params);
+	public void lectureBookDelete(HashMap<String, String> params) {
+		lectureMapper.lectureBookDelete(params);
+	}
 
-	void lectureBridgeDelete(HashMap<String, String> params);
+	public void lectureUpdate(HashMap<String, String> params) {
+		lectureMapper.lectureUpdate(params);
+	}
 
-	void lecMovUpdate(HashMap<String, String> params);
+	public void Modify_Lecture_On_Off(HashMap<String, String> params) {
+		lectureMapper.Modify_Lecture_On_Off(params);
+	}
 
-	List<HashMap<String, String>> lectureSeqList(HashMap<String, String> params);
+	public void lectureIsUseUpdate(HashMap<String, String> params) {
+		lectureMapper.lectureIsUseUpdate(params);
+	}
 
-	void lectureSeqUpdate(HashMap<String, String> params);
+	public void lectureDelete(HashMap<String, String> params) {
+		lectureMapper.lectureDelete(params);
+	}
 
+	public void lectureBridgeDelete(HashMap<String, String> params) {
+		lectureMapper.lectureBridgeDelete(params);
+	}
 
+	public void lecMovUpdate(HashMap<String, String> params) {
+		lectureMapper.lecMovUpdate(params);
+	}
 
-	List<HashMap<String, String>> lectureViewJongList(HashMap<String, String> params);
+	public List<HashMap<String, String>> lectureSeqList(HashMap<String, String> params) {
+		return lectureMapper.lectureSeqList(params);
+	}
 
-	List<HashMap<String, String>> lectureJongList(HashMap<String, String> params);
+	public void lectureSeqUpdate(HashMap<String, String> params) {
+		lectureMapper.lectureSeqUpdate(params);
+	}
 
-	int lectureJongListCount(HashMap<String, String> params);
+	public List<HashMap<String, String>> lectureViewJongList(HashMap<String, String> params) {
+		return lectureMapper.lectureViewJongList(params);
+	}
 
-	List<HashMap<String, String>> lectureYearList(HashMap<String, String> params);
+	public List<HashMap<String, String>> lectureJongList(HashMap<String, String> params) {
+		return lectureMapper.lectureJongList(params);
+	}
 
-	int lectureYearListCount(HashMap<String, String> params);
+	public int lectureJongListCount(HashMap<String, String> params) {
+		return lectureMapper.lectureJongListCount(params);
+	}
 
-	List<HashMap<String, String>> lectureJongSubjectList(HashMap<String, String> params);
+	public List<HashMap<String, String>> lectureYearList(HashMap<String, String> params) {
+		return lectureMapper.lectureYearList(params);
+	}
 
-	List<HashMap<String, String>> lectureJongView(HashMap<String, String> params);
+	public int lectureYearListCount(HashMap<String, String> params) {
+		return lectureMapper.lectureYearListCount(params);
+	}
 
-	int lectureJongSubjectListCount(HashMap<String, String> params);
+	public List<HashMap<String, String>> lectureJongSubjectList(HashMap<String, String> params) {
+		return lectureMapper.lectureJongSubjectList(params);
+	}
 
-	void lectureLecJongInsert(HashMap<String, String> params);
+	public List<HashMap<String, String>> lectureJongView(HashMap<String, String> params) {
+		return lectureMapper.lectureJongView(params);
+	}
 
-	void lectureChoiceJongNoInsert(HashMap<String, String> params);
+	public int lectureJongSubjectListCount(HashMap<String, String> params) {
+		return lectureMapper.lectureJongSubjectListCount(params);
+	}
 
-	List<HashMap<String, String>> lectureViewLeccodeList(HashMap<String, String> params);
+	public void lectureLecJongInsert(HashMap<String, String> params) {
+		lectureMapper.lectureLecJongInsert(params);
+	}
 
-	void lectureLecJongDelete(HashMap<String, String> params);
+	public void lectureChoiceJongNoInsert(HashMap<String, String> params) {
+		lectureMapper.lectureChoiceJongNoInsert(params);
+	}
 
-	void lectureChoiceJongNoDelete(HashMap<String, String> params);
+	public List<HashMap<String, String>> lectureViewLeccodeList(HashMap<String, String> params) {
+		return lectureMapper.lectureViewLeccodeList(params);
+	}
 
-	List<HashMap<String, String>> lecturePayList(HashMap<String, String> params);
+	public void lectureLecJongDelete(HashMap<String, String> params) {
+		lectureMapper.lectureLecJongDelete(params);
+	}
 
-	List<HashMap<String, String>> lectureJongPayList(HashMap<String, String> params);
+	public void lectureChoiceJongNoDelete(HashMap<String, String> params) {
+		lectureMapper.lectureChoiceJongNoDelete(params);
+	}
 
-	List<HashMap<String, String>> lectureDataMemoViewList(HashMap<String, String> params);
+	public List<HashMap<String, String>> lecturePayList(HashMap<String, String> params) {
+		return lectureMapper.lecturePayList(params);
+	}
 
-	List<HashMap<String, String>> lectureDataViewList(HashMap<String, String> params);
+	public List<HashMap<String, String>> lectureJongPayList(HashMap<String, String> params) {
+		return lectureMapper.lectureJongPayList(params);
+	}
 
-	List<HashMap<String, String>> lectureMobileList(HashMap<String, String> params);
+	public List<HashMap<String, String>> lectureDataMemoViewList(HashMap<String, String> params) {
+		return lectureMapper.lectureDataMemoViewList(params);
+	}
 
-	List<HashMap<String, String>> lectureDataMovieViewList(HashMap<String, String> params);
+	public List<HashMap<String, String>> lectureDataViewList(HashMap<String, String> params) {
+		return lectureMapper.lectureDataViewList(params);
+	}
 
-	List<HashMap<String, String>> lectureDataMovieList(HashMap<String, String> params);
+	public List<HashMap<String, String>> lectureMobileList(HashMap<String, String> params) {
+		return lectureMapper.lectureMobileList(params);
+	}
 
-	void lectureMovieInsert(HashMap<String, String> params);
+	public List<HashMap<String, String>> lectureDataMovieViewList(HashMap<String, String> params) {
+		return lectureMapper.lectureDataMovieViewList(params);
+	}
 
-	void lectureMovieDelete(HashMap<String, String> params);
+	public List<HashMap<String, String>> lectureDataMovieList(HashMap<String, String> params) {
+		return lectureMapper.lectureDataMovieList(params);
+	}
 
-	void lectureMovieUpdate(HashMap<String, String> params);
+	public void lectureMovieInsert(HashMap<String, String> params) {
+		lectureMapper.lectureMovieInsert(params);
+	}
 
-	void lectureMovieFileDelete(HashMap<String, String> params);
+	public void lectureMovieDelete(HashMap<String, String> params) {
+		lectureMapper.lectureMovieDelete(params);
+	}
 
+	public void lectureMovieUpdate(HashMap<String, String> params) {
+		lectureMapper.lectureMovieUpdate(params);
+	}
 
-	void lectureMovieMemoInsert(HashMap<String, String> params);
+	public void lectureMovieFileDelete(HashMap<String, String> params) {
+		lectureMapper.lectureMovieFileDelete(params);
+	}
 
+	public void lectureMovieMemoInsert(HashMap<String, String> params) {
+		lectureMapper.lectureMovieMemoInsert(params);
+	}
 
-	void lectureMovieMemoUpdate(HashMap<String, String> params);
+	public void lectureMovieMemoUpdate(HashMap<String, String> params) {
+		lectureMapper.lectureMovieMemoUpdate(params);
+	}
 
-	void lectureMovieMemoDelete(HashMap<String, String> params);
+	public void lectureMovieMemoDelete(HashMap<String, String> params) {
+		lectureMapper.lectureMovieMemoDelete(params);
+	}
 
-	int lectureDeleteCheck(HashMap<String, String> params);
+	public int lectureDeleteCheck(HashMap<String, String> params) {
+		return lectureMapper.lectureDeleteCheck(params);
+	}
 
+	public List<HashMap<String, String>> playinfo(HashMap<String, String> params) {
+		return lectureMapper.playinfo(params);
+	}
 
-	List<HashMap<String, String>> playinfo(HashMap<String, String> params);
+	public List<HashMap<String, String>> getCbMovie4_free_admin(HashMap<String, String> params) {
+		return lectureMapper.getCbMovie4_free_admin(params);
+	}
 
-	List<HashMap<String, String>> getCbMovie4_free_admin(HashMap<String, String> params);
+	public int getCbMovie4_free_admin_count(HashMap<String, String> params) {
+		return lectureMapper.getCbMovie4_free_admin_count(params);
+	}
 
-	int getCbMovie4_free_admin_count(HashMap<String, String> params);
+	public HashMap<String, String> lectureOnDetailS(HashMap<String, String> params) {
+		return lectureMapper.lectureOnDetailS(params);
+	}
 
-	HashMap<String, String> lectureOnDetailS(HashMap<String, String> params);
+	public void insertPmpDownLog(HashMap<String, String> params) {
+		lectureMapper.insertPmpDownLog(params);
+	}
 
-	void insertPmpDownLog(HashMap<String, String> params);
+	public List<HashMap<String, String>> lectureWMV(HashMap<String, String> params) {
+		return lectureMapper.lectureWMV(params);
+	}
 
-	List<HashMap<String, String>> lectureWMV(HashMap<String, String> params);
+	public List<HashMap<String, String>> lectureDown_Count(HashMap<String, String> params) {
+		return lectureMapper.lectureDown_Count(params);
+	}
 
-	List<HashMap<String, String>> lectureDown_Count(HashMap<String, String> params);
+	public void oldFreeToNewFreeInsert(HashMap<String, String> params) {
+		lectureMapper.oldFreeToNewFreeInsert(params);
+	}
 
-	void oldFreeToNewFreeInsert(HashMap<String, String> params);
-	
-	void oldBogangFreeToNewBogangFree(HashMap<String, String> params);
-	
-	List<HashMap<String, String>> lectureFreePassPayList(HashMap<String, String> params);
-	
-	List<HashMap<String, String>> YearIngList(HashMap<String, String> params);
-	
-	List<HashMap<String, String>> MyYearIngList(HashMap<String, String> params);
-	
-	List<HashMap<String, String>> bookView(HashMap<String, String> params);
+	public void oldBogangFreeToNewBogangFree(HashMap<String, String> params) {
+		lectureMapper.oldBogangFreeToNewBogangFree(params);
+	}
+
+	public List<HashMap<String, String>> lectureFreePassPayList(HashMap<String, String> params) {
+		return lectureMapper.lectureFreePassPayList(params);
+	}
+
+	public List<HashMap<String, String>> YearIngList(HashMap<String, String> params) {
+		return lectureMapper.YearIngList(params);
+	}
+
+	public List<HashMap<String, String>> MyYearIngList(HashMap<String, String> params) {
+		return lectureMapper.MyYearIngList(params);
+	}
+
+	public List<HashMap<String, String>> bookView(HashMap<String, String> params) {
+		return lectureMapper.bookView(params);
+	}
 }


### PR DESCRIPTION
Replaced `LectureService` interface with a concrete service implementation using the `@Service` annotation. Updated the mapper injection method and refactored methods to directly leverage `LectureMapper` for database interactions. Removed unused constructors, annotations, and legacy code.