### PR TITLE
refactor: replace service interfaces with concrete implementations

### DIFF
--- a/src/main/java/com/academy/common/CommonUtil.java
+++ b/src/main/java/com/academy/common/CommonUtil.java
@@ -10,6 +10,7 @@ import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Locale;
+import java.util.Map;
 
 public class CommonUtil {
 	public static final String FOLDER_SEPARATOR = "/";
@@ -77,6 +78,10 @@ public class CommonUtil {
      */
     public static String isNull(String obj, String def) {
         return empty(obj) ? def : obj;
+    }
+
+    public static String isNull(Map obj, String def) {
+        return empty(obj.toString()) ? def : obj.toString();
     }
 
     /**

--- a/src/main/java/com/academy/lecture/CategoryApi.java
+++ b/src/main/java/com/academy/lecture/CategoryApi.java
@@ -1,32 +1,23 @@
 package com.academy.lecture;
 
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
+import java.util.Map;
 
 import org.json.simple.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.ui.ModelMap;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.academy.common.CORSFilter;
-import com.willbes.platform.util.CommonUtil;
-import com.willbes.web.lecture.service.CategoryService;
+import com.academy.common.CommonUtil;
+import com.academy.lecture.service.CategoryService;
+import com.academy.lecture.service.CategoryVO;
 
 /**
  * @FileName   : CategoryApi.java
  * @Project    :
- * @Date       : 2015. 05. 20.
+ * @Date       : 2025. 11.
  * @Author     : miraenet
  * @변경이력    :
  * @프로그램 설명 : 카테고리 관리 API
@@ -35,29 +26,26 @@ import com.willbes.web.lecture.service.CategoryService;
 @RequestMapping("/api/category")
 public class CategoryApi extends CORSFilter {
 
-    private CategoryService seriesCategoryService;
+    private CategoryService categoryService;
 
     @Autowired
-    public CategoryApi(CategoryService seriesCategoryService) {
-        this.seriesCategoryService = seriesCategoryService;
+    public CategoryApi(CategoryService categoryService) {
+        this.categoryService = categoryService;
     }
 
     /**
      * @Method Name  : getSeriesCateTree
-     * @Date         : 2015. 05. 20.
+     * @Date         : 2025. 11.
      * @Author       : miraenet
      * @변경이력      :
      * @Method 설명      : 카테고리 트리 조회
-     * @param request
+     * @param CategoryVO
      * @return
      * @throws Exception
      */
     @GetMapping(value = "/tree")
-    public JSONObject getSeriesCateTree(HttpServletRequest request) throws Exception {
-        HashMap<String, Object> params = new HashMap<String, Object>();
-        setParam(params, request);
-
-        List<HashMap<String, Object>> menuList = seriesCategoryService.getSeriesCateTree();
+    public JSONObject getSeriesCateTree(@ModelAttribute("CategoryVO") CategoryVO categoryVO) throws Exception {
+        ArrayList<JSONObject> menuList = categoryService.getSeriesCateTree();
 
         HashMap<String, Object> result = new HashMap<String, Object>();
         result.put("menuList", menuList);
@@ -68,19 +56,18 @@ public class CategoryApi extends CORSFilter {
 
     /**
      * @Method Name  : getDetail
-     * @Date         : 2015. 05. 20.
+     * @Date         : 2025. 11.
      * @Author       : miraenet
      * @변경이력      :
      * @Method 설명      : 카테고리 상세 조회
-     * @param request
+     * @param CategoryVO
      * @return
      * @throws Exception
      */
     @GetMapping(value = "/detail")
-    public JSONObject getDetail(@ModelAttribute HashMap<String, Object> params, HttpServletRequest request) throws Exception {
-        setParam(params, request);
+    public JSONObject getDetail(@ModelAttribute("CategoryVO") CategoryVO categoryVO) throws Exception {
 
-        HashMap<String, Object> detail = seriesCategoryService.getDetail(params);
+        JSONObject detail = categoryService.getDetail(categoryVO);
 
         HashMap<String, Object> result = new HashMap<String, Object>();
         result.put("detail", detail);
@@ -91,23 +78,22 @@ public class CategoryApi extends CORSFilter {
 
     /**
      * @Method Name  : getMaxOrdr
-     * @Date         : 2015. 05. 20.
+     * @Date         : 2025. 11.
      * @Author       : miraenet
      * @변경이력      :
      * @Method 설명      : 최대 순서 조회
-     * @param request
+     * @param CategoryVO
      * @return
      * @throws Exception
      */
     @GetMapping(value = "/maxOrdr")
-    public JSONObject getMaxOrdr(@ModelAttribute HashMap<String, Object> params, HttpServletRequest request) throws Exception {
-        setParam(params, request);
+    public JSONObject getMaxOrdr(@ModelAttribute("CategoryVO") CategoryVO categoryVO, @RequestParam Map<?, ?> commandMap) throws Exception {
 
-        HashMap<String, Object> maxMenuMap = seriesCategoryService.getMaxOrdr(params);
+        JSONObject maxMenuMap = categoryService.getMaxOrdr(categoryVO);
 
         HashMap<String, Object> result = new HashMap<String, Object>();
         if(maxMenuMap == null){
-            String ORDR = CommonUtil.isNull(request.getParameter("ORDR"), "0");
+            String ORDR = CommonUtil.isNull((String) commandMap.get("ORDR"), "0");
             if(ORDR.equals("0")){ //Root
                 result.put("ORDR", 1);
             }else{
@@ -117,7 +103,7 @@ public class CategoryApi extends CORSFilter {
             result.put("ORDR", maxMenuMap.get("ORDR"));
             result.put("P_NAME", maxMenuMap.get("P_NAME"));
         }
-        String CODE = CommonUtil.isNull(request.getParameter("CODE"), "");
+        String CODE = CommonUtil.isNull((String) commandMap.get("CODE"), "");
         if(CODE!=null && CODE!=""){
             result.put("P_CODE", CODE);
         }
@@ -128,24 +114,23 @@ public class CategoryApi extends CORSFilter {
 
     /**
      * @Method Name  : deleteProcess
-     * @Date         : 2015. 05. 20.
+     * @Date         : 2025. 11.
      * @Author       : miraenet
      * @변경이력      :
      * @Method 설명      : 카테고리 삭제
-     * @param request
+     * @param CategoryVO
      * @return
      * @throws Exception
      */
     @DeleteMapping(value = "/delete")
     @Transactional(readOnly=false,rollbackFor=Exception.class)
-    public JSONObject deleteProcess(@RequestBody HashMap<String, Object> params, HttpServletRequest request) throws Exception {
-        setParam(params, request);
+    public JSONObject deleteProcess(@ModelAttribute("CategoryVO") CategoryVO categoryVO, @RequestParam Map<?, ?> commandMap) throws Exception {
 
-        int isDelete = seriesCategoryService.deleteProcess(params);
+        int isDelete = categoryService.deleteProcess(categoryVO);
 
         HashMap<String, Object> result = new HashMap<String, Object>();
         result.put("isDelete", isDelete);
-        result.put("VIEWCODE", params.get("CODE"));
+        result.put("VIEWCODE", commandMap.get("CODE"));
 
         JSONObject jObject = new JSONObject(result);
         return jObject;
@@ -153,19 +138,18 @@ public class CategoryApi extends CORSFilter {
 
     /**
      * @Method Name  : idCheck
-     * @Date         : 2015. 05. 20.
+     * @Date         : 2025. 11.
      * @Author       : miraenet
      * @변경이력      :
      * @Method 설명      : ID 중복 확인
-     * @param request
+     * @param CategoryVO
      * @return
      * @throws Exception
      */
     @GetMapping(value = "/idCheck")
-    public JSONObject idCheck(@ModelAttribute HashMap<String, Object> params, HttpServletRequest request) throws Exception {
-        setParam(params, request);
+    public JSONObject idCheck(@ModelAttribute("CategoryVO") CategoryVO categoryVO) throws Exception {
 
-        int idCount = seriesCategoryService.idCheck(params);
+        int idCount = categoryService.idCheck(categoryVO);
 
         HashMap<String, Object> result = new HashMap<String, Object>();
         result.put("idCount", idCount);
@@ -182,23 +166,22 @@ public class CategoryApi extends CORSFilter {
 
     /**
      * @Method Name  : insertProcess
-     * @Date         : 2015. 05. 20.
+     * @Date         : 2025. 11.
      * @Author       : miraenet
      * @변경이력      :
      * @Method 설명      : 카테고리 등록
-     * @param request
+     * @param CategoryVO
      * @return
      * @throws Exception
      */
     @PostMapping(value = "/insert")
-    public JSONObject insertProcess(@RequestBody HashMap<String, Object> params, HttpServletRequest request) throws Exception {
-        setParam(params, request);
+    public JSONObject insertProcess(@ModelAttribute("CategoryVO") CategoryVO categoryVO, @RequestParam Map<?, ?> commandMap) throws Exception {
 
-        int isInsert = seriesCategoryService.insertProcess(params);
+        int isInsert = categoryService.insertProcess(categoryVO);
 
         HashMap<String, Object> result = new HashMap<String, Object>();
         result.put("isInsert", isInsert);
-        result.put("VIEWCODE", params.get("CODE"));
+        result.put("VIEWCODE", commandMap.get("CODE"));
 
         JSONObject jObject = new JSONObject(result);
         return jObject;
@@ -206,57 +189,24 @@ public class CategoryApi extends CORSFilter {
 
     /**
      * @Method Name  : updateProcess
-     * @Date         : 2015. 05. 20.
+     * @Date         : 2025. 11.
      * @Author       : miraenet
      * @변경이력      :
      * @Method 설명      : 카테고리 수정
-     * @param request
+     * @param CategoryVO
      * @return
      * @throws Exception
      */
     @PutMapping(value = "/update")
-    public JSONObject updateProcess(@RequestBody HashMap<String, Object> params, HttpServletRequest request) throws Exception {
-        setParam(params, request);
+    public JSONObject updateProcess(@ModelAttribute("CategoryVO") CategoryVO categoryVO, @RequestParam Map<?, ?> commandMap) throws Exception {
 
-        seriesCategoryService.updateProcess(params);
+        categoryService.updateProcess(categoryVO);
 
         HashMap<String, Object> result = new HashMap<String, Object>();
         result.put("isUpdate", 1);
-        result.put("VIEWCODE", params.get("CODE"));
+        result.put("VIEWCODE", commandMap.get("CODE"));
 
         JSONObject jObject = new JSONObject(result);
         return jObject;
     }
-
-    /**
-     * @Method Name : setParam
-     * @작성일 : 2015. 05.
-     * @Method 설명 : 파라미터 SETTING
-     * @param params
-     * @param request
-     * @return HashMap
-     * @throws Exception
-     */
-    @SuppressWarnings("unchecked")
-    public void setParam(HashMap<String, Object> params, HttpServletRequest request) throws Exception {
-        HttpSession session = request.getSession(false);
-        if(session != null) {
-            HashMap<String, String> loginInfo = (HashMap<String, String>)session.getAttribute("AdmUserInfo");
-            if(loginInfo != null) {
-                params.put("REG_ID", loginInfo.get("USER_ID"));
-                params.put("UPD_ID", loginInfo.get("USER_ID"));
-            }
-        }
-        params.put("currentPage", CommonUtil.isNull(request.getParameter("currentPage"), "1"));
-        params.put("CODE", CommonUtil.isNull(request.getParameter("CODE"), ""));
-        params.put("NAME", CommonUtil.isNull(request.getParameter("NAME"), ""));
-        params.put("USE_ON", CommonUtil.isNull(request.getParameter("USE_ON"), ""));
-        params.put("USE_OFF", CommonUtil.isNull(request.getParameter("USE_OFF"), ""));
-        params.put("ISUSE", CommonUtil.isNull(request.getParameter("ISUSE"), ""));
-        params.put("ORDR", CommonUtil.isNull(request.getParameter("ORDR"), ""));
-        params.put("P_CODE", CommonUtil.isNull(request.getParameter("P_CODE"), ""));
-        params.put("SRS_CD", CommonUtil.isNull(request.getParameter("SRS_CD"), ""));
-        params.put("TYPE_CHOICE", CommonUtil.isNull(request.getParameter("TYPE_CHOICE"), "C"));
-    }
-
 }

--- a/src/main/java/com/academy/lecture/service/CategoryService.java
+++ b/src/main/java/com/academy/lecture/service/CategoryService.java
@@ -1,76 +1,50 @@
 package com.academy.lecture.service;
 
-import java.util.HashMap;
-import java.util.List;
+import java.util.ArrayList;
+
+import org.json.simple.JSONObject;
+import org.springframework.stereotype.Service;
+
+import com.academy.mapper.CategoryMapper;
 
 /**
- * @FileName   : SeriesCategoryService.java
- * @Project    :
- * @Date       : 2015. 05. 20.
- * @Author     : miraenet
- * @변경이력    :
- * @프로그램 설명 : 운영자 관리 service
+ * Category Service
+ * ExamService 패턴 적용 - ArrayList<JSONObject> 및 VO 사용
  */
-public interface CategoryService {
+@Service
+public class CategoryService {
 
-    /**
-     * @Date         : 2015. 05. 20.
-     * @Author       : miraenet
-     * @변경이력      :
-     * @Method 설명      :	 트리 리스트
-     * @return
-     */
-    List<HashMap<String, Object>> getSeriesCateTree();
-    /**
-     * @Method Name  : getDetail
-     * @Date         : 2015. 05. 20.
-     * @Author       : miraenet
-     * @변경이력      :
-     * @Method 설명      :	 상세
-     * @param params
-     * @return
-     */
-    HashMap<String, Object> getDetail(HashMap<String, Object> params);
-    /**
-     * @Method Name  : updateProcess
-     * @Date         : 2015. 05. 20.
-     * @Author       : miraenet
-     * @변경이력      :
-     * @Method 설명      :	 수정 프로세스
-     * @param params
-     */
-    void updateProcess(HashMap<String, Object> params);
-    /**
-     * @Method Name  : deleteProcess
-     * @Date         : 2015. 05. 20.
-     * @Author       : miraenet
-     * @변경이력      :
-     * @Method 설명      :	삭제 프로세스
-     * @param params
-     * @return
-     */
-    int deleteProcess(HashMap<String, Object> params);
+	private CategoryMapper categoryMapper;
 
-    /**
-     * @Method Name  : idCheck
-     * @Date         : 2015. 05. 20.
-     * @Author       : miraenet
-     * @변경이력      :
-     * @Method 설명      :	ID 중복체크
-     * @param params
-     * @return
-     */
-    int idCheck(HashMap<String, Object> params);
-    /**
-     * @Method Name  : insertProcess
-     * @Date         : 2015. 05. 20.
-     * @Author       : miraenet
-     * @변경이력      :
-     * @Method 설명      :	등록 프로세스
-     * @param params
-     * @return
-     */
-    int insertProcess(HashMap<String, Object> params);
+	public CategoryService(CategoryMapper categoryMapper) {
+		this.categoryMapper = categoryMapper;
+	}
 
-    HashMap<String, Object> getMaxOrdr(Object obj);
+	public ArrayList<JSONObject> getSeriesCateTree() {
+		return categoryMapper.getSeriesCateTree();
+	}
+
+	public JSONObject getDetail(CategoryVO categoryVO) {
+		return categoryMapper.getDetail(categoryVO);
+	}
+
+	public void updateProcess(CategoryVO categoryVO) {
+		categoryMapper.updateProcess(categoryVO);
+	}
+
+	public int deleteProcess(CategoryVO categoryVO) {
+		return categoryMapper.deleteProcess(categoryVO);
+	}
+
+	public int idCheck(CategoryVO categoryVO) {
+		return categoryMapper.idCheck(categoryVO);
+	}
+
+	public int insertProcess(CategoryVO categoryVO) {
+		return categoryMapper.insertProcess(categoryVO);
+	}
+
+	public JSONObject getMaxOrdr(CategoryVO categoryVO) {
+		return categoryMapper.getMaxOrdr(categoryVO);
+	}
 }

--- a/src/main/java/com/academy/lecture/service/FormService.java
+++ b/src/main/java/com/academy/lecture/service/FormService.java
@@ -1,25 +1,58 @@
 package com.academy.lecture.service;
 
-import java.util.HashMap;
-import java.util.List;
+import java.util.ArrayList;
 
-public interface FormService {
+import org.json.simple.JSONObject;
+import org.springframework.stereotype.Service;
 
-	List<HashMap<String, String>> formList(HashMap<String, String> params);
-	
-	int formListCount(HashMap<String, String> params);
+import com.academy.mapper.FormMapper;
 
-	String formGetCode();
-	
-	void formInsert(HashMap<String, String> params);
-	
-	List<HashMap<String, String>> formView(HashMap<String, String> params);
-	
-	void formUpdate(HashMap<String, String> params);
-	
-	void formDelete(HashMap<String, String> params);
-	
-	int formCheck(HashMap<String, String> params);
-	
-	List<HashMap<String, String>> getCodeList(HashMap<String, String> params);
+/**
+ * Form Service
+ * ExamService 패턴 적용 - ArrayList<JSONObject> 및 VO 사용
+ */
+@Service
+public class FormService {
+
+	private FormMapper formMapper;
+
+	public FormService(FormMapper formMapper) {
+		this.formMapper = formMapper;
+	}
+
+	public ArrayList<JSONObject> formList(FormVO formVO) {
+		return formMapper.formList(formVO);
+	}
+
+	public int formListCount(FormVO formVO) {
+		return formMapper.formListCount(formVO);
+	}
+
+	public String formGetCode() {
+		return formMapper.formGetCode();
+	}
+
+	public void formInsert(FormVO formVO) {
+		formMapper.formInsert(formVO);
+	}
+
+	public ArrayList<JSONObject> formView(FormVO formVO) {
+		return formMapper.formView(formVO);
+	}
+
+	public void formUpdate(FormVO formVO) {
+		formMapper.formUpdate(formVO);
+	}
+
+	public void formDelete(FormVO formVO) {
+		formMapper.formDelete(formVO);
+	}
+
+	public int formCheck(FormVO formVO) {
+		return formMapper.formCheck(formVO);
+	}
+
+	public ArrayList<JSONObject> getCodeList(FormVO formVO) {
+		return formMapper.getCodeList(formVO);
+	}
 }

--- a/src/main/java/com/academy/lecture/service/KindService.java
+++ b/src/main/java/com/academy/lecture/service/KindService.java
@@ -1,27 +1,62 @@
 package com.academy.lecture.service;
 
-import java.util.HashMap;
-import java.util.List;
+import java.util.ArrayList;
 
-public interface KindService {
+import org.json.simple.JSONObject;
+import org.springframework.stereotype.Service;
 
-	List<HashMap<String, String>> getKindList(Object obj);
+import com.academy.mapper.KindMapper;
 
-	List<HashMap<String, String>> kindList(HashMap<String, String> params);
+/**
+ * Kind Service
+ * ExamService 패턴 적용 - ArrayList<JSONObject> 및 VO 사용
+ */
+@Service
+public class KindService {
 
-	int kindListCount(HashMap<String, String> params);
+	private KindMapper kindMapper;
 
-	void kindInsert(HashMap<String, String> params);
+	public KindService(KindMapper kindMapper) {
+		this.kindMapper = kindMapper;
+	}
 
-	List<HashMap<String, String>> kindView(HashMap<String, String> params);
+	public ArrayList<JSONObject> getKindList(KindVO kindVO) {
+		return kindMapper.getKindList(kindVO);
+	}
 
-	void kindUpdate(HashMap<String, String> params);
+	public ArrayList<JSONObject> kindList(KindVO kindVO) {
+		return kindMapper.kindList(kindVO);
+	}
 
-	void kindDelete(HashMap<String, String> params);
+	public int kindListCount(KindVO kindVO) {
+		return kindMapper.kindListCount(kindVO);
+	}
 
-	int kindCheck(HashMap<String, String> params);
+	public void kindInsert(KindVO kindVO) {
+		kindMapper.kindInsert(kindVO);
+	}
 
-	List<HashMap<String, String>> selectKindCode();
+	public ArrayList<JSONObject> kindView(KindVO kindVO) {
+		return kindMapper.kindView(kindVO);
+	}
 
-	void SeqUpdate(HashMap<String, String> params);
+	public void kindUpdate(KindVO kindVO) {
+		kindMapper.kindUpdate(kindVO);
+	}
+
+	public void kindDelete(KindVO kindVO) {
+		kindMapper.kindDelete(kindVO);
+	}
+
+	public int kindCheck(KindVO kindVO) {
+		return kindMapper.kindCheck(kindVO);
+	}
+
+	public ArrayList<JSONObject> selectKindCode() {
+		return kindMapper.selectKindCode();
+	}
+
+	public void SeqUpdate(KindVO kindVO) {
+		kindMapper.SeqUpdate(kindVO);
+	}
 }

--- a/src/main/java/com/academy/lecture/service/LectureMstService.java
+++ b/src/main/java/com/academy/lecture/service/LectureMstService.java
@@ -1,55 +1,106 @@
 package com.academy.lecture.service;
 
-import java.util.HashMap;
-import java.util.List;
+import java.util.ArrayList;
 
-public interface LectureMstService {
+import org.json.simple.JSONObject;
+import org.springframework.stereotype.Service;
 
-	
-	List<HashMap<String, String>> lecturemstList(HashMap<String, String> params);
-	
-	int lecturemstListCount(HashMap<String, String> params);
-	
-	List<HashMap<String, String>> getBridgeMstcodeSeq(HashMap<String, String> params);
-	
-	List<HashMap<String, String>> getBridgeMstcode(HashMap<String, String> params);
-	
-	List<HashMap<String, String>> getMstcode(HashMap<String, String> params);
-	
-	void lecturemstInsert(HashMap<String, String> params);
-	
-	void lectureBridgeInsert(HashMap<String, String> params);
-	
-	void lectureBookInsert2(HashMap<String, String> params);
-	
-	List<HashMap<String, String>> lectureDataMemoViewList(HashMap<String, String> params);
-	
-	List<HashMap<String, String>> lectureDataViewList(HashMap<String, String> params);
-	
-	List<HashMap<String, String>> lectureWMV(HashMap<String, String> params);
-	
-	List<HashMap<String, String>> lectureDown_Count(HashMap<String, String> params);
-	
-	
-	
-	int lectureDeleteCheck(HashMap<String, String> params);
-	
-	List<HashMap<String, String>> lectureView(HashMap<String, String> params);
-	
-	List<HashMap<String, String>> lectureViewList(HashMap<String, String> params);
-	
-	List<HashMap<String, String>> lectureViewBookList(HashMap<String, String> params);
-	
-	
-	
-	void lectureBookDelete(HashMap<String, String> params);
-	
-	void lecturemstUpdate(HashMap<String, String> params);
-	
-	void lectureBookInsert(HashMap<String, String> params);
-	
-	void lectureDelete(HashMap<String, String> params);
-	
-	void lectureBridgeDelete(HashMap<String, String> params);
-	
+import com.academy.mapper.LectureMstMapper;
+
+/**
+ * LectureMst Service
+ * ExamService 패턴 적용 - ArrayList<JSONObject> 및 VO 사용
+ */
+@Service
+public class LectureMstService {
+
+	private LectureMstMapper lectureMstMapper;
+
+	public LectureMstService(LectureMstMapper lectureMstMapper) {
+		this.lectureMstMapper = lectureMstMapper;
+	}
+
+	public ArrayList<JSONObject> lecturemstList(LectureMstVO lectureMstVO) {
+		return lectureMstMapper.lecturemstList(lectureMstVO);
+	}
+
+	public int lecturemstListCount(LectureMstVO lectureMstVO) {
+		return lectureMstMapper.lecturemstListCount(lectureMstVO);
+	}
+
+	public ArrayList<JSONObject> getBridgeMstcodeSeq(LectureMstVO lectureMstVO) {
+		return lectureMstMapper.getBridgeMstcodeSeq(lectureMstVO);
+	}
+
+	public ArrayList<JSONObject> getBridgeMstcode(LectureMstVO lectureMstVO) {
+		return lectureMstMapper.getBridgeMstcode(lectureMstVO);
+	}
+
+	public ArrayList<JSONObject> getMstcode(LectureMstVO lectureMstVO) {
+		return lectureMstMapper.getMstcode(lectureMstVO);
+	}
+
+	public void lecturemstInsert(LectureMstVO lectureMstVO) {
+		lectureMstMapper.lecturemstInsert(lectureMstVO);
+	}
+
+	public void lectureBridgeInsert(LectureMstVO lectureMstVO) {
+		lectureMstMapper.lectureBridgeInsert(lectureMstVO);
+	}
+
+	public void lectureBookInsert2(LectureMstVO lectureMstVO) {
+		lectureMstMapper.lectureBookInsert2(lectureMstVO);
+	}
+
+	public ArrayList<JSONObject> lectureDataMemoViewList(LectureMstVO lectureMstVO) {
+		return lectureMstMapper.lectureDataMemoViewList(lectureMstVO);
+	}
+
+	public ArrayList<JSONObject> lectureDataViewList(LectureMstVO lectureMstVO) {
+		return lectureMstMapper.lectureDataViewList(lectureMstVO);
+	}
+
+	public ArrayList<JSONObject> lectureWMV(LectureMstVO lectureMstVO) {
+		return lectureMstMapper.lectureWMV(lectureMstVO);
+	}
+
+	public ArrayList<JSONObject> lectureDown_Count(LectureMstVO lectureMstVO) {
+		return lectureMstMapper.lectureDown_Count(lectureMstVO);
+	}
+
+	public int lectureDeleteCheck(LectureMstVO lectureMstVO) {
+		return lectureMstMapper.lectureDeleteCheck(lectureMstVO);
+	}
+
+	public ArrayList<JSONObject> lectureView(LectureMstVO lectureMstVO) {
+		return lectureMstMapper.lectureView(lectureMstVO);
+	}
+
+	public ArrayList<JSONObject> lectureViewList(LectureMstVO lectureMstVO) {
+		return lectureMstMapper.lectureViewList(lectureMstVO);
+	}
+
+	public ArrayList<JSONObject> lectureViewBookList(LectureMstVO lectureMstVO) {
+		return lectureMstMapper.lectureViewBookList(lectureMstVO);
+	}
+
+	public void lectureBookDelete(LectureMstVO lectureMstVO) {
+		lectureMstMapper.lectureBookDelete(lectureMstVO);
+	}
+
+	public void lecturemstUpdate(LectureMstVO lectureMstVO) {
+		lectureMstMapper.lecturemstUpdate(lectureMstVO);
+	}
+
+	public void lectureBookInsert(LectureMstVO lectureMstVO) {
+		lectureMstMapper.lectureBookInsert(lectureMstVO);
+	}
+
+	public void lectureDelete(LectureMstVO lectureMstVO) {
+		lectureMstMapper.lectureDelete(lectureMstVO);
+	}
+
+	public void lectureBridgeDelete(LectureMstVO lectureMstVO) {
+		lectureMstMapper.lectureBridgeDelete(lectureMstVO);
+	}
 }

--- a/src/main/java/com/academy/lecture/service/LectureService.java
+++ b/src/main/java/com/academy/lecture/service/LectureService.java
@@ -1,15 +1,15 @@
 package com.academy.lecture.service;
 
-import java.util.HashMap;
-import java.util.List;
+import java.util.ArrayList;
 
+import org.json.simple.JSONObject;
 import org.springframework.stereotype.Service;
 
 import com.academy.mapper.LectureMapper;
 
 /**
  * Lecture Service
- * LoginService 패턴 적용 - ServiceImpl 없이 @Service 클래스로 직접 구현
+ * ExamService 패턴 적용 - ArrayList<JSONObject> 및 VO 사용
  */
 @Service
 public class LectureService {
@@ -20,271 +20,283 @@ public class LectureService {
 		this.lectureMapper = lectureMapper;
 	}
 
-	public List<HashMap<String, String>> lectureList(HashMap<String, String> params) {
-		return lectureMapper.lectureList(params);
+	public ArrayList<JSONObject> lectureList(LectureVO lectureVO) {
+		return lectureMapper.lectureList(lectureVO);
 	}
 
-	public List<HashMap<String, String>> oldFreeToNewFree(HashMap<String, String> params) {
-		return lectureMapper.oldFreeToNewFree(params);
+	public ArrayList<JSONObject> oldFreeToNewFree(LectureVO lectureVO) {
+		return lectureMapper.oldFreeToNewFree(lectureVO);
 	}
 
-	public int lectureListCount(HashMap<String, String> params) {
-		return lectureMapper.lectureListCount(params);
+	public int lectureListCount(LectureVO lectureVO) {
+		return lectureMapper.lectureListCount(lectureVO);
 	}
 
-	public List<HashMap<String, String>> bookList(HashMap<String, String> params) {
-		return lectureMapper.bookList(params);
+	public ArrayList<JSONObject> bookList(LectureVO lectureVO) {
+		return lectureMapper.bookList(lectureVO);
 	}
 
-	public int bookListCount(HashMap<String, String> params) {
-		return lectureMapper.bookListCount(params);
+	public int bookListCount(LectureVO lectureVO) {
+		return lectureMapper.bookListCount(lectureVO);
 	}
 
-	public List<HashMap<String, String>> getBridgeLeccodeSeq(HashMap<String, String> params) {
-		return lectureMapper.getBridgeLeccodeSeq(params);
+	public ArrayList<JSONObject> getBridgeLeccodeSeq(LectureVO lectureVO) {
+		return lectureMapper.getBridgeLeccodeSeq(lectureVO);
 	}
 
-	public List<HashMap<String, String>> getJongLeccodeSeq(HashMap<String, String> params) {
-		return lectureMapper.getJongLeccodeSeq(params);
+	public ArrayList<JSONObject> getJongLeccodeSeq(LectureVO lectureVO) {
+		return lectureMapper.getJongLeccodeSeq(lectureVO);
 	}
 
-	public List<HashMap<String, String>> getLeccode(HashMap<String, String> params) {
-		return lectureMapper.getLeccode(params);
+	public ArrayList<JSONObject> getLeccode(LectureVO lectureVO) {
+		return lectureMapper.getLeccode(lectureVO);
 	}
 
-	public List<HashMap<String, String>> getBridgeLeccode(HashMap<String, String> params) {
-		return lectureMapper.getBridgeLeccode(params);
+	public ArrayList<JSONObject> getBridgeLeccode(LectureVO lectureVO) {
+		return lectureMapper.getBridgeLeccode(lectureVO);
 	}
 
-	public List<HashMap<String, String>> BridgeLeccode(HashMap<String, String> params) {
-		return lectureMapper.BridgeLeccode(params);
+	public ArrayList<JSONObject> BridgeLeccode(LectureVO lectureVO) {
+		return lectureMapper.BridgeLeccode(lectureVO);
 	}
 
-	public void lectureInsert(HashMap<String, String> params) {
-		lectureMapper.lectureInsert(params);
+	public void lectureInsert(LectureVO lectureVO) {
+		lectureMapper.lectureInsert(lectureVO);
 	}
 
-	public void lectureBridgeInsert(HashMap<String, String> params) {
-		lectureMapper.lectureBridgeInsert(params);
+	public void lectureBridgeInsert(LectureVO lectureVO) {
+		lectureMapper.lectureBridgeInsert(lectureVO);
 	}
 
-	public void lectureBookInsert(HashMap<String, String> params) {
-		lectureMapper.lectureBookInsert(params);
+	public void lectureBookInsert(LectureVO lectureVO) {
+		lectureMapper.lectureBookInsert(lectureVO);
 	}
 
-	public void lectureBookInsert2(HashMap<String, String> params) {
-		lectureMapper.lectureBookInsert2(params);
+	public void lectureBookInsert2(LectureVO lectureVO) {
+		lectureMapper.lectureBookInsert2(lectureVO);
 	}
 
-	public List<HashMap<String, String>> lectureViewList(HashMap<String, String> params) {
-		return lectureMapper.lectureViewList(params);
+	public ArrayList<JSONObject> lectureViewList(LectureVO lectureVO) {
+		return lectureMapper.lectureViewList(lectureVO);
 	}
 
-	public List<HashMap<String, String>> lectureView(HashMap<String, String> params) {
-		return lectureMapper.lectureView(params);
+	public ArrayList<JSONObject> lectureView(LectureVO lectureVO) {
+		return lectureMapper.lectureView(lectureVO);
 	}
 
-	public List<HashMap<String, String>> lectureViewBookList(HashMap<String, String> params) {
-		return lectureMapper.lectureViewBookList(params);
+	public ArrayList<JSONObject> lectureViewBookList(LectureVO lectureVO) {
+		return lectureMapper.lectureViewBookList(lectureVO);
 	}
 
-	public void lectureBookDelete(HashMap<String, String> params) {
-		lectureMapper.lectureBookDelete(params);
+	public void lectureBookDelete(LectureVO lectureVO) {
+		lectureMapper.lectureBookDelete(lectureVO);
 	}
 
-	public void lectureUpdate(HashMap<String, String> params) {
-		lectureMapper.lectureUpdate(params);
+	public void lectureUpdate(LectureVO lectureVO) {
+		lectureMapper.lectureUpdate(lectureVO);
 	}
 
-	public void Modify_Lecture_On_Off(HashMap<String, String> params) {
-		lectureMapper.Modify_Lecture_On_Off(params);
+	public void Modify_Lecture_On_Off(LectureVO lectureVO) {
+		lectureMapper.Modify_Lecture_On_Off(lectureVO);
 	}
 
-	public void lectureIsUseUpdate(HashMap<String, String> params) {
-		lectureMapper.lectureIsUseUpdate(params);
+	public void lectureIsUseUpdate(LectureVO lectureVO) {
+		lectureMapper.lectureIsUseUpdate(lectureVO);
 	}
 
-	public void lectureDelete(HashMap<String, String> params) {
-		lectureMapper.lectureDelete(params);
+	public void lectureDelete(LectureVO lectureVO) {
+		lectureMapper.lectureDelete(lectureVO);
 	}
 
-	public void lectureBridgeDelete(HashMap<String, String> params) {
-		lectureMapper.lectureBridgeDelete(params);
+	public void lectureBridgeDelete(LectureVO lectureVO) {
+		lectureMapper.lectureBridgeDelete(lectureVO);
 	}
 
-	public void lecMovUpdate(HashMap<String, String> params) {
-		lectureMapper.lecMovUpdate(params);
+	public void lecMovUpdate(LectureVO lectureVO) {
+		lectureMapper.lecMovUpdate(lectureVO);
 	}
 
-	public List<HashMap<String, String>> lectureSeqList(HashMap<String, String> params) {
-		return lectureMapper.lectureSeqList(params);
+	public ArrayList<JSONObject> lectureSeqList(LectureVO lectureVO) {
+		return lectureMapper.lectureSeqList(lectureVO);
 	}
 
-	public void lectureSeqUpdate(HashMap<String, String> params) {
-		lectureMapper.lectureSeqUpdate(params);
+	public void lectureSeqUpdate(LectureVO lectureVO) {
+		lectureMapper.lectureSeqUpdate(lectureVO);
 	}
 
-	public List<HashMap<String, String>> lectureViewJongList(HashMap<String, String> params) {
-		return lectureMapper.lectureViewJongList(params);
+	public ArrayList<JSONObject> lectureViewJongList(LectureVO lectureVO) {
+		return lectureMapper.lectureViewJongList(lectureVO);
 	}
 
-	public List<HashMap<String, String>> lectureJongList(HashMap<String, String> params) {
-		return lectureMapper.lectureJongList(params);
+	public ArrayList<JSONObject> lectureJongList(LectureVO lectureVO) {
+		return lectureMapper.lectureJongList(lectureVO);
 	}
 
-	public int lectureJongListCount(HashMap<String, String> params) {
-		return lectureMapper.lectureJongListCount(params);
+	public int lectureJongListCount(LectureVO lectureVO) {
+		return lectureMapper.lectureJongListCount(lectureVO);
 	}
 
-	public List<HashMap<String, String>> lectureYearList(HashMap<String, String> params) {
-		return lectureMapper.lectureYearList(params);
+	public ArrayList<JSONObject> lectureYearList(LectureVO lectureVO) {
+		return lectureMapper.lectureYearList(lectureVO);
 	}
 
-	public int lectureYearListCount(HashMap<String, String> params) {
-		return lectureMapper.lectureYearListCount(params);
+	public int lectureYearListCount(LectureVO lectureVO) {
+		return lectureMapper.lectureYearListCount(lectureVO);
 	}
 
-	public List<HashMap<String, String>> lectureJongSubjectList(HashMap<String, String> params) {
-		return lectureMapper.lectureJongSubjectList(params);
+	public ArrayList<JSONObject> lectureJongSubjectList(LectureVO lectureVO) {
+		return lectureMapper.lectureJongSubjectList(lectureVO);
 	}
 
-	public List<HashMap<String, String>> lectureJongView(HashMap<String, String> params) {
-		return lectureMapper.lectureJongView(params);
+	public ArrayList<JSONObject> lectureJongView(LectureVO lectureVO) {
+		return lectureMapper.lectureJongView(lectureVO);
 	}
 
-	public int lectureJongSubjectListCount(HashMap<String, String> params) {
-		return lectureMapper.lectureJongSubjectListCount(params);
+	public int lectureJongSubjectListCount(LectureVO lectureVO) {
+		return lectureMapper.lectureJongSubjectListCount(lectureVO);
 	}
 
-	public void lectureLecJongInsert(HashMap<String, String> params) {
-		lectureMapper.lectureLecJongInsert(params);
+	public void lectureLecJongInsert(LectureVO lectureVO) {
+		lectureMapper.lectureLecJongInsert(lectureVO);
 	}
 
-	public void lectureChoiceJongNoInsert(HashMap<String, String> params) {
-		lectureMapper.lectureChoiceJongNoInsert(params);
+	public void lectureChoiceJongNoInsert(LectureVO lectureVO) {
+		lectureMapper.lectureChoiceJongNoInsert(lectureVO);
 	}
 
-	public List<HashMap<String, String>> lectureViewLeccodeList(HashMap<String, String> params) {
-		return lectureMapper.lectureViewLeccodeList(params);
+	public ArrayList<JSONObject> lectureViewLeccodeList(LectureVO lectureVO) {
+		return lectureMapper.lectureViewLeccodeList(lectureVO);
 	}
 
-	public void lectureLecJongDelete(HashMap<String, String> params) {
-		lectureMapper.lectureLecJongDelete(params);
+	public void lectureLecJongDelete(LectureVO lectureVO) {
+		lectureMapper.lectureLecJongDelete(lectureVO);
 	}
 
-	public void lectureChoiceJongNoDelete(HashMap<String, String> params) {
-		lectureMapper.lectureChoiceJongNoDelete(params);
+	public void lectureChoiceJongNoDelete(LectureVO lectureVO) {
+		lectureMapper.lectureChoiceJongNoDelete(lectureVO);
 	}
 
-	public List<HashMap<String, String>> lecturePayList(HashMap<String, String> params) {
-		return lectureMapper.lecturePayList(params);
+	public ArrayList<JSONObject> lecturePayList(LectureVO lectureVO) {
+		return lectureMapper.lecturePayList(lectureVO);
 	}
 
-	public List<HashMap<String, String>> lectureJongPayList(HashMap<String, String> params) {
-		return lectureMapper.lectureJongPayList(params);
+	public ArrayList<JSONObject> lectureJongPayList(LectureVO lectureVO) {
+		return lectureMapper.lectureJongPayList(lectureVO);
 	}
 
-	public List<HashMap<String, String>> lectureDataMemoViewList(HashMap<String, String> params) {
-		return lectureMapper.lectureDataMemoViewList(params);
+	public ArrayList<JSONObject> lectureDataMemoViewList(LectureVO lectureVO) {
+		return lectureMapper.lectureDataMemoViewList(lectureVO);
 	}
 
-	public List<HashMap<String, String>> lectureDataViewList(HashMap<String, String> params) {
-		return lectureMapper.lectureDataViewList(params);
+	public ArrayList<JSONObject> lectureDataViewList(LectureVO lectureVO) {
+		return lectureMapper.lectureDataViewList(lectureVO);
 	}
 
-	public List<HashMap<String, String>> lectureMobileList(HashMap<String, String> params) {
-		return lectureMapper.lectureMobileList(params);
+	public ArrayList<JSONObject> lectureMobileList(LectureVO lectureVO) {
+		return lectureMapper.lectureMobileList(lectureVO);
 	}
 
-	public List<HashMap<String, String>> lectureDataMovieViewList(HashMap<String, String> params) {
-		return lectureMapper.lectureDataMovieViewList(params);
+	public ArrayList<JSONObject> lectureDataMovieViewList(LectureVO lectureVO) {
+		return lectureMapper.lectureDataMovieViewList(lectureVO);
 	}
 
-	public List<HashMap<String, String>> lectureDataMovieList(HashMap<String, String> params) {
-		return lectureMapper.lectureDataMovieList(params);
+	public ArrayList<JSONObject> lectureDataMovieList(LectureVO lectureVO) {
+		return lectureMapper.lectureDataMovieList(lectureVO);
 	}
 
-	public void lectureMovieInsert(HashMap<String, String> params) {
-		lectureMapper.lectureMovieInsert(params);
+	public void lectureMovieInsert(LectureVO lectureVO) {
+		lectureMapper.lectureMovieInsert(lectureVO);
 	}
 
-	public void lectureMovieDelete(HashMap<String, String> params) {
-		lectureMapper.lectureMovieDelete(params);
+	public void lectureMovieDelete(LectureVO lectureVO) {
+		lectureMapper.lectureMovieDelete(lectureVO);
 	}
 
-	public void lectureMovieUpdate(HashMap<String, String> params) {
-		lectureMapper.lectureMovieUpdate(params);
+	public void lectureMovieUpdate(LectureVO lectureVO) {
+		lectureMapper.lectureMovieUpdate(lectureVO);
 	}
 
-	public void lectureMovieFileDelete(HashMap<String, String> params) {
-		lectureMapper.lectureMovieFileDelete(params);
+	public void lectureMovieFileDelete(LectureVO lectureVO) {
+		lectureMapper.lectureMovieFileDelete(lectureVO);
 	}
 
-	public void lectureMovieMemoInsert(HashMap<String, String> params) {
-		lectureMapper.lectureMovieMemoInsert(params);
+	public void lectureMovieMemoInsert(LectureVO lectureVO) {
+		lectureMapper.lectureMovieMemoInsert(lectureVO);
 	}
 
-	public void lectureMovieMemoUpdate(HashMap<String, String> params) {
-		lectureMapper.lectureMovieMemoUpdate(params);
+	public void lectureMovieMemoUpdate(LectureVO lectureVO) {
+		lectureMapper.lectureMovieMemoUpdate(lectureVO);
 	}
 
-	public void lectureMovieMemoDelete(HashMap<String, String> params) {
-		lectureMapper.lectureMovieMemoDelete(params);
+	public void lectureMovieMemoDelete(LectureVO lectureVO) {
+		lectureMapper.lectureMovieMemoDelete(lectureVO);
 	}
 
-	public int lectureDeleteCheck(HashMap<String, String> params) {
-		return lectureMapper.lectureDeleteCheck(params);
+	public int lectureDeleteCheck(LectureVO lectureVO) {
+		return lectureMapper.lectureDeleteCheck(lectureVO);
 	}
 
-	public List<HashMap<String, String>> playinfo(HashMap<String, String> params) {
-		return lectureMapper.playinfo(params);
+	public ArrayList<JSONObject> playinfo(LectureVO lectureVO) {
+		return lectureMapper.playinfo(lectureVO);
 	}
 
-	public List<HashMap<String, String>> getCbMovie4_free_admin(HashMap<String, String> params) {
-		return lectureMapper.getCbMovie4_free_admin(params);
+	public ArrayList<JSONObject> getCbMovie4_free_admin(LectureVO lectureVO) {
+		return lectureMapper.getCbMovie4_free_admin(lectureVO);
 	}
 
-	public int getCbMovie4_free_admin_count(HashMap<String, String> params) {
-		return lectureMapper.getCbMovie4_free_admin_count(params);
+	public int getCbMovie4_free_admin_count(LectureVO lectureVO) {
+		return lectureMapper.getCbMovie4_free_admin_count(lectureVO);
 	}
 
-	public HashMap<String, String> lectureOnDetailS(HashMap<String, String> params) {
-		return lectureMapper.lectureOnDetailS(params);
+	public JSONObject lectureOnDetailS(LectureVO lectureVO) {
+		return lectureMapper.lectureOnDetailS(lectureVO);
 	}
 
-	public void insertPmpDownLog(HashMap<String, String> params) {
-		lectureMapper.insertPmpDownLog(params);
+	public void insertPmpDownLog(LectureVO lectureVO) {
+		lectureMapper.insertPmpDownLog(lectureVO);
 	}
 
-	public List<HashMap<String, String>> lectureWMV(HashMap<String, String> params) {
-		return lectureMapper.lectureWMV(params);
+	public ArrayList<JSONObject> lectureWMV(LectureVO lectureVO) {
+		return lectureMapper.lectureWMV(lectureVO);
 	}
 
-	public List<HashMap<String, String>> lectureDown_Count(HashMap<String, String> params) {
-		return lectureMapper.lectureDown_Count(params);
+	public ArrayList<JSONObject> lectureDown_Count(LectureVO lectureVO) {
+		return lectureMapper.lectureDown_Count(lectureVO);
 	}
 
-	public void oldFreeToNewFreeInsert(HashMap<String, String> params) {
-		lectureMapper.oldFreeToNewFreeInsert(params);
+	public void oldFreeToNewFreeInsert(LectureVO lectureVO) {
+		lectureMapper.oldFreeToNewFreeInsert(lectureVO);
 	}
 
-	public void oldBogangFreeToNewBogangFree(HashMap<String, String> params) {
-		lectureMapper.oldBogangFreeToNewBogangFree(params);
+	public void oldBogangFreeToNewBogangFree(LectureVO lectureVO) {
+		lectureMapper.oldBogangFreeToNewBogangFree(lectureVO);
 	}
 
-	public List<HashMap<String, String>> lectureFreePassPayList(HashMap<String, String> params) {
-		return lectureMapper.lectureFreePassPayList(params);
+	public ArrayList<JSONObject> lectureFreePassPayList(LectureVO lectureVO) {
+		return lectureMapper.lectureFreePassPayList(lectureVO);
 	}
 
-	public List<HashMap<String, String>> YearIngList(HashMap<String, String> params) {
-		return lectureMapper.YearIngList(params);
+	public ArrayList<JSONObject> YearIngList(LectureVO lectureVO) {
+		return lectureMapper.YearIngList(lectureVO);
 	}
 
-	public List<HashMap<String, String>> MyYearIngList(HashMap<String, String> params) {
-		return lectureMapper.MyYearIngList(params);
+	public ArrayList<JSONObject> MyYearIngList(LectureVO lectureVO) {
+		return lectureMapper.MyYearIngList(lectureVO);
 	}
 
-	public List<HashMap<String, String>> bookView(HashMap<String, String> params) {
-		return lectureMapper.bookView(params);
+	public ArrayList<JSONObject> bookView(LectureVO lectureVO) {
+		return lectureMapper.bookView(lectureVO);
+	}
+
+	public String getRleccode(LectureVO lectureVO) {
+		return lectureMapper.getRleccode(lectureVO);
+	}
+
+	public void oldTbmovieToNewTbmovieInsert(LectureVO lectureVO) {
+		lectureMapper.oldTbmovieToNewTbmovieInsert(lectureVO);
+	}
+
+	public void oldBogangFreeToNewFreeBogangInsert(LectureVO lectureVO) {
+		lectureMapper.oldBogangFreeToNewFreeBogangInsert(lectureVO);
 	}
 }

--- a/src/main/java/com/academy/lecture/service/MacAddressManagerService.java
+++ b/src/main/java/com/academy/lecture/service/MacAddressManagerService.java
@@ -1,19 +1,46 @@
 package com.academy.lecture.service;
 
-import java.util.HashMap;
-import java.util.List;
+import java.util.ArrayList;
 
-public interface MacAddressManagerService {
+import org.json.simple.JSONObject;
+import org.springframework.stereotype.Service;
 
-	List<HashMap<String, String>> macaddressmanagerList(HashMap<String, String> params);
-	
-	List<HashMap<String, String>> devicelist(HashMap<String, String> params);
-	
-	List<HashMap<String, String>> macaddressView(HashMap<String, String> params);
+import com.academy.mapper.MacAddressManagerMapper;
 
-	int macaddressmanagerListCount(HashMap<String, String> params);
+/**
+ * MacAddressManager Service
+ * ExamService 패턴 적용 - ArrayList<JSONObject> 및 VO 사용
+ */
+@Service
+public class MacAddressManagerService {
 
-	void macaddressmanagerUpdate(HashMap<String, String> params);
-	void macaddressmanagerUpdate1(HashMap<String, String> params);
+	private MacAddressManagerMapper macAddressManagerMapper;
 
+	public MacAddressManagerService(MacAddressManagerMapper macAddressManagerMapper) {
+		this.macAddressManagerMapper = macAddressManagerMapper;
+	}
+
+	public ArrayList<JSONObject> macaddressmanagerList(MacAddressManagerVO macAddressManagerVO) {
+		return macAddressManagerMapper.macaddressmanagerList(macAddressManagerVO);
+	}
+
+	public ArrayList<JSONObject> devicelist(MacAddressManagerVO macAddressManagerVO) {
+		return macAddressManagerMapper.devicelist(macAddressManagerVO);
+	}
+
+	public ArrayList<JSONObject> macaddressView(MacAddressManagerVO macAddressManagerVO) {
+		return macAddressManagerMapper.macaddressView(macAddressManagerVO);
+	}
+
+	public int macaddressmanagerListCount(MacAddressManagerVO macAddressManagerVO) {
+		return macAddressManagerMapper.macaddressmanagerListCount(macAddressManagerVO);
+	}
+
+	public void macaddressmanagerUpdate(MacAddressManagerVO macAddressManagerVO) {
+		macAddressManagerMapper.macaddressmanagerUpdate(macAddressManagerVO);
+	}
+
+	public void macaddressmanagerUpdate1(MacAddressManagerVO macAddressManagerVO) {
+		macAddressManagerMapper.macaddressmanagerUpdate1(macAddressManagerVO);
+	}
 }

--- a/src/main/java/com/academy/lecture/service/OpenLectureService.java
+++ b/src/main/java/com/academy/lecture/service/OpenLectureService.java
@@ -1,125 +1,250 @@
 package com.academy.lecture.service;
 
-import java.util.HashMap;
-import java.util.List;
+import java.util.ArrayList;
 
-public interface OpenLectureService {
+import org.json.simple.JSONObject;
+import org.springframework.stereotype.Service;
 
-	List<HashMap<String, String>> openlectureList(HashMap<String, String> params);
-	
-	int openlectureListCount(HashMap<String, String> params);
+import com.academy.mapper.OpenLectureMapper;
 
-	List<HashMap<String, String>> bookList(HashMap<String, String> params);
-	
-	int bookListCount(HashMap<String, String> params);	
-	
-	List<HashMap<String, String>> getBridgeLeccodeSeq(HashMap<String, String> params);// 삭제대상
-	
-	List<HashMap<String, String>> getJongLeccodeSeq(HashMap<String, String> params); // 삭제대상
-	
-	List<HashMap<String, String>> getopenLeccode(HashMap<String, String> params); // 삭제대상
-	
-	List<HashMap<String, String>> getBridgeLeccode(HashMap<String, String> params);//삭제대상
-	
-	List<HashMap<String, String>> BridgeLeccode(HashMap<String, String> params);
-	
-	void openlectureInsert(HashMap<String, String> params);
-	
-	void openlectureBridgeInsert(HashMap<String, String> params);
-	
-	void openlectureBookInsert(HashMap<String, String> params);
-	
-	void openlectureBookInsert2(HashMap<String, String> params);
-	
-	List<HashMap<String, String>> openlectureViewList(HashMap<String, String> params);
-	
-	List<HashMap<String, String>> openlectureView(HashMap<String, String> params);
-	
-	List<HashMap<String, String>> openlectureViewBookList(HashMap<String, String> params);
-	
-	void openlectureBookDelete(HashMap<String, String> params);
-	
-	void openlectureUpdate(HashMap<String, String> params);
-	
-	void Modify_Lecture_On_Off(HashMap<String, String> params);
-	
-	void openlectureIsUseUpdate(HashMap<String, String> params);
-	
-	void openlectureDelete(HashMap<String, String> params);
-	
-	void openlectureBridgeDelete(HashMap<String, String> params);	
-	
-	void lecMovUpdate(HashMap<String, String> params);	
-	
-	List<HashMap<String, String>> openlectureSeqList(HashMap<String, String> params);
-	
-	void openlectureSeqUpdate(HashMap<String, String> params);	
+/**
+ * OpenLecture Service
+ * ExamService 패턴 적용 - ArrayList<JSONObject> 및 VO 사용
+ */
+@Service
+public class OpenLectureService {
 
-	
-	
-	List<HashMap<String, String>> openlectureViewJongList(HashMap<String, String> params);
-	
-	List<HashMap<String, String>> openlectureJongList(HashMap<String, String> params);
-	
-	int openlectureJongListCount(HashMap<String, String> params);	
-	
-	List<HashMap<String, String>> openlectureJongSubjectList(HashMap<String, String> params);	
-	
-	List<HashMap<String, String>> openlectureJongView(HashMap<String, String> params);
-	
-	int openlectureJongSubjectListCount(HashMap<String, String> params);
-	
-	void openlectureLecJongInsert(HashMap<String, String> params);
-	
-	void openlectureChoiceJongNoInsert(HashMap<String, String> params);
-	
-	List<HashMap<String, String>> openlectureViewLeccodeList(HashMap<String, String> params);
-	
-	void openlectureLecJongDelete(HashMap<String, String> params);	
-	
-	void openlectureChoiceJongNoDelete(HashMap<String, String> params);
-	
-	List<HashMap<String, String>> openlecturePayList(HashMap<String, String> params);
-	
-	List<HashMap<String, String>> openlectureJongPayList(HashMap<String, String> params);
-	
-	List<HashMap<String, String>> openlectureDataMemoViewList(HashMap<String, String> params);
-	
-	List<HashMap<String, String>> openlectureDataViewList(HashMap<String, String> params);
-	
-	List<HashMap<String, String>> openlectureDataMovieViewList(HashMap<String, String> params);
-	
-	List<HashMap<String, String>> openlectureDataMovieList(HashMap<String, String> params);
-	
-	void openlectureMovieInsert(HashMap<String, String> params);
-	
-	void openlectureMovieDelete(HashMap<String, String> params);		
-	
-	void openlectureMovieUpdate(HashMap<String, String> params);
-	
-	void openlectureMovieFileDelete(HashMap<String, String> params);	
-	
+	private OpenLectureMapper openLectureMapper;
 
-	void openlectureMovieMemoInsert(HashMap<String, String> params);
-		
-	void openlectureMovieMemoUpdate(HashMap<String, String> params);
-	
-	void openlectureMovieMemoDelete(HashMap<String, String> params);
-	
-	int openlectureDeleteCheck(HashMap<String, String> params);
-	
-	
-	List<HashMap<String, String>> playinfo(HashMap<String, String> params);
+	public OpenLectureService(OpenLectureMapper openLectureMapper) {
+		this.openLectureMapper = openLectureMapper;
+	}
 
-	List<HashMap<String, String>> getCbMovie4_free_admin(HashMap<String, String> params);
-	
-	int getCbMovie4_free_admin_count(HashMap<String, String> params);	
-	
-	HashMap<String, String> openlectureOnDetailS(HashMap<String, String> params);
-	
-	void insertPmpDownLog(HashMap<String, String> params);
-	
-	List<HashMap<String, String>> openlectureWMV(HashMap<String, String> params);
-	
-	List<HashMap<String, String>> openlectureDown_Count(HashMap<String, String> params);
+	public ArrayList<JSONObject> openlectureList(OpenLectureVO openLectureVO) {
+		return openLectureMapper.openlectureList(openLectureVO);
+	}
+
+	public int openlectureListCount(OpenLectureVO openLectureVO) {
+		return openLectureMapper.openlectureListCount(openLectureVO);
+	}
+
+	public ArrayList<JSONObject> bookList(OpenLectureVO openLectureVO) {
+		return openLectureMapper.bookList(openLectureVO);
+	}
+
+	public int bookListCount(OpenLectureVO openLectureVO) {
+		return openLectureMapper.bookListCount(openLectureVO);
+	}
+
+	public ArrayList<JSONObject> getBridgeLeccodeSeq(OpenLectureVO openLectureVO) {
+		return openLectureMapper.getBridgeLeccodeSeq(openLectureVO);
+	}
+
+	public ArrayList<JSONObject> getJongLeccodeSeq(OpenLectureVO openLectureVO) {
+		return openLectureMapper.getJongLeccodeSeq(openLectureVO);
+	}
+
+	public ArrayList<JSONObject> getopenLeccode(OpenLectureVO openLectureVO) {
+		return openLectureMapper.getopenLeccode(openLectureVO);
+	}
+
+	public ArrayList<JSONObject> getBridgeLeccode(OpenLectureVO openLectureVO) {
+		return openLectureMapper.getBridgeLeccode(openLectureVO);
+	}
+
+	public ArrayList<JSONObject> BridgeLeccode(OpenLectureVO openLectureVO) {
+		return openLectureMapper.BridgeLeccode(openLectureVO);
+	}
+
+	public void openlectureInsert(OpenLectureVO openLectureVO) {
+		openLectureMapper.openlectureInsert(openLectureVO);
+	}
+
+	public void openlectureBridgeInsert(OpenLectureVO openLectureVO) {
+		openLectureMapper.openlectureBridgeInsert(openLectureVO);
+	}
+
+	public void openlectureBookInsert(OpenLectureVO openLectureVO) {
+		openLectureMapper.openlectureBookInsert(openLectureVO);
+	}
+
+	public void openlectureBookInsert2(OpenLectureVO openLectureVO) {
+		openLectureMapper.openlectureBookInsert2(openLectureVO);
+	}
+
+	public ArrayList<JSONObject> openlectureViewList(OpenLectureVO openLectureVO) {
+		return openLectureMapper.openlectureViewList(openLectureVO);
+	}
+
+	public ArrayList<JSONObject> openlectureView(OpenLectureVO openLectureVO) {
+		return openLectureMapper.openlectureView(openLectureVO);
+	}
+
+	public ArrayList<JSONObject> openlectureViewBookList(OpenLectureVO openLectureVO) {
+		return openLectureMapper.openlectureViewBookList(openLectureVO);
+	}
+
+	public void openlectureBookDelete(OpenLectureVO openLectureVO) {
+		openLectureMapper.openlectureBookDelete(openLectureVO);
+	}
+
+	public void openlectureUpdate(OpenLectureVO openLectureVO) {
+		openLectureMapper.openlectureUpdate(openLectureVO);
+	}
+
+	public void Modify_Lecture_On_Off(OpenLectureVO openLectureVO) {
+		openLectureMapper.Modify_Lecture_On_Off(openLectureVO);
+	}
+
+	public void openlectureIsUseUpdate(OpenLectureVO openLectureVO) {
+		openLectureMapper.openlectureIsUseUpdate(openLectureVO);
+	}
+
+	public void openlectureDelete(OpenLectureVO openLectureVO) {
+		openLectureMapper.openlectureDelete(openLectureVO);
+	}
+
+	public void openlectureBridgeDelete(OpenLectureVO openLectureVO) {
+		openLectureMapper.openlectureBridgeDelete(openLectureVO);
+	}
+
+	public void lecMovUpdate(OpenLectureVO openLectureVO) {
+		openLectureMapper.lecMovUpdate(openLectureVO);
+	}
+
+	public ArrayList<JSONObject> openlectureSeqList(OpenLectureVO openLectureVO) {
+		return openLectureMapper.openlectureSeqList(openLectureVO);
+	}
+
+	public void openlectureSeqUpdate(OpenLectureVO openLectureVO) {
+		openLectureMapper.openlectureSeqUpdate(openLectureVO);
+	}
+
+	public ArrayList<JSONObject> openlectureViewJongList(OpenLectureVO openLectureVO) {
+		return openLectureMapper.openlectureViewJongList(openLectureVO);
+	}
+
+	public ArrayList<JSONObject> openlectureJongList(OpenLectureVO openLectureVO) {
+		return openLectureMapper.openlectureJongList(openLectureVO);
+	}
+
+	public int openlectureJongListCount(OpenLectureVO openLectureVO) {
+		return openLectureMapper.openlectureJongListCount(openLectureVO);
+	}
+
+	public ArrayList<JSONObject> openlectureJongSubjectList(OpenLectureVO openLectureVO) {
+		return openLectureMapper.openlectureJongSubjectList(openLectureVO);
+	}
+
+	public ArrayList<JSONObject> openlectureJongView(OpenLectureVO openLectureVO) {
+		return openLectureMapper.openlectureJongView(openLectureVO);
+	}
+
+	public int openlectureJongSubjectListCount(OpenLectureVO openLectureVO) {
+		return openLectureMapper.openlectureJongSubjectListCount(openLectureVO);
+	}
+
+	public void openlectureLecJongInsert(OpenLectureVO openLectureVO) {
+		openLectureMapper.openlectureLecJongInsert(openLectureVO);
+	}
+
+	public void openlectureChoiceJongNoInsert(OpenLectureVO openLectureVO) {
+		openLectureMapper.openlectureChoiceJongNoInsert(openLectureVO);
+	}
+
+	public ArrayList<JSONObject> openlectureViewLeccodeList(OpenLectureVO openLectureVO) {
+		return openLectureMapper.openlectureViewLeccodeList(openLectureVO);
+	}
+
+	public void openlectureLecJongDelete(OpenLectureVO openLectureVO) {
+		openLectureMapper.openlectureLecJongDelete(openLectureVO);
+	}
+
+	public void openlectureChoiceJongNoDelete(OpenLectureVO openLectureVO) {
+		openLectureMapper.openlectureChoiceJongNoDelete(openLectureVO);
+	}
+
+	public ArrayList<JSONObject> openlecturePayList(OpenLectureVO openLectureVO) {
+		return openLectureMapper.openlecturePayList(openLectureVO);
+	}
+
+	public ArrayList<JSONObject> openlectureJongPayList(OpenLectureVO openLectureVO) {
+		return openLectureMapper.openlectureJongPayList(openLectureVO);
+	}
+
+	public ArrayList<JSONObject> openlectureDataMemoViewList(OpenLectureVO openLectureVO) {
+		return openLectureMapper.openlectureDataMemoViewList(openLectureVO);
+	}
+
+	public ArrayList<JSONObject> openlectureDataViewList(OpenLectureVO openLectureVO) {
+		return openLectureMapper.openlectureDataViewList(openLectureVO);
+	}
+
+	public ArrayList<JSONObject> openlectureDataMovieViewList(OpenLectureVO openLectureVO) {
+		return openLectureMapper.openlectureDataMovieViewList(openLectureVO);
+	}
+
+	public ArrayList<JSONObject> openlectureDataMovieList(OpenLectureVO openLectureVO) {
+		return openLectureMapper.openlectureDataMovieList(openLectureVO);
+	}
+
+	public void openlectureMovieInsert(OpenLectureVO openLectureVO) {
+		openLectureMapper.openlectureMovieInsert(openLectureVO);
+	}
+
+	public void openlectureMovieDelete(OpenLectureVO openLectureVO) {
+		openLectureMapper.openlectureMovieDelete(openLectureVO);
+	}
+
+	public void openlectureMovieUpdate(OpenLectureVO openLectureVO) {
+		openLectureMapper.openlectureMovieUpdate(openLectureVO);
+	}
+
+	public void openlectureMovieFileDelete(OpenLectureVO openLectureVO) {
+		openLectureMapper.openlectureMovieFileDelete(openLectureVO);
+	}
+
+	public void openlectureMovieMemoInsert(OpenLectureVO openLectureVO) {
+		openLectureMapper.openlectureMovieMemoInsert(openLectureVO);
+	}
+
+	public void openlectureMovieMemoUpdate(OpenLectureVO openLectureVO) {
+		openLectureMapper.openlectureMovieMemoUpdate(openLectureVO);
+	}
+
+	public void openlectureMovieMemoDelete(OpenLectureVO openLectureVO) {
+		openLectureMapper.openlectureMovieMemoDelete(openLectureVO);
+	}
+
+	public int openlectureDeleteCheck(OpenLectureVO openLectureVO) {
+		return openLectureMapper.openlectureDeleteCheck(openLectureVO);
+	}
+
+	public ArrayList<JSONObject> playinfo(OpenLectureVO openLectureVO) {
+		return openLectureMapper.playinfo(openLectureVO);
+	}
+
+	public ArrayList<JSONObject> getCbMovie4_free_admin(OpenLectureVO openLectureVO) {
+		return openLectureMapper.getCbMovie4_free_admin(openLectureVO);
+	}
+
+	public int getCbMovie4_free_admin_count(OpenLectureVO openLectureVO) {
+		return openLectureMapper.getCbMovie4_free_admin_count(openLectureVO);
+	}
+
+	public JSONObject openlectureOnDetailS(OpenLectureVO openLectureVO) {
+		return openLectureMapper.openlectureOnDetailS(openLectureVO);
+	}
+
+	public void insertPmpDownLog(OpenLectureVO openLectureVO) {
+		openLectureMapper.insertPmpDownLog(openLectureVO);
+	}
+
+	public ArrayList<JSONObject> openlectureWMV(OpenLectureVO openLectureVO) {
+		return openLectureMapper.openlectureWMV(openLectureVO);
+	}
+
+	public ArrayList<JSONObject> openlectureDown_Count(OpenLectureVO openLectureVO) {
+		return openLectureMapper.openlectureDown_Count(openLectureVO);
+	}
 }

--- a/src/main/java/com/academy/lecture/service/ProductEventService.java
+++ b/src/main/java/com/academy/lecture/service/ProductEventService.java
@@ -1,45 +1,74 @@
 package com.academy.lecture.service;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.ArrayList;
 
-public interface ProductEventService {
+import org.json.simple.JSONObject;
+import org.springframework.stereotype.Service;
 
-	List<HashMap<String, String>> list(HashMap<String, String> params);
-	
-	int listCount(HashMap<String, String> params);
+import com.academy.mapper.ProductEventMapper;
 
-	HashMap<String, String> getOne(HashMap<String, String> params);
+/**
+ * ProductEvent Service
+ * ExamService 패턴 적용 - ArrayList<JSONObject> 및 VO 사용
+ */
+@Service
+public class ProductEventService {
 
-	List<HashMap<String, String>> list_prd(HashMap<String, String> params);
+	private ProductEventMapper productEventMapper;
 
-	void insert(HashMap<String, String> params);
-	
-	void update(HashMap<String, String> params);
+	public ProductEventService(ProductEventMapper productEventMapper) {
+		this.productEventMapper = productEventMapper;
+	}
 
-	void lec_insert(HashMap<String, String> params);
-	
-	void lec_delete(HashMap<String, String> params);
-	
-	// 강의선택 팝업 카테고리 셀렉트박스 리스트
-	@SuppressWarnings({ "rawtypes" })
-	List getCaCatCdList(Map keyName);
-	
-	// 강의선택 팝업 학습형태 셀렉트박스 리스트
-	@SuppressWarnings({ "rawtypes" })
-	List getVwMenuMstTree_lec(Map keyName);
-	
-	// 강의선택 팝업 과목 셀렉트박스 리스트
-	@SuppressWarnings({ "rawtypes" })
-	List getCaSubjectCdList(Map keyName);
-	
-	// 강의선택 팝업  리스트
-	@SuppressWarnings({ "rawtypes" })
-	List getCbLecMstFreeOrderList(Map keyName);
-		
-	// 강의선택 팝업  카운트
-	@SuppressWarnings({ "rawtypes" })
-	int getCbLecMstListFreeOrderCount(Map keyName);
+	public ArrayList<JSONObject> list(ProductEventVO productEventVO) {
+		return productEventMapper.list(productEventVO);
+	}
 
+	public int listCount(ProductEventVO productEventVO) {
+		return productEventMapper.listCount(productEventVO);
+	}
+
+	public JSONObject getOne(ProductEventVO productEventVO) {
+		return productEventMapper.getOne(productEventVO);
+	}
+
+	public ArrayList<JSONObject> list_prd(ProductEventVO productEventVO) {
+		return productEventMapper.list_prd(productEventVO);
+	}
+
+	public void insert(ProductEventVO productEventVO) {
+		productEventMapper.insert(productEventVO);
+	}
+
+	public void update(ProductEventVO productEventVO) {
+		productEventMapper.update(productEventVO);
+	}
+
+	public void lec_insert(ProductEventVO productEventVO) {
+		productEventMapper.lec_insert(productEventVO);
+	}
+
+	public void lec_delete(ProductEventVO productEventVO) {
+		productEventMapper.lec_delete(productEventVO);
+	}
+
+	public ArrayList<JSONObject> getCaCatCdList(ProductEventVO productEventVO) {
+		return productEventMapper.getCaCatCdList(productEventVO);
+	}
+
+	public ArrayList<JSONObject> getVwMenuMstTree_lec(ProductEventVO productEventVO) {
+		return productEventMapper.getVwMenuMstTree_lec(productEventVO);
+	}
+
+	public ArrayList<JSONObject> getCaSubjectCdList(ProductEventVO productEventVO) {
+		return productEventMapper.getCaSubjectCdList(productEventVO);
+	}
+
+	public ArrayList<JSONObject> getCbLecMstFreeOrderList(ProductEventVO productEventVO) {
+		return productEventMapper.getCbLecMstFreeOrderList(productEventVO);
+	}
+
+	public int getCbLecMstListFreeOrderCount(ProductEventVO productEventVO) {
+		return productEventMapper.getCbLecMstListFreeOrderCount(productEventVO);
+	}
 }

--- a/src/main/java/com/academy/lecture/service/SeriesService.java
+++ b/src/main/java/com/academy/lecture/service/SeriesService.java
@@ -1,26 +1,66 @@
 package com.academy.lecture.service;
 
-import java.util.HashMap;
-import java.util.List;
+import java.util.ArrayList;
 
+import org.json.simple.JSONObject;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-public interface SeriesService {
+import com.academy.mapper.SeriesMapper;
 
-	List<HashMap<String, String>> seriesList(Object obj);
+/**
+ * Series Service
+ * ExamService 패턴 적용 - ArrayList<JSONObject> 및 VO 사용
+ */
+@Service
+public class SeriesService {
 
-	int seriesListCount(Object obj);
+	private SeriesMapper seriesMapper;
 
-    @Transactional(readOnly=false,rollbackFor=Exception.class)
-	void seriesInsert(Object obj);
+	public SeriesService(SeriesMapper seriesMapper) {
+		this.seriesMapper = seriesMapper;
+	}
 
-	List<HashMap<String, String>> seriesView(Object obj);
+	public ArrayList<JSONObject> seriesList(SeriesVO seriesVO) {
+		return seriesMapper.seriesList(seriesVO);
+	}
 
-    @Transactional(readOnly=false,rollbackFor=Exception.class)
-	void seriesUpdate(Object obj);
+	public int seriesListCount(SeriesVO seriesVO) {
+		return seriesMapper.seriesListCount(seriesVO);
+	}
 
-    @Transactional(readOnly=false,rollbackFor=Exception.class)
-	void seriesDelete(Object obj);
+	@Transactional(readOnly = false, rollbackFor = Exception.class)
+	public void seriesInsert(SeriesVO seriesVO) {
+		seriesMapper.seriesInsert(seriesVO);
+	}
 
-	int seriesCheck(Object obj);
+	public ArrayList<JSONObject> seriesView(SeriesVO seriesVO) {
+		return seriesMapper.seriesView(seriesVO);
+	}
+
+	@Transactional(readOnly = false, rollbackFor = Exception.class)
+	public void seriesUpdate(SeriesVO seriesVO) {
+		seriesMapper.seriesUpdate(seriesVO);
+	}
+
+	@Transactional(readOnly = false, rollbackFor = Exception.class)
+	public void seriesDelete(SeriesVO seriesVO) {
+		seriesMapper.seriesDelete(seriesVO);
+	}
+
+	public int seriesCheck(SeriesVO seriesVO) {
+		return seriesMapper.seriesCheck(seriesVO);
+	}
+
+	public void catSeriesInsert(SeriesVO seriesVO) {
+		seriesMapper.catSeriesInsert(seriesVO);
+	}
+
+	public void catSeriesDeleteWthCatCd(SeriesVO seriesVO) {
+		seriesMapper.catSeriesDeleteWthCatCd(seriesVO);
+	}
+
+	public void catSeriesDeleteWthSrsCd(SeriesVO seriesVO) {
+		seriesMapper.catSeriesDeleteWthSrsCd(seriesVO);
+	}
 }

--- a/src/main/java/com/academy/lecture/service/SubjectService.java
+++ b/src/main/java/com/academy/lecture/service/SubjectService.java
@@ -1,49 +1,102 @@
 package com.academy.lecture.service;
 
-import java.util.HashMap;
-import java.util.List;
+import java.util.ArrayList;
 
-public interface SubjectService {
+import org.json.simple.JSONObject;
+import org.springframework.stereotype.Service;
 
-	List<HashMap<String, String>> subjectList(HashMap<String, String> params);
+import com.academy.mapper.SubjectMapper;
 
-	int subjectListCount(HashMap<String, String> params);
+/**
+ * Subject Service
+ * ExamService 패턴 적용 - ArrayList<JSONObject> 및 VO 사용
+ */
+@Service
+public class SubjectService {
 
-	String subjectGetCode(HashMap<String, String> params);
+	private SubjectMapper subjectMapper;
 
-	void subjectInsert(HashMap<String, String> params);
+	public SubjectService(SubjectMapper subjectMapper) {
+		this.subjectMapper = subjectMapper;
+	}
 
-	List<HashMap<String, String>> subjectView(HashMap<String, String> params);
+	public ArrayList<JSONObject> subjectList(SubjectVO subjectVO) {
+		return subjectMapper.subjectList(subjectVO);
+	}
 
-	void subjectUpdate(HashMap<String, String> params);
+	public int subjectListCount(SubjectVO subjectVO) {
+		return subjectMapper.subjectListCount(subjectVO);
+	}
 
-	void subjectDelete(HashMap<String, String> params);
+	public String subjectGetCode(SubjectVO subjectVO) {
+		return subjectMapper.subjectGetCode(subjectVO);
+	}
 
-	int subjectCheck(HashMap<String, String> params);
+	public void subjectInsert(SubjectVO subjectVO) {
+		subjectMapper.subjectInsert(subjectVO);
+	}
 
-	void subjectCategoryInsert(HashMap<String, String> params);
+	public ArrayList<JSONObject> subjectView(SubjectVO subjectVO) {
+		return subjectMapper.subjectView(subjectVO);
+	}
 
-	void subjectCategoryDelete(HashMap<String, String> params);
+	public void subjectUpdate(SubjectVO subjectVO) {
+		subjectMapper.subjectUpdate(subjectVO);
+	}
 
-	void subjectCategoryDeleteByCat(HashMap<String, String> params);
+	public void subjectDelete(SubjectVO subjectVO) {
+		subjectMapper.subjectDelete(subjectVO);
+	}
 
-	void subjectCategoryOrderInsert(HashMap<String, String> params);
-	
-	int chkSubjectCategoryOrderCnt(HashMap<String, String> params);
+	public int subjectCheck(SubjectVO subjectVO) {
+		return subjectMapper.subjectCheck(subjectVO);
+	}
 
-	int chkSubjectCategoryCnt(HashMap<String, String> params);
-	
-	void subjectCategoryOrderDeleteByOnoff(HashMap<String, String> params);
-	
-	String getSubjectCategoryOrderIdx(HashMap<String, String> params);
-	
-	
-	void subjectCategoryOrderDelete(HashMap<String, String> params);
+	public void subjectCategoryInsert(SubjectVO subjectVO) {
+		subjectMapper.subjectCategoryInsert(subjectVO);
+	}
 
-	List<HashMap<String, String>> subjectCategoryView(HashMap<String, String> params);
+	public void subjectCategoryDelete(SubjectVO subjectVO) {
+		subjectMapper.subjectCategoryDelete(subjectVO);
+	}
 
-	List<HashMap<String, String>> findSubjectCategoryList(HashMap<String, String> params);
+	public void subjectCategoryDeleteByCat(SubjectVO subjectVO) {
+		subjectMapper.subjectCategoryDeleteByCat(subjectVO);
+	}
 
-	void main_category_subject_order_Insert(HashMap<String, String> params);
+	public void subjectCategoryOrderInsert(SubjectVO subjectVO) {
+		subjectMapper.subjectCategoryOrderInsert(subjectVO);
+	}
 
+	public int chkSubjectCategoryOrderCnt(SubjectVO subjectVO) {
+		return subjectMapper.chkSubjectCategoryOrderCnt(subjectVO);
+	}
+
+	public int chkSubjectCategoryCnt(SubjectVO subjectVO) {
+		return subjectMapper.chkSubjectCategoryCnt(subjectVO);
+	}
+
+	public void subjectCategoryOrderDeleteByOnoff(SubjectVO subjectVO) {
+		subjectMapper.subjectCategoryOrderDeleteByOnoff(subjectVO);
+	}
+
+	public String getSubjectCategoryOrderIdx(SubjectVO subjectVO) {
+		return subjectMapper.getSubjectCategoryOrderIdx(subjectVO);
+	}
+
+	public void subjectCategoryOrderDelete(SubjectVO subjectVO) {
+		subjectMapper.subjectCategoryOrderDelete(subjectVO);
+	}
+
+	public ArrayList<JSONObject> subjectCategoryView(SubjectVO subjectVO) {
+		return subjectMapper.subjectCategoryView(subjectVO);
+	}
+
+	public ArrayList<JSONObject> findSubjectCategoryList(SubjectVO subjectVO) {
+		return subjectMapper.findSubjectCategoryList(subjectVO);
+	}
+
+	public void main_category_subject_order_Insert(SubjectVO subjectVO) {
+		subjectMapper.main_category_subject_order_Insert(subjectVO);
+	}
 }

--- a/src/main/java/com/academy/lecture/service/TeacherService.java
+++ b/src/main/java/com/academy/lecture/service/TeacherService.java
@@ -1,76 +1,166 @@
 package com.academy.lecture.service;
 
-import java.util.HashMap;
-import java.util.List;
+import java.util.ArrayList;
 
-public interface TeacherService {
+import org.json.simple.JSONObject;
+import org.springframework.stereotype.Service;
 
-    List<HashMap<String, String>> getKindList(HashMap<String, String> params);
+import com.academy.mapper.TeacherMapper;
 
-    List<HashMap<String, String>> getSubjectList(HashMap<String, String> params);
+/**
+ * Teacher Service
+ * ExamService 패턴 적용 - ArrayList<JSONObject> 및 VO 사용
+ */
+@Service
+public class TeacherService {
 
-    List<HashMap<String, String>> teacherList(HashMap<String, String> params);
+	private TeacherMapper teacherMapper;
 
-    int teacherListCount(HashMap<String, String> params);
+	public TeacherService(TeacherMapper teacherMapper) {
+		this.teacherMapper = teacherMapper;
+	}
 
-    List<HashMap<String, String>> teacherAllList(HashMap<String, String> params);
-    
-    int teacherAllListCount(HashMap<String, String> params);
+	public ArrayList<JSONObject> getKindList(TeacherVO teacherVO) {
+		return teacherMapper.getKindList(teacherVO);
+	}
 
-    int teacherIdCheck(HashMap<String, String> params);
+	public ArrayList<JSONObject> getSubjectList(TeacherVO teacherVO) {
+		return teacherMapper.getSubjectList(teacherVO);
+	}
 
-    void teacherInsert(Object obj);
+	public ArrayList<JSONObject> teacherList(TeacherVO teacherVO) {
+		return teacherMapper.teacherList(teacherVO);
+	}
 
-    List<HashMap<String, String>> teacherView(HashMap<String, String> params);
+	public int teacherListCount(TeacherVO teacherVO) {
+		return teacherMapper.teacherListCount(teacherVO);
+	}
 
-    void teacherUpdate(Object obj);
+	public ArrayList<JSONObject> teacherAllList(TeacherVO teacherVO) {
+		return teacherMapper.teacherAllList(teacherVO);
+	}
 
-    void teacherCategoryInsert(HashMap<String, String> params);
+	public int teacherAllListCount(TeacherVO teacherVO) {
+		return teacherMapper.teacherAllListCount(teacherVO);
+	}
 
-    void teacherSubjectInsert(HashMap<String, String> params);
+	public int teacherIdCheck(TeacherVO teacherVO) {
+		return teacherMapper.teacherIdCheck(teacherVO);
+	}
 
-    void teacherIsUseUpdate(Object obj);
+	public void teacherInsert(TeacherVO teacherVO) {
+		teacherMapper.teacherInsert(teacherVO);
+	}
 
-    void teacherDelete(HashMap<String, String> params);
+	public ArrayList<JSONObject> teacherView(TeacherVO teacherVO) {
+		return teacherMapper.teacherView(teacherVO);
+	}
 
-    void teacherCategoryDelete(HashMap<String, String> params);
+	public void teacherUpdate(TeacherVO teacherVO) {
+		teacherMapper.teacherUpdate(teacherVO);
+	}
 
-    void teacherSubjectDelete(HashMap<String, String> params);
+	public void teacherCategoryInsert(TeacherVO teacherVO) {
+		teacherMapper.teacherCategoryInsert(teacherVO);
+	}
 
-    void teacherSeqUpdate(Object obj);
+	public void teacherSubjectInsert(TeacherVO teacherVO) {
+		teacherMapper.teacherSubjectInsert(teacherVO);
+	}
 
-    List<HashMap<String, String>> teacherBookLog(HashMap<String, String> params);
+	public void teacherSubjectUpdate(TeacherVO teacherVO) {
+		teacherMapper.teacherSubjectUpdate(teacherVO);
+	}
 
-	void teacherMain_Category_Insert(HashMap<String, String> params);
+	public int teacherSubjectCount(TeacherVO teacherVO) {
+		return teacherMapper.teacherSubjectCount(teacherVO);
+	}
 
-	void teacherMain_Category_Delete(HashMap<String, String> params);
+	public void teacherIsUseUpdate(TeacherVO teacherVO) {
+		teacherMapper.teacherIsUseUpdate(teacherVO);
+	}
 
-	List<HashMap<String, String>> teacherMainList(HashMap<String, String> params);
+	public void teacherDelete(TeacherVO teacherVO) {
+		teacherMapper.teacherDelete(teacherVO);
+	}
 
-	int teacherMainListCount(HashMap<String, String> params);
+	public void teacherCategoryDelete(TeacherVO teacherVO) {
+		teacherMapper.teacherCategoryDelete(teacherVO);
+	}
 
-    List<HashMap<String, String>> findTeacherList(HashMap<String, String> params);
+	public void teacherSubjectDelete(TeacherVO teacherVO) {
+		teacherMapper.teacherSubjectDelete(teacherVO);
+	}
 
-	int teacherMain_Category_Subject(HashMap<String, String> params);
-	
-	int teacherIntro_Category_Subject(HashMap<String, String> params);	
-	
-	int teacherIntro_F_Category_Subject(HashMap<String, String> params);
-	
-	List<HashMap<String, String>> teacherIntroList(HashMap<String, String> params);
+	public void teacherSeqUpdate(TeacherVO teacherVO) {
+		teacherMapper.teacherSeqUpdate(teacherVO);
+	}
 
-	int teacherIntroListCount(HashMap<String, String> params);
-	
-	void teacherIntro_Category_Insert(HashMap<String, String> params);
-	
-	void teacherIntro_F_Category_Insert(HashMap<String, String> params);
+	public ArrayList<JSONObject> teacherBookLog(TeacherVO teacherVO) {
+		return teacherMapper.teacherBookLog(teacherVO);
+	}
 
-	void teacherIntro_Category_Delete(HashMap<String, String> params);	
-	
-	void teacherIntro_F_Category_Delete(HashMap<String, String> params);
-	
-	List<HashMap<String, String>> teacherIntro_offList(HashMap<String, String> params);
+	public void teacherMain_Category_Insert(TeacherVO teacherVO) {
+		teacherMapper.teacherMain_Category_Insert(teacherVO);
+	}
 
-	int teacherIntro_offListCount(HashMap<String, String> params);
+	public void teacherMain_Category_Delete(TeacherVO teacherVO) {
+		teacherMapper.teacherMain_Category_Delete(teacherVO);
+	}
 
+	public ArrayList<JSONObject> teacherMainList(TeacherVO teacherVO) {
+		return teacherMapper.teacherMainList(teacherVO);
+	}
+
+	public int teacherMainListCount(TeacherVO teacherVO) {
+		return teacherMapper.teacherMainListCount(teacherVO);
+	}
+
+	public ArrayList<JSONObject> findTeacherList(TeacherVO teacherVO) {
+		return teacherMapper.findTeacherList(teacherVO);
+	}
+
+	public int teacherMain_Category_Subject(TeacherVO teacherVO) {
+		return teacherMapper.teacherMain_Category_Subject(teacherVO);
+	}
+
+	public int teacherIntro_Category_Subject(TeacherVO teacherVO) {
+		return teacherMapper.teacherIntro_Category_Subject(teacherVO);
+	}
+
+	public int teacherIntro_F_Category_Subject(TeacherVO teacherVO) {
+		return teacherMapper.teacherIntro_F_Category_Subject(teacherVO);
+	}
+
+	public ArrayList<JSONObject> teacherIntroList(TeacherVO teacherVO) {
+		return teacherMapper.teacherIntroList(teacherVO);
+	}
+
+	public int teacherIntroListCount(TeacherVO teacherVO) {
+		return teacherMapper.teacherIntroListCount(teacherVO);
+	}
+
+	public void teacherIntro_Category_Insert(TeacherVO teacherVO) {
+		teacherMapper.teacherIntro_Category_Insert(teacherVO);
+	}
+
+	public void teacherIntro_F_Category_Insert(TeacherVO teacherVO) {
+		teacherMapper.teacherIntro_F_Category_Insert(teacherVO);
+	}
+
+	public void teacherIntro_Category_Delete(TeacherVO teacherVO) {
+		teacherMapper.teacherIntro_Category_Delete(teacherVO);
+	}
+
+	public void teacherIntro_F_Category_Delete(TeacherVO teacherVO) {
+		teacherMapper.teacherIntro_F_Category_Delete(teacherVO);
+	}
+
+	public ArrayList<JSONObject> teacherIntro_offList(TeacherVO teacherVO) {
+		return teacherMapper.teacherIntro_offList(teacherVO);
+	}
+
+	public int teacherIntro_offListCount(TeacherVO teacherVO) {
+		return teacherMapper.teacherIntro_offListCount(teacherVO);
+	}
 }

--- a/src/main/java/com/academy/mapper/CategoryMapper.java
+++ b/src/main/java/com/academy/mapper/CategoryMapper.java
@@ -1,27 +1,30 @@
 package com.academy.mapper;
 
-import java.util.HashMap;
-import java.util.List;
+import java.util.ArrayList;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.json.simple.JSONObject;
+
+import com.academy.lecture.service.CategoryVO;
 
 /**
  * Category Mapper Interface
+ * ExamMapper 패턴 적용 - ArrayList<JSONObject> 및 VO 사용
  */
 @Mapper
 public interface CategoryMapper {
 
-    List<HashMap<String, Object>> getSeriesCateTree();
+    ArrayList<JSONObject> getSeriesCateTree();
 
-    HashMap<String, Object> getDetail(HashMap<String, Object> params);
+    JSONObject getDetail(CategoryVO categoryVO);
 
-    void updateProcess(HashMap<String, Object> params);
+    void updateProcess(CategoryVO categoryVO);
 
-    int deleteProcess(HashMap<String, Object> params);
+    int deleteProcess(CategoryVO categoryVO);
 
-    int idCheck(HashMap<String, Object> params);
+    int idCheck(CategoryVO categoryVO);
 
-    int insertProcess(HashMap<String, Object> params);
+    int insertProcess(CategoryVO categoryVO);
 
-    HashMap<String, Object> getMaxOrdr(Object obj);
+    JSONObject getMaxOrdr(CategoryVO categoryVO);
 }

--- a/src/main/java/com/academy/mapper/FormMapper.java
+++ b/src/main/java/com/academy/mapper/FormMapper.java
@@ -1,31 +1,34 @@
 package com.academy.mapper;
 
-import java.util.HashMap;
-import java.util.List;
+import java.util.ArrayList;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.json.simple.JSONObject;
+
+import com.academy.lecture.service.FormVO;
 
 /**
  * Form Mapper Interface
+ * ExamMapper 패턴 적용 - ArrayList<JSONObject> 및 VO 사용
  */
 @Mapper
 public interface FormMapper {
 
-    List<HashMap<String, String>> formList(HashMap<String, String> params);
+    ArrayList<JSONObject> formList(FormVO formVO);
 
-    int formListCount(HashMap<String, String> params);
+    int formListCount(FormVO formVO);
 
     String formGetCode();
 
-    void formInsert(HashMap<String, String> params);
+    void formInsert(FormVO formVO);
 
-    List<HashMap<String, String>> formView(HashMap<String, String> params);
+    ArrayList<JSONObject> formView(FormVO formVO);
 
-    void formUpdate(HashMap<String, String> params);
+    void formUpdate(FormVO formVO);
 
-    void formDelete(HashMap<String, String> params);
+    void formDelete(FormVO formVO);
 
-    int formCheck(HashMap<String, String> params);
+    int formCheck(FormVO formVO);
 
-    List<HashMap<String, String>> getCodeList(HashMap<String, String> params);
+    ArrayList<JSONObject> getCodeList(FormVO formVO);
 }

--- a/src/main/java/com/academy/mapper/KindMapper.java
+++ b/src/main/java/com/academy/mapper/KindMapper.java
@@ -1,33 +1,36 @@
 package com.academy.mapper;
 
-import java.util.HashMap;
-import java.util.List;
+import java.util.ArrayList;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.json.simple.JSONObject;
+
+import com.academy.lecture.service.KindVO;
 
 /**
  * Kind Mapper Interface
+ * ExamMapper 패턴 적용 - ArrayList<JSONObject> 및 VO 사용
  */
 @Mapper
 public interface KindMapper {
 
-    List<HashMap<String, String>> getKindList(Object obj);
+    ArrayList<JSONObject> getKindList(KindVO kindVO);
 
-    List<HashMap<String, String>> kindList(HashMap<String, String> params);
+    ArrayList<JSONObject> kindList(KindVO kindVO);
 
-    int kindListCount(HashMap<String, String> params);
+    int kindListCount(KindVO kindVO);
 
-    void kindInsert(HashMap<String, String> params);
+    void kindInsert(KindVO kindVO);
 
-    List<HashMap<String, String>> kindView(HashMap<String, String> params);
+    ArrayList<JSONObject> kindView(KindVO kindVO);
 
-    void kindUpdate(HashMap<String, String> params);
+    void kindUpdate(KindVO kindVO);
 
-    void kindDelete(HashMap<String, String> params);
+    void kindDelete(KindVO kindVO);
 
-    int kindCheck(HashMap<String, String> params);
+    int kindCheck(KindVO kindVO);
 
-    List<HashMap<String, String>> selectKindCode();
+    ArrayList<JSONObject> selectKindCode();
 
-    void SeqUpdate(HashMap<String, String> params);
+    void SeqUpdate(KindVO kindVO);
 }

--- a/src/main/java/com/academy/mapper/LectureMapper.java
+++ b/src/main/java/com/academy/mapper/LectureMapper.java
@@ -1,154 +1,156 @@
 package com.academy.mapper;
 
-import java.util.HashMap;
-import java.util.List;
+import java.util.ArrayList;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.json.simple.JSONObject;
+
+import com.academy.lecture.service.LectureVO;
 
 /**
  * Lecture Mapper Interface
- * lectureLectureSQL.xml 매퍼 파일과 연동
+ * ExamMapper 패턴 적용 - ArrayList<JSONObject> 및 VO 사용
  */
 @Mapper
 public interface LectureMapper {
 
-    List<HashMap<String, String>> lectureList(HashMap<String, String> params);
+    ArrayList<JSONObject> lectureList(LectureVO lectureVO);
 
-    List<HashMap<String, String>> oldFreeToNewFree(HashMap<String, String> params);
+    ArrayList<JSONObject> oldFreeToNewFree(LectureVO lectureVO);
 
-    int lectureListCount(HashMap<String, String> params);
+    int lectureListCount(LectureVO lectureVO);
 
-    List<HashMap<String, String>> bookList(HashMap<String, String> params);
+    ArrayList<JSONObject> bookList(LectureVO lectureVO);
 
-    int bookListCount(HashMap<String, String> params);
+    int bookListCount(LectureVO lectureVO);
 
-    List<HashMap<String, String>> getBridgeLeccodeSeq(HashMap<String, String> params);
+    ArrayList<JSONObject> getBridgeLeccodeSeq(LectureVO lectureVO);
 
-    List<HashMap<String, String>> getJongLeccodeSeq(HashMap<String, String> params);
+    ArrayList<JSONObject> getJongLeccodeSeq(LectureVO lectureVO);
 
-    List<HashMap<String, String>> getLeccode(HashMap<String, String> params);
+    ArrayList<JSONObject> getLeccode(LectureVO lectureVO);
 
-    List<HashMap<String, String>> getBridgeLeccode(HashMap<String, String> params);
+    ArrayList<JSONObject> getBridgeLeccode(LectureVO lectureVO);
 
-    List<HashMap<String, String>> BridgeLeccode(HashMap<String, String> params);
+    ArrayList<JSONObject> BridgeLeccode(LectureVO lectureVO);
 
-    void lectureInsert(HashMap<String, String> params);
+    void lectureInsert(LectureVO lectureVO);
 
-    void lectureBridgeInsert(HashMap<String, String> params);
+    void lectureBridgeInsert(LectureVO lectureVO);
 
-    void lectureBookInsert(HashMap<String, String> params);
+    void lectureBookInsert(LectureVO lectureVO);
 
-    void lectureBookInsert2(HashMap<String, String> params);
+    void lectureBookInsert2(LectureVO lectureVO);
 
-    List<HashMap<String, String>> lectureViewList(HashMap<String, String> params);
+    ArrayList<JSONObject> lectureViewList(LectureVO lectureVO);
 
-    List<HashMap<String, String>> lectureView(HashMap<String, String> params);
+    ArrayList<JSONObject> lectureView(LectureVO lectureVO);
 
-    List<HashMap<String, String>> lectureViewBookList(HashMap<String, String> params);
+    ArrayList<JSONObject> lectureViewBookList(LectureVO lectureVO);
 
-    void lectureBookDelete(HashMap<String, String> params);
+    void lectureBookDelete(LectureVO lectureVO);
 
-    void lectureUpdate(HashMap<String, String> params);
+    void lectureUpdate(LectureVO lectureVO);
 
-    void Modify_Lecture_On_Off(HashMap<String, String> params);
+    void Modify_Lecture_On_Off(LectureVO lectureVO);
 
-    void lectureIsUseUpdate(HashMap<String, String> params);
+    void lectureIsUseUpdate(LectureVO lectureVO);
 
-    void lectureDelete(HashMap<String, String> params);
+    void lectureDelete(LectureVO lectureVO);
 
-    void lectureBridgeDelete(HashMap<String, String> params);
+    void lectureBridgeDelete(LectureVO lectureVO);
 
-    void lecMovUpdate(HashMap<String, String> params);
+    void lecMovUpdate(LectureVO lectureVO);
 
-    List<HashMap<String, String>> lectureSeqList(HashMap<String, String> params);
+    ArrayList<JSONObject> lectureSeqList(LectureVO lectureVO);
 
-    void lectureSeqUpdate(HashMap<String, String> params);
+    void lectureSeqUpdate(LectureVO lectureVO);
 
-    List<HashMap<String, String>> lectureViewJongList(HashMap<String, String> params);
+    ArrayList<JSONObject> lectureViewJongList(LectureVO lectureVO);
 
-    List<HashMap<String, String>> lectureJongList(HashMap<String, String> params);
+    ArrayList<JSONObject> lectureJongList(LectureVO lectureVO);
 
-    int lectureJongListCount(HashMap<String, String> params);
+    int lectureJongListCount(LectureVO lectureVO);
 
-    List<HashMap<String, String>> lectureYearList(HashMap<String, String> params);
+    ArrayList<JSONObject> lectureYearList(LectureVO lectureVO);
 
-    int lectureYearListCount(HashMap<String, String> params);
+    int lectureYearListCount(LectureVO lectureVO);
 
-    List<HashMap<String, String>> lectureJongSubjectList(HashMap<String, String> params);
+    ArrayList<JSONObject> lectureJongSubjectList(LectureVO lectureVO);
 
-    List<HashMap<String, String>> lectureJongView(HashMap<String, String> params);
+    ArrayList<JSONObject> lectureJongView(LectureVO lectureVO);
 
-    int lectureJongSubjectListCount(HashMap<String, String> params);
+    int lectureJongSubjectListCount(LectureVO lectureVO);
 
-    void lectureLecJongInsert(HashMap<String, String> params);
+    void lectureLecJongInsert(LectureVO lectureVO);
 
-    void lectureChoiceJongNoInsert(HashMap<String, String> params);
+    void lectureChoiceJongNoInsert(LectureVO lectureVO);
 
-    List<HashMap<String, String>> lectureViewLeccodeList(HashMap<String, String> params);
+    ArrayList<JSONObject> lectureViewLeccodeList(LectureVO lectureVO);
 
-    void lectureLecJongDelete(HashMap<String, String> params);
+    void lectureLecJongDelete(LectureVO lectureVO);
 
-    void lectureChoiceJongNoDelete(HashMap<String, String> params);
+    void lectureChoiceJongNoDelete(LectureVO lectureVO);
 
-    List<HashMap<String, String>> lecturePayList(HashMap<String, String> params);
+    ArrayList<JSONObject> lecturePayList(LectureVO lectureVO);
 
-    List<HashMap<String, String>> lectureJongPayList(HashMap<String, String> params);
+    ArrayList<JSONObject> lectureJongPayList(LectureVO lectureVO);
 
-    List<HashMap<String, String>> lectureDataMemoViewList(HashMap<String, String> params);
+    ArrayList<JSONObject> lectureDataMemoViewList(LectureVO lectureVO);
 
-    List<HashMap<String, String>> lectureDataViewList(HashMap<String, String> params);
+    ArrayList<JSONObject> lectureDataViewList(LectureVO lectureVO);
 
-    List<HashMap<String, String>> lectureMobileList(HashMap<String, String> params);
+    ArrayList<JSONObject> lectureMobileList(LectureVO lectureVO);
 
-    List<HashMap<String, String>> lectureDataMovieViewList(HashMap<String, String> params);
+    ArrayList<JSONObject> lectureDataMovieViewList(LectureVO lectureVO);
 
-    List<HashMap<String, String>> lectureDataMovieList(HashMap<String, String> params);
+    ArrayList<JSONObject> lectureDataMovieList(LectureVO lectureVO);
 
-    void lectureMovieInsert(HashMap<String, String> params);
+    void lectureMovieInsert(LectureVO lectureVO);
 
-    void lectureMovieDelete(HashMap<String, String> params);
+    void lectureMovieDelete(LectureVO lectureVO);
 
-    void lectureMovieUpdate(HashMap<String, String> params);
+    void lectureMovieUpdate(LectureVO lectureVO);
 
-    void lectureMovieFileDelete(HashMap<String, String> params);
+    void lectureMovieFileDelete(LectureVO lectureVO);
 
-    void lectureMovieMemoInsert(HashMap<String, String> params);
+    void lectureMovieMemoInsert(LectureVO lectureVO);
 
-    void lectureMovieMemoUpdate(HashMap<String, String> params);
+    void lectureMovieMemoUpdate(LectureVO lectureVO);
 
-    void lectureMovieMemoDelete(HashMap<String, String> params);
+    void lectureMovieMemoDelete(LectureVO lectureVO);
 
-    int lectureDeleteCheck(HashMap<String, String> params);
+    int lectureDeleteCheck(LectureVO lectureVO);
 
-    List<HashMap<String, String>> playinfo(HashMap<String, String> params);
+    ArrayList<JSONObject> playinfo(LectureVO lectureVO);
 
-    List<HashMap<String, String>> getCbMovie4_free_admin(HashMap<String, String> params);
+    ArrayList<JSONObject> getCbMovie4_free_admin(LectureVO lectureVO);
 
-    int getCbMovie4_free_admin_count(HashMap<String, String> params);
+    int getCbMovie4_free_admin_count(LectureVO lectureVO);
 
-    HashMap<String, String> lectureOnDetailS(HashMap<String, String> params);
+    JSONObject lectureOnDetailS(LectureVO lectureVO);
 
-    void insertPmpDownLog(HashMap<String, String> params);
+    void insertPmpDownLog(LectureVO lectureVO);
 
-    List<HashMap<String, String>> lectureWMV(HashMap<String, String> params);
+    ArrayList<JSONObject> lectureWMV(LectureVO lectureVO);
 
-    List<HashMap<String, String>> lectureDown_Count(HashMap<String, String> params);
+    ArrayList<JSONObject> lectureDown_Count(LectureVO lectureVO);
 
-    void oldFreeToNewFreeInsert(HashMap<String, String> params);
+    void oldFreeToNewFreeInsert(LectureVO lectureVO);
 
-    void oldBogangFreeToNewBogangFree(HashMap<String, String> params);
+    void oldBogangFreeToNewBogangFree(LectureVO lectureVO);
 
-    List<HashMap<String, String>> lectureFreePassPayList(HashMap<String, String> params);
+    ArrayList<JSONObject> lectureFreePassPayList(LectureVO lectureVO);
 
-    List<HashMap<String, String>> YearIngList(HashMap<String, String> params);
+    ArrayList<JSONObject> YearIngList(LectureVO lectureVO);
 
-    List<HashMap<String, String>> MyYearIngList(HashMap<String, String> params);
+    ArrayList<JSONObject> MyYearIngList(LectureVO lectureVO);
 
-    List<HashMap<String, String>> bookView(HashMap<String, String> params);
+    ArrayList<JSONObject> bookView(LectureVO lectureVO);
 
-    String getRleccode(HashMap<String, String> params);
+    String getRleccode(LectureVO lectureVO);
 
-    void oldTbmovieToNewTbmovieInsert(HashMap<String, String> params);
+    void oldTbmovieToNewTbmovieInsert(LectureVO lectureVO);
 
-    void oldBogangFreeToNewFreeBogangInsert(HashMap<String, String> params);
+    void oldBogangFreeToNewFreeBogangInsert(LectureVO lectureVO);
 }

--- a/src/main/java/com/academy/mapper/LectureMstMapper.java
+++ b/src/main/java/com/academy/mapper/LectureMstMapper.java
@@ -1,55 +1,58 @@
 package com.academy.mapper;
 
-import java.util.HashMap;
-import java.util.List;
+import java.util.ArrayList;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.json.simple.JSONObject;
+
+import com.academy.lecture.service.LectureMstVO;
 
 /**
  * LectureMst Mapper Interface
+ * ExamMapper 패턴 적용 - ArrayList<JSONObject> 및 VO 사용
  */
 @Mapper
 public interface LectureMstMapper {
 
-    List<HashMap<String, String>> lecturemstList(HashMap<String, String> params);
+    ArrayList<JSONObject> lecturemstList(LectureMstVO lectureMstVO);
 
-    int lecturemstListCount(HashMap<String, String> params);
+    int lecturemstListCount(LectureMstVO lectureMstVO);
 
-    List<HashMap<String, String>> getBridgeMstcodeSeq(HashMap<String, String> params);
+    ArrayList<JSONObject> getBridgeMstcodeSeq(LectureMstVO lectureMstVO);
 
-    List<HashMap<String, String>> getBridgeMstcode(HashMap<String, String> params);
+    ArrayList<JSONObject> getBridgeMstcode(LectureMstVO lectureMstVO);
 
-    List<HashMap<String, String>> getMstcode(HashMap<String, String> params);
+    ArrayList<JSONObject> getMstcode(LectureMstVO lectureMstVO);
 
-    void lecturemstInsert(HashMap<String, String> params);
+    void lecturemstInsert(LectureMstVO lectureMstVO);
 
-    void lectureBridgeInsert(HashMap<String, String> params);
+    void lectureBridgeInsert(LectureMstVO lectureMstVO);
 
-    void lectureBookInsert2(HashMap<String, String> params);
+    void lectureBookInsert2(LectureMstVO lectureMstVO);
 
-    List<HashMap<String, String>> lectureDataMemoViewList(HashMap<String, String> params);
+    ArrayList<JSONObject> lectureDataMemoViewList(LectureMstVO lectureMstVO);
 
-    List<HashMap<String, String>> lectureDataViewList(HashMap<String, String> params);
+    ArrayList<JSONObject> lectureDataViewList(LectureMstVO lectureMstVO);
 
-    List<HashMap<String, String>> lectureWMV(HashMap<String, String> params);
+    ArrayList<JSONObject> lectureWMV(LectureMstVO lectureMstVO);
 
-    List<HashMap<String, String>> lectureDown_Count(HashMap<String, String> params);
+    ArrayList<JSONObject> lectureDown_Count(LectureMstVO lectureMstVO);
 
-    int lectureDeleteCheck(HashMap<String, String> params);
+    int lectureDeleteCheck(LectureMstVO lectureMstVO);
 
-    List<HashMap<String, String>> lectureView(HashMap<String, String> params);
+    ArrayList<JSONObject> lectureView(LectureMstVO lectureMstVO);
 
-    List<HashMap<String, String>> lectureViewList(HashMap<String, String> params);
+    ArrayList<JSONObject> lectureViewList(LectureMstVO lectureMstVO);
 
-    List<HashMap<String, String>> lectureViewBookList(HashMap<String, String> params);
+    ArrayList<JSONObject> lectureViewBookList(LectureMstVO lectureMstVO);
 
-    void lectureBookDelete(HashMap<String, String> params);
+    void lectureBookDelete(LectureMstVO lectureMstVO);
 
-    void lecturemstUpdate(HashMap<String, String> params);
+    void lecturemstUpdate(LectureMstVO lectureMstVO);
 
-    void lectureBookInsert(HashMap<String, String> params);
+    void lectureBookInsert(LectureMstVO lectureMstVO);
 
-    void lectureDelete(HashMap<String, String> params);
+    void lectureDelete(LectureMstVO lectureMstVO);
 
-    void lectureBridgeDelete(HashMap<String, String> params);
+    void lectureBridgeDelete(LectureMstVO lectureMstVO);
 }

--- a/src/main/java/com/academy/mapper/MacAddressManagerMapper.java
+++ b/src/main/java/com/academy/mapper/MacAddressManagerMapper.java
@@ -1,25 +1,28 @@
 package com.academy.mapper;
 
-import java.util.HashMap;
-import java.util.List;
+import java.util.ArrayList;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.json.simple.JSONObject;
+
+import com.academy.lecture.service.MacAddressManagerVO;
 
 /**
  * MacAddressManager Mapper Interface
+ * ExamMapper 패턴 적용 - ArrayList<JSONObject> 및 VO 사용
  */
 @Mapper
 public interface MacAddressManagerMapper {
 
-    List<HashMap<String, String>> macaddressmanagerList(HashMap<String, String> params);
+	ArrayList<JSONObject> macaddressmanagerList(MacAddressManagerVO macAddressManagerVO);
 
-    List<HashMap<String, String>> devicelist(HashMap<String, String> params);
+	ArrayList<JSONObject> devicelist(MacAddressManagerVO macAddressManagerVO);
 
-    List<HashMap<String, String>> macaddressView(HashMap<String, String> params);
+	ArrayList<JSONObject> macaddressView(MacAddressManagerVO macAddressManagerVO);
 
-    int macaddressmanagerListCount(HashMap<String, String> params);
+	int macaddressmanagerListCount(MacAddressManagerVO macAddressManagerVO);
 
-    void macaddressmanagerUpdate(HashMap<String, String> params);
+	void macaddressmanagerUpdate(MacAddressManagerVO macAddressManagerVO);
 
-    void macaddressmanagerUpdate1(HashMap<String, String> params);
+	void macaddressmanagerUpdate1(MacAddressManagerVO macAddressManagerVO);
 }

--- a/src/main/java/com/academy/mapper/OpenLectureMapper.java
+++ b/src/main/java/com/academy/mapper/OpenLectureMapper.java
@@ -1,127 +1,130 @@
 package com.academy.mapper;
 
-import java.util.HashMap;
-import java.util.List;
+import java.util.ArrayList;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.json.simple.JSONObject;
+
+import com.academy.lecture.service.OpenLectureVO;
 
 /**
  * OpenLecture Mapper Interface
+ * ExamMapper 패턴 적용 - ArrayList<JSONObject> 및 VO 사용
  */
 @Mapper
 public interface OpenLectureMapper {
 
-    List<HashMap<String, String>> openlectureList(HashMap<String, String> params);
+	ArrayList<JSONObject> openlectureList(OpenLectureVO openLectureVO);
 
-    int openlectureListCount(HashMap<String, String> params);
+	int openlectureListCount(OpenLectureVO openLectureVO);
 
-    List<HashMap<String, String>> bookList(HashMap<String, String> params);
+	ArrayList<JSONObject> bookList(OpenLectureVO openLectureVO);
 
-    int bookListCount(HashMap<String, String> params);
+	int bookListCount(OpenLectureVO openLectureVO);
 
-    List<HashMap<String, String>> getBridgeLeccodeSeq(HashMap<String, String> params);
+	ArrayList<JSONObject> getBridgeLeccodeSeq(OpenLectureVO openLectureVO);
 
-    List<HashMap<String, String>> getJongLeccodeSeq(HashMap<String, String> params);
+	ArrayList<JSONObject> getJongLeccodeSeq(OpenLectureVO openLectureVO);
 
-    List<HashMap<String, String>> getopenLeccode(HashMap<String, String> params);
+	ArrayList<JSONObject> getopenLeccode(OpenLectureVO openLectureVO);
 
-    List<HashMap<String, String>> getBridgeLeccode(HashMap<String, String> params);
+	ArrayList<JSONObject> getBridgeLeccode(OpenLectureVO openLectureVO);
 
-    List<HashMap<String, String>> BridgeLeccode(HashMap<String, String> params);
+	ArrayList<JSONObject> BridgeLeccode(OpenLectureVO openLectureVO);
 
-    void openlectureInsert(HashMap<String, String> params);
+	void openlectureInsert(OpenLectureVO openLectureVO);
 
-    void openlectureBridgeInsert(HashMap<String, String> params);
+	void openlectureBridgeInsert(OpenLectureVO openLectureVO);
 
-    void openlectureBookInsert(HashMap<String, String> params);
+	void openlectureBookInsert(OpenLectureVO openLectureVO);
 
-    void openlectureBookInsert2(HashMap<String, String> params);
+	void openlectureBookInsert2(OpenLectureVO openLectureVO);
 
-    List<HashMap<String, String>> openlectureViewList(HashMap<String, String> params);
+	ArrayList<JSONObject> openlectureViewList(OpenLectureVO openLectureVO);
 
-    List<HashMap<String, String>> openlectureView(HashMap<String, String> params);
+	ArrayList<JSONObject> openlectureView(OpenLectureVO openLectureVO);
 
-    List<HashMap<String, String>> openlectureViewBookList(HashMap<String, String> params);
+	ArrayList<JSONObject> openlectureViewBookList(OpenLectureVO openLectureVO);
 
-    void openlectureBookDelete(HashMap<String, String> params);
+	void openlectureBookDelete(OpenLectureVO openLectureVO);
 
-    void openlectureUpdate(HashMap<String, String> params);
+	void openlectureUpdate(OpenLectureVO openLectureVO);
 
-    void Modify_Lecture_On_Off(HashMap<String, String> params);
+	void Modify_Lecture_On_Off(OpenLectureVO openLectureVO);
 
-    void openlectureIsUseUpdate(HashMap<String, String> params);
+	void openlectureIsUseUpdate(OpenLectureVO openLectureVO);
 
-    void openlectureDelete(HashMap<String, String> params);
+	void openlectureDelete(OpenLectureVO openLectureVO);
 
-    void openlectureBridgeDelete(HashMap<String, String> params);
+	void openlectureBridgeDelete(OpenLectureVO openLectureVO);
 
-    void lecMovUpdate(HashMap<String, String> params);
+	void lecMovUpdate(OpenLectureVO openLectureVO);
 
-    List<HashMap<String, String>> openlectureSeqList(HashMap<String, String> params);
+	ArrayList<JSONObject> openlectureSeqList(OpenLectureVO openLectureVO);
 
-    void openlectureSeqUpdate(HashMap<String, String> params);
+	void openlectureSeqUpdate(OpenLectureVO openLectureVO);
 
-    List<HashMap<String, String>> openlectureViewJongList(HashMap<String, String> params);
+	ArrayList<JSONObject> openlectureViewJongList(OpenLectureVO openLectureVO);
 
-    List<HashMap<String, String>> openlectureJongList(HashMap<String, String> params);
+	ArrayList<JSONObject> openlectureJongList(OpenLectureVO openLectureVO);
 
-    int openlectureJongListCount(HashMap<String, String> params);
+	int openlectureJongListCount(OpenLectureVO openLectureVO);
 
-    List<HashMap<String, String>> openlectureJongSubjectList(HashMap<String, String> params);
+	ArrayList<JSONObject> openlectureJongSubjectList(OpenLectureVO openLectureVO);
 
-    List<HashMap<String, String>> openlectureJongView(HashMap<String, String> params);
+	ArrayList<JSONObject> openlectureJongView(OpenLectureVO openLectureVO);
 
-    int openlectureJongSubjectListCount(HashMap<String, String> params);
+	int openlectureJongSubjectListCount(OpenLectureVO openLectureVO);
 
-    void openlectureLecJongInsert(HashMap<String, String> params);
+	void openlectureLecJongInsert(OpenLectureVO openLectureVO);
 
-    void openlectureChoiceJongNoInsert(HashMap<String, String> params);
+	void openlectureChoiceJongNoInsert(OpenLectureVO openLectureVO);
 
-    List<HashMap<String, String>> openlectureViewLeccodeList(HashMap<String, String> params);
+	ArrayList<JSONObject> openlectureViewLeccodeList(OpenLectureVO openLectureVO);
 
-    void openlectureLecJongDelete(HashMap<String, String> params);
+	void openlectureLecJongDelete(OpenLectureVO openLectureVO);
 
-    void openlectureChoiceJongNoDelete(HashMap<String, String> params);
+	void openlectureChoiceJongNoDelete(OpenLectureVO openLectureVO);
 
-    List<HashMap<String, String>> openlecturePayList(HashMap<String, String> params);
+	ArrayList<JSONObject> openlecturePayList(OpenLectureVO openLectureVO);
 
-    List<HashMap<String, String>> openlectureJongPayList(HashMap<String, String> params);
+	ArrayList<JSONObject> openlectureJongPayList(OpenLectureVO openLectureVO);
 
-    List<HashMap<String, String>> openlectureDataMemoViewList(HashMap<String, String> params);
+	ArrayList<JSONObject> openlectureDataMemoViewList(OpenLectureVO openLectureVO);
 
-    List<HashMap<String, String>> openlectureDataViewList(HashMap<String, String> params);
+	ArrayList<JSONObject> openlectureDataViewList(OpenLectureVO openLectureVO);
 
-    List<HashMap<String, String>> openlectureDataMovieViewList(HashMap<String, String> params);
+	ArrayList<JSONObject> openlectureDataMovieViewList(OpenLectureVO openLectureVO);
 
-    List<HashMap<String, String>> openlectureDataMovieList(HashMap<String, String> params);
+	ArrayList<JSONObject> openlectureDataMovieList(OpenLectureVO openLectureVO);
 
-    void openlectureMovieInsert(HashMap<String, String> params);
+	void openlectureMovieInsert(OpenLectureVO openLectureVO);
 
-    void openlectureMovieDelete(HashMap<String, String> params);
+	void openlectureMovieDelete(OpenLectureVO openLectureVO);
 
-    void openlectureMovieUpdate(HashMap<String, String> params);
+	void openlectureMovieUpdate(OpenLectureVO openLectureVO);
 
-    void openlectureMovieFileDelete(HashMap<String, String> params);
+	void openlectureMovieFileDelete(OpenLectureVO openLectureVO);
 
-    void openlectureMovieMemoInsert(HashMap<String, String> params);
+	void openlectureMovieMemoInsert(OpenLectureVO openLectureVO);
 
-    void openlectureMovieMemoUpdate(HashMap<String, String> params);
+	void openlectureMovieMemoUpdate(OpenLectureVO openLectureVO);
 
-    void openlectureMovieMemoDelete(HashMap<String, String> params);
+	void openlectureMovieMemoDelete(OpenLectureVO openLectureVO);
 
-    int openlectureDeleteCheck(HashMap<String, String> params);
+	int openlectureDeleteCheck(OpenLectureVO openLectureVO);
 
-    List<HashMap<String, String>> playinfo(HashMap<String, String> params);
+	ArrayList<JSONObject> playinfo(OpenLectureVO openLectureVO);
 
-    List<HashMap<String, String>> getCbMovie4_free_admin(HashMap<String, String> params);
+	ArrayList<JSONObject> getCbMovie4_free_admin(OpenLectureVO openLectureVO);
 
-    int getCbMovie4_free_admin_count(HashMap<String, String> params);
+	int getCbMovie4_free_admin_count(OpenLectureVO openLectureVO);
 
-    HashMap<String, String> openlectureOnDetailS(HashMap<String, String> params);
+	JSONObject openlectureOnDetailS(OpenLectureVO openLectureVO);
 
-    void insertPmpDownLog(HashMap<String, String> params);
+	void insertPmpDownLog(OpenLectureVO openLectureVO);
 
-    List<HashMap<String, String>> openlectureWMV(HashMap<String, String> params);
+	ArrayList<JSONObject> openlectureWMV(OpenLectureVO openLectureVO);
 
-    List<HashMap<String, String>> openlectureDown_Count(HashMap<String, String> params);
+	ArrayList<JSONObject> openlectureDown_Count(OpenLectureVO openLectureVO);
 }

--- a/src/main/java/com/academy/mapper/ProductEventMapper.java
+++ b/src/main/java/com/academy/mapper/ProductEventMapper.java
@@ -1,45 +1,42 @@
 package com.academy.mapper;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.ArrayList;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.json.simple.JSONObject;
+
+import com.academy.lecture.service.ProductEventVO;
 
 /**
  * ProductEvent Mapper Interface
+ * ExamMapper 패턴 적용 - ArrayList<JSONObject> 및 VO 사용
  */
 @Mapper
 public interface ProductEventMapper {
 
-    List<HashMap<String, String>> list(HashMap<String, String> params);
+	ArrayList<JSONObject> list(ProductEventVO productEventVO);
 
-    int listCount(HashMap<String, String> params);
+	int listCount(ProductEventVO productEventVO);
 
-    HashMap<String, String> getOne(HashMap<String, String> params);
+	JSONObject getOne(ProductEventVO productEventVO);
 
-    List<HashMap<String, String>> list_prd(HashMap<String, String> params);
+	ArrayList<JSONObject> list_prd(ProductEventVO productEventVO);
 
-    void insert(HashMap<String, String> params);
+	void insert(ProductEventVO productEventVO);
 
-    void update(HashMap<String, String> params);
+	void update(ProductEventVO productEventVO);
 
-    void lec_insert(HashMap<String, String> params);
+	void lec_insert(ProductEventVO productEventVO);
 
-    void lec_delete(HashMap<String, String> params);
+	void lec_delete(ProductEventVO productEventVO);
 
-    @SuppressWarnings({ "rawtypes" })
-    List getCaCatCdList(Map keyName);
+	ArrayList<JSONObject> getCaCatCdList(ProductEventVO productEventVO);
 
-    @SuppressWarnings({ "rawtypes" })
-    List getVwMenuMstTree_lec(Map keyName);
+	ArrayList<JSONObject> getVwMenuMstTree_lec(ProductEventVO productEventVO);
 
-    @SuppressWarnings({ "rawtypes" })
-    List getCaSubjectCdList(Map keyName);
+	ArrayList<JSONObject> getCaSubjectCdList(ProductEventVO productEventVO);
 
-    @SuppressWarnings({ "rawtypes" })
-    List getCbLecMstFreeOrderList(Map keyName);
+	ArrayList<JSONObject> getCbLecMstFreeOrderList(ProductEventVO productEventVO);
 
-    @SuppressWarnings({ "rawtypes" })
-    int getCbLecMstListFreeOrderCount(Map keyName);
+	int getCbLecMstListFreeOrderCount(ProductEventVO productEventVO);
 }

--- a/src/main/java/com/academy/mapper/SeriesMapper.java
+++ b/src/main/java/com/academy/mapper/SeriesMapper.java
@@ -1,33 +1,36 @@
 package com.academy.mapper;
 
-import java.util.HashMap;
-import java.util.List;
+import java.util.ArrayList;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.json.simple.JSONObject;
+
+import com.academy.lecture.service.SeriesVO;
 
 /**
  * Series Mapper Interface
+ * ExamMapper 패턴 적용 - ArrayList<JSONObject> 및 VO 사용
  */
 @Mapper
 public interface SeriesMapper {
 
-    List<HashMap<String, String>> seriesList(Object obj);
+    ArrayList<JSONObject> seriesList(SeriesVO seriesVO);
 
-    int seriesListCount(Object obj);
+    int seriesListCount(SeriesVO seriesVO);
 
-    void seriesInsert(Object obj);
+    void seriesInsert(SeriesVO seriesVO);
 
-    List<HashMap<String, String>> seriesView(Object obj);
+    ArrayList<JSONObject> seriesView(SeriesVO seriesVO);
 
-    void seriesUpdate(Object obj);
+    void seriesUpdate(SeriesVO seriesVO);
 
-    void seriesDelete(Object obj);
+    void seriesDelete(SeriesVO seriesVO);
 
-    int seriesCheck(Object obj);
+    int seriesCheck(SeriesVO seriesVO);
 
-    void catSeriesInsert(Object obj);
+    void catSeriesInsert(SeriesVO seriesVO);
 
-    void catSeriesDeleteWthCatCd(Object obj);
+    void catSeriesDeleteWthCatCd(SeriesVO seriesVO);
 
-    void catSeriesDeleteWthSrsCd(Object obj);
+    void catSeriesDeleteWthSrsCd(SeriesVO seriesVO);
 }

--- a/src/main/java/com/academy/mapper/SubjectMapper.java
+++ b/src/main/java/com/academy/mapper/SubjectMapper.java
@@ -1,53 +1,56 @@
 package com.academy.mapper;
 
-import java.util.HashMap;
-import java.util.List;
+import java.util.ArrayList;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.json.simple.JSONObject;
+
+import com.academy.lecture.service.SubjectVO;
 
 /**
  * Subject Mapper Interface
+ * ExamMapper 패턴 적용 - ArrayList<JSONObject> 및 VO 사용
  */
 @Mapper
 public interface SubjectMapper {
 
-    List<HashMap<String, String>> subjectList(HashMap<String, String> params);
+    ArrayList<JSONObject> subjectList(SubjectVO subjectVO);
 
-    int subjectListCount(HashMap<String, String> params);
+    int subjectListCount(SubjectVO subjectVO);
 
-    String subjectGetCode(HashMap<String, String> params);
+    String subjectGetCode(SubjectVO subjectVO);
 
-    void subjectInsert(HashMap<String, String> params);
+    void subjectInsert(SubjectVO subjectVO);
 
-    List<HashMap<String, String>> subjectView(HashMap<String, String> params);
+    ArrayList<JSONObject> subjectView(SubjectVO subjectVO);
 
-    void subjectUpdate(HashMap<String, String> params);
+    void subjectUpdate(SubjectVO subjectVO);
 
-    void subjectDelete(HashMap<String, String> params);
+    void subjectDelete(SubjectVO subjectVO);
 
-    int subjectCheck(HashMap<String, String> params);
+    int subjectCheck(SubjectVO subjectVO);
 
-    void subjectCategoryInsert(HashMap<String, String> params);
+    void subjectCategoryInsert(SubjectVO subjectVO);
 
-    void subjectCategoryDelete(HashMap<String, String> params);
+    void subjectCategoryDelete(SubjectVO subjectVO);
 
-    void subjectCategoryDeleteByCat(HashMap<String, String> params);
+    void subjectCategoryDeleteByCat(SubjectVO subjectVO);
 
-    void subjectCategoryOrderInsert(HashMap<String, String> params);
+    void subjectCategoryOrderInsert(SubjectVO subjectVO);
 
-    int chkSubjectCategoryOrderCnt(HashMap<String, String> params);
+    int chkSubjectCategoryOrderCnt(SubjectVO subjectVO);
 
-    int chkSubjectCategoryCnt(HashMap<String, String> params);
+    int chkSubjectCategoryCnt(SubjectVO subjectVO);
 
-    void subjectCategoryOrderDeleteByOnoff(HashMap<String, String> params);
+    void subjectCategoryOrderDeleteByOnoff(SubjectVO subjectVO);
 
-    String getSubjectCategoryOrderIdx(HashMap<String, String> params);
+    String getSubjectCategoryOrderIdx(SubjectVO subjectVO);
 
-    void subjectCategoryOrderDelete(HashMap<String, String> params);
+    void subjectCategoryOrderDelete(SubjectVO subjectVO);
 
-    List<HashMap<String, String>> subjectCategoryView(HashMap<String, String> params);
+    ArrayList<JSONObject> subjectCategoryView(SubjectVO subjectVO);
 
-    List<HashMap<String, String>> findSubjectCategoryList(HashMap<String, String> params);
+    ArrayList<JSONObject> findSubjectCategoryList(SubjectVO subjectVO);
 
-    void main_category_subject_order_Insert(HashMap<String, String> params);
+    void main_category_subject_order_Insert(SubjectVO subjectVO);
 }

--- a/src/main/java/com/academy/mapper/TeacherMapper.java
+++ b/src/main/java/com/academy/mapper/TeacherMapper.java
@@ -1,85 +1,88 @@
 package com.academy.mapper;
 
-import java.util.HashMap;
-import java.util.List;
+import java.util.ArrayList;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.json.simple.JSONObject;
+
+import com.academy.lecture.service.TeacherVO;
 
 /**
  * Teacher Mapper Interface
+ * ExamMapper 패턴 적용 - ArrayList<JSONObject> 및 VO 사용
  */
 @Mapper
 public interface TeacherMapper {
 
-    List<HashMap<String, String>> getKindList(HashMap<String, String> params);
+    ArrayList<JSONObject> getKindList(TeacherVO teacherVO);
 
-    List<HashMap<String, String>> getSubjectList(HashMap<String, String> params);
+    ArrayList<JSONObject> getSubjectList(TeacherVO teacherVO);
 
-    List<HashMap<String, String>> teacherList(HashMap<String, String> params);
+    ArrayList<JSONObject> teacherList(TeacherVO teacherVO);
 
-    int teacherListCount(HashMap<String, String> params);
+    int teacherListCount(TeacherVO teacherVO);
 
-    List<HashMap<String, String>> teacherAllList(HashMap<String, String> params);
+    ArrayList<JSONObject> teacherAllList(TeacherVO teacherVO);
 
-    int teacherAllListCount(HashMap<String, String> params);
+    int teacherAllListCount(TeacherVO teacherVO);
 
-    int teacherIdCheck(HashMap<String, String> params);
+    int teacherIdCheck(TeacherVO teacherVO);
 
-    void teacherInsert(Object obj);
+    void teacherInsert(TeacherVO teacherVO);
 
-    List<HashMap<String, String>> teacherView(HashMap<String, String> params);
+    ArrayList<JSONObject> teacherView(TeacherVO teacherVO);
 
-    void teacherUpdate(Object obj);
+    void teacherUpdate(TeacherVO teacherVO);
 
-    void teacherCategoryInsert(HashMap<String, String> params);
+    void teacherCategoryInsert(TeacherVO teacherVO);
 
-    void teacherSubjectInsert(HashMap<String, String> params);
+    void teacherSubjectInsert(TeacherVO teacherVO);
 
-    void teacherSubjectUpdate(Object obj);
+    void teacherSubjectUpdate(TeacherVO teacherVO);
 
-    int teacherSubjectCount(Object obj);
+    int teacherSubjectCount(TeacherVO teacherVO);
 
-    void teacherIsUseUpdate(Object obj);
+    void teacherIsUseUpdate(TeacherVO teacherVO);
 
-    void teacherDelete(HashMap<String, String> params);
+    void teacherDelete(TeacherVO teacherVO);
 
-    void teacherCategoryDelete(HashMap<String, String> params);
+    void teacherCategoryDelete(TeacherVO teacherVO);
 
-    void teacherSubjectDelete(HashMap<String, String> params);
+    void teacherSubjectDelete(TeacherVO teacherVO);
 
-    void teacherSeqUpdate(Object obj);
+    void teacherSeqUpdate(TeacherVO teacherVO);
 
-    List<HashMap<String, String>> teacherBookLog(HashMap<String, String> params);
+    ArrayList<JSONObject> teacherBookLog(TeacherVO teacherVO);
 
-    void teacherMain_Category_Insert(HashMap<String, String> params);
+    void teacherMain_Category_Insert(TeacherVO teacherVO);
 
-    void teacherMain_Category_Delete(HashMap<String, String> params);
+    void teacherMain_Category_Delete(TeacherVO teacherVO);
 
-    List<HashMap<String, String>> teacherMainList(HashMap<String, String> params);
+    ArrayList<JSONObject> teacherMainList(TeacherVO teacherVO);
 
-    int teacherMainListCount(HashMap<String, String> params);
+    int teacherMainListCount(TeacherVO teacherVO);
 
-    List<HashMap<String, String>> findTeacherList(HashMap<String, String> params);
+    ArrayList<JSONObject> findTeacherList(TeacherVO teacherVO);
 
-    int teacherMain_Category_Subject(HashMap<String, String> params);
+    int teacherMain_Category_Subject(TeacherVO teacherVO);
 
-    int teacherIntro_Category_Subject(HashMap<String, String> params);
+    int teacherIntro_Category_Subject(TeacherVO teacherVO);
 
-    int teacherIntro_F_Category_Subject(HashMap<String, String> params);
+    int teacherIntro_F_Category_Subject(TeacherVO teacherVO);
 
-    List<HashMap<String, String>> teacherIntroList(HashMap<String, String> params);
+    ArrayList<JSONObject> teacherIntroList(TeacherVO teacherVO);
 
-    int teacherIntroListCount(HashMap<String, String> params);
+    int teacherIntroListCount(TeacherVO teacherVO);
 
-    void teacherIntro_Category_Insert(HashMap<String, String> params);
+    void teacherIntro_Category_Insert(TeacherVO teacherVO);
 
-    void teacherIntro_F_Category_Insert(HashMap<String, String> params);
+    void teacherIntro_F_Category_Insert(TeacherVO teacherVO);
 
-    void teacherIntro_Category_Delete(HashMap<String, String> params);
+    void teacherIntro_Category_Delete(TeacherVO teacherVO);
 
-    void teacherIntro_F_Category_Delete(HashMap<String, String> params);
+    void teacherIntro_F_Category_Delete(TeacherVO teacherVO);
 
-    List<HashMap<String, String>> teacherIntro_offList(HashMap<String, String> params);
+    ArrayList<JSONObject> teacherIntro_offList(TeacherVO teacherVO);
 
-    int teacherIntro_offListCount(HashMap<String, String> params);
+    int teacherIntro_offListCount(TeacherVO teacherVO);
 }

--- a/src/main/java/com/academy/productorder/service/ProductOrderService.java
+++ b/src/main/java/com/academy/productorder/service/ProductOrderService.java
@@ -4,590 +4,794 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public interface ProductOrderService {
-	
-	/* last modified 2014-08-20 */
+import org.springframework.stereotype.Service;
+
+import com.academy.mapper.ProductOrderMapper;
+
+/**
+ * ProductOrder Service
+ * LoginService 패턴 적용 - ServiceImpl 없이 @Service 클래스로 직접 구현
+ * last modified 2014-08-20
+ */
+@Service
+public class ProductOrderService {
+
+	private ProductOrderMapper productOrderMapper;
+
+	public ProductOrderService(ProductOrderMapper productOrderMapper) {
+		this.productOrderMapper = productOrderMapper;
+	}
 
 	@SuppressWarnings({ "rawtypes" })
-	List getOrderStatuscodeList(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	List getPaymentList(Map keyName);
-	
-	// 전체상품주문관리 리스트(0원)
-	@SuppressWarnings({ "rawtypes" })
-	List getOrderListDB_0(Map keyName);
-	
-	// 전체상품주문관리 총 건수(0원)
-	@SuppressWarnings({ "rawtypes" })
-	int getOrderListCount_0(Map keyName);
-	
-	// 전체상품주문관리 리스트(0원)
-	@SuppressWarnings({ "rawtypes" })
-	List getOrderListDB_freelec(Map keyName);
-	
-	// 전체상품주문관리 총 건수(0원)
-	@SuppressWarnings({ "rawtypes" })
-	int getOrderListCount_freelec(Map keyName);
-	
-	// 전체상품주문관리 리스트
-	@SuppressWarnings({ "rawtypes" })
-	List getOrderListDB(Map keyName);
-	
-	// 전체상품주문관리 총 건수
-	@SuppressWarnings({ "rawtypes" })
-	int getOrderListCount(Map keyName);
-	
-	//2번째 리스트
-	@SuppressWarnings({ "rawtypes" })
-	List getTblOrderMgntListDB(Map keyName);
-		
-	// 전체상품주문관리 엑셀 리스트
-	@SuppressWarnings({ "rawtypes" })
-	List<HashMap<String, String>> getOrderExcelListDB(HashMap<String, String> params);
-		
-	// 카드변경
-	@SuppressWarnings({ "rawtypes" })
-	int setPayKindUpdate(Map keyName);
-	
-	
-	
-	
-	
-	// 입금상태저장
-	@SuppressWarnings({ "rawtypes" })
-	int updateDepositStatus1(Map keyName);
-	
-	// 입금상태저장
-	@SuppressWarnings({ "rawtypes" })
-	int getDepositStatusCount(Map keyName);
-	
-	// 입금상태저장
-	@SuppressWarnings({ "rawtypes" })
-	int updateDepositStatus2(Map keyName);
-	
-	// 입금상태저장
-	@SuppressWarnings({ "rawtypes" })
-	int updateDepositStatus3(Map keyName);
-	
-	// 입금상태저장
-	@SuppressWarnings({ "rawtypes" })
-	int updateDepositStatus4(Map keyName);
-	
-	// 입금상태저장
-	@SuppressWarnings({ "rawtypes" })
-	int updateDepositStatus5(Map keyName);
-	
-	//도서 재고 더하기
-	@SuppressWarnings({ "rawtypes" })
-	int updateBookStockPlus(Map keyName);
-	
-	
-	
-	
-	
-	
-	
-	//상품명 팝업
-	@SuppressWarnings({ "rawtypes" })
-	List getPmpdownloadListPop(Map keyName);
-	@SuppressWarnings({ "rawtypes" })
-	List getMobiledownloadListPop(Map keyName);
-		
-	//상품명 팝업
-	@SuppressWarnings({ "rawtypes" })
-	List getTblOrderList(Map keyName);
-	
-	//상품명 팝업 리스트
-	@SuppressWarnings({ "rawtypes" })
-	List getOrderListPopDB(Map keyName);
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	//구입금액
-	@SuppressWarnings({ "rawtypes" })
-	List getCourse_type_code(Map keyName);
-	
-	//구입금액
-	@SuppressWarnings({ "rawtypes" })
-	List getPlayyn(Map keyName);
-	
-	//구입금액
-	@SuppressWarnings({ "rawtypes" })
-	List getPoint(Map keyName);
-	
-	//구입금액
-	@SuppressWarnings({ "rawtypes" })
-	List getTblOrderMgntNoPopViewList(Map keyName);
-
-	//구입금액
-	@SuppressWarnings({ "rawtypes" })
-	int getTblOrderMgntNoPopViewCount(Map keyName);
-	
-	//구입금액
-	@SuppressWarnings({ "rawtypes" })
-	int getPrice_Sum(Map keyName);
-	
-	//구입금액
-	@SuppressWarnings({ "rawtypes" })
-	int getOldRefundViewCount(Map keyName);
-	
-	//구입금액
-	@SuppressWarnings({ "rawtypes" })
-	List getRefund_Point(Map keyName);
-	
-	//구입금액
-	@SuppressWarnings({ "rawtypes" })
-	List getOldRefundView(Map keyName);
-	
-	
-	
-	//택배비
-	@SuppressWarnings({ "rawtypes" })
-	List getTblDeliver_refund_list(Map keyName);
-		
-		
-		
-	//전체상품주문관리 주문번호 상세
-	@SuppressWarnings({ "rawtypes" })
-	List getTblApprovalsViewList(Map keyName);
-	
-	//전체상품주문관리 주문번호 상세
-	@SuppressWarnings({ "rawtypes" })
-	int getTblDeliversViewListCount(Map keyName);
-	
-	//전체상품주문관리 주문번호 상세
-	@SuppressWarnings({ "rawtypes" })
-	List getTblDeliversViewList(Map keyName);
-	
-	//전체상품주문관리 주문번호 상세
-	@SuppressWarnings({ "rawtypes" })
-	List getTblOrdersViewList(Map keyName);
-	
-	//전체상품주문관리 주문번호 상세
-	@SuppressWarnings({ "rawtypes" })
-	List getLecMstViewList(Map keyName);
-		
-	@SuppressWarnings({ "rawtypes" })
-	int updateDelivers(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int updateApprovals(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int updateDeliversWmv(Map keyName);
-		
-	
-	@SuppressWarnings({ "rawtypes" })
-	int updateMoney1(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int updateStudy_Per(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int getMoneySum(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int updateMoney2(Map keyName);
-		
-		
-	@SuppressWarnings({ "rawtypes" })
-	int refund_money_delete(Map keyName);	
-		
-	
-	
-	@SuppressWarnings({ "rawtypes" })
-	List getMylecture(Map keyName);
-		
-	@SuppressWarnings({ "rawtypes" })
-	int updateMylecture1(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int updateMylecture2(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int updateMylecture3(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int updateMylecture4(Map keyName);
-		
-	@SuppressWarnings({ "rawtypes" })	
-	int updateEndDateMyLecture(Map keyName); 
-	
-	@SuppressWarnings({ "rawtypes" })
-	int getMylectureCount(Map keyName);	
-		
-	@SuppressWarnings({ "rawtypes" })
-	int updateMylecture5(Map keyName);	
-		
-	@SuppressWarnings({ "rawtypes" })
-	int insertMylecture6(Map keyName);	
-	
-	
-	
-	
-	@SuppressWarnings({ "rawtypes" })
-	int insertOrderMgntNo1(Map keyName);
-	@SuppressWarnings({ "rawtypes" })
-	int updateOrderMgntNo2(Map keyName);
-	@SuppressWarnings({ "rawtypes" })
-	int updateOrderMgntNo3(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int insertOrderMgntNo2(Map keyName);
-		
-	@SuppressWarnings({ "rawtypes" })
-	int updateApprovals2(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int insertMileageHistory(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int insertMileageHistory3(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int updateMaMember(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int updateMylecture_1(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int updateMylecture_2(Map keyName);
-	
-	
-	
-	
-	
-	@SuppressWarnings({ "rawtypes" })
-	int updateOrderMgntNo1(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int updateMileageHistory(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int updateMaMember2(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int updateApprovals3(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int deleteOrderMgntNo(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int updateMaMember3(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int updateApprovals4(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int insertMileageHistory2(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int updateMylecture_3(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int updateApprovals5(Map keyName);
-	
-	
-	
-	
-	
-	//SMS보내기
-	@SuppressWarnings({ "rawtypes" })
-	int insertSendMsgMultiSendUser(Map keyName);
-	
-	
-	
-	
-	
-	// 사용자 팝업
-	@SuppressWarnings({ "rawtypes" })
-	List getTmMember_View(Map keyName);
-	
-	// 사용자 팝업
-	@SuppressWarnings({ "rawtypes" })
-	List getCsccode(Map keyName);
-	
-	// 사용자 팝업
-	@SuppressWarnings({ "rawtypes" })
-	List Cs_board_list(Map keyName);
-	
-	// 사용자 팝업
-	@SuppressWarnings({ "rawtypes" })
-	int getCsBoardListCount(Map keyName);
-	
-	// 사용자 팝업
-	@SuppressWarnings({ "rawtypes" })
-	List getTm_mycoupon_list_admin(Map keyName);
-	
-	// 사용자 팝업
-	@SuppressWarnings({ "rawtypes" })
-	int getTm_mycoupon_listCount_admin(Map keyName);
-	
-	// 사용자 팝업 - 동영상 강의 리스트
-	@SuppressWarnings({ "rawtypes" })
-	List Tm_Class_List(Map keyName);
-	
-	// 사용자 팝업 - 학원강의 리스트
-	@SuppressWarnings({ "rawtypes" })
-	List Off_Class_List(Map keyName);
-	
-	// 사용자 팝업
-	@SuppressWarnings({ "rawtypes" })
-	int getTmClassListCount(Map keyName);
-	
-	// 사용자 팝업
-	@SuppressWarnings({ "rawtypes" })
-	List getMemoList(Map keyName);
-	
-	// 사용자 팝업
-	@SuppressWarnings({ "rawtypes" })
-	int getMemoListCount(Map keyName);
-	
-	
-	@SuppressWarnings({ "rawtypes" })
-	int insertBoardCs(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int updateMemo(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int getSelectBefore_Point(Map keyName);
-	
-	// 사용자 팝업
-	@SuppressWarnings({ "rawtypes" })
-	List getTmCoupon(Map keyName);
-	
-	
-	// 사용자 팝업
-	@SuppressWarnings({ "rawtypes" })
-	List getTmCouponList(Map keyName);
-	// 사용자 팝업
-	@SuppressWarnings({ "rawtypes" })
-	List getTmMoCouponList(Map keyName);
-	
-	// 사용자 팝업
-	@SuppressWarnings({ "rawtypes" })
-	int getTmCouponCount(Map keyName);
-	// 사용자 팝업
-	@SuppressWarnings({ "rawtypes" })
-	int getTmMoCouponCount(Map keyName);
-	
-	// 사용자 팝업
-	@SuppressWarnings({ "rawtypes" })
-	int getCouponCount(Map keyName);
+	public List getOrderStatuscodeList(Map keyName) {
+		return productOrderMapper.getOrderStatuscodeList(keyName);
+	}
 
 	@SuppressWarnings({ "rawtypes" })
-	int insertTmCoupon(Map keyName);
-		
-	@SuppressWarnings({ "rawtypes" })
-	int insertMyCoupon(Map keyName);
-		
-	
-	
-	
-	
-	// off 전체상품주문관리 리스트
-	@SuppressWarnings({ "rawtypes" })
-	List getOffOrderListDB(Map keyName);
-	
-	// off 전체상품주문관리 총 건수
-	@SuppressWarnings({ "rawtypes" })
-	int getOffOrderListCount(Map keyName);
-	
-	//off 2번째 리스트
-	@SuppressWarnings({ "rawtypes" })
-	List getOffTblOrderMgntListDB(Map keyName);
-		
-	// off 전체상품주문관리 엑셀 리스트
-	@SuppressWarnings({ "rawtypes" })
-	List<HashMap<String, String>> getOffOrderExcelListDB(HashMap<String, String> params);
-	
-	//id체크
-	@SuppressWarnings({ "rawtypes" })
-	List getIdChk(Map keyName);
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	// 품목변경 팝업 카테고리 셀렉트박스 리스트
-	@SuppressWarnings({ "rawtypes" })
-	List getCaCatCdList(Map keyName);
-	
-	// 품목변경 팝업 학습형태 셀렉트박스 리스트
-	@SuppressWarnings({ "rawtypes" })
-	List getVwMenuMstTree_lec(Map keyName);
-	
-	// 품목변경 팝업 과목 셀렉트박스 리스트
-	@SuppressWarnings({ "rawtypes" })
-	List getCaSubjectCdList(Map keyName);
-	
-	// 품목변경 팝업  리스트
-	@SuppressWarnings({ "rawtypes" })
-	List getCbLecMstFreeOrderList(Map keyName);
-		
-	// 품목변경 팝업  카운트
-	@SuppressWarnings({ "rawtypes" })
-	int getCbLecMstListFreeOrderCount(Map keyName);
-	
-	
-	@SuppressWarnings({ "rawtypes" })
-	List getChangePrice(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	List getUCount(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int insertCart(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	List getSubCode2(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int deleteCart(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int deleteAllCart(Map keyName);
-	
-	
-	
-	
-	
-	@SuppressWarnings({ "rawtypes" })
-	List getMCount(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int insertOffOrders(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int insertOffApprovals(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int insertOffOrderMgntNo(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int insertOffMylecture(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int modifyOffMylecture(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int insertOffMylecture_N(Map keyName);
-	
-	
-	@SuppressWarnings({ "rawtypes" })
-	List getUpdateDetail(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	List getSubCodeUp(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	List getSubList(Map keyName);
-	
-	
-	@SuppressWarnings({ "rawtypes" })
-	int updateOffOrders(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int Coupon_Del(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int updateOffApprovals(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int updateOffMgntNo(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int updateOffMgntNo_N(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int deleteOffOrderMgntNo(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int deleteOffMylecture(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int deleteOffOrders(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int deleteOffApprovals(Map keyName);
-	
-	
-	
-	@SuppressWarnings({ "rawtypes" })
-	List getPrintPop(Map keyName);
-	
-	
-	@SuppressWarnings({ "rawtypes" })
-	int updatePrintOffOrders1(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int updatePrintOffOrders2(Map keyName);
-	
-	
-	@SuppressWarnings({ "rawtypes" })
-	int updateOffRefund(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int insertRefundOffOrderMgntNo(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int updateOffMylecture(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int updateOffMylectureRefund(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int insertOffRefund(Map keyName);
-	
-	
-	
-	@SuppressWarnings({ "rawtypes" })
-	int deleteOffCancelOrderMgntNo(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int deleteOffCancelRefund(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int updateOffCancelMylecture(Map keyName);
-	
-	@SuppressWarnings({ "rawtypes" })
-	int Delete_Year_Package_Point(Map keyName);
+	public List getPaymentList(Map keyName) {
+		return productOrderMapper.getPaymentList(keyName);
+	}
 
-	List<HashMap<String, String>> getTmPointHistory(HashMap<String, String> params);
-
-	void insertTmBoard(Map<String, Object> searchMap);
-
-	List<HashMap<String, String>> getTmBoardList(Map<String, Object> searchMap);
-
-	List<HashMap<String, String>> getVOCCODEList(HashMap<String, String> params);
-
-	List<HashMap<String, String>> getDUTYCODEList(HashMap<String, String> params);
-
-	List<HashMap<String, String>> getOffApprovalsCount(Map<String, String> searchMap);
-	
-	List<HashMap<String, String>> getCcode(HashMap<String, String> params);
-
-	// 내 강의실 누락 강의 등록 2016-01-18	
-	void insertMyLecture(Map<String, String> params);
-	void insertMyLectureN(Map<String, String> params);
-	
 	@SuppressWarnings({ "rawtypes" })
-	int getPlusPoint(Map keyName);
-	
-	void BookPointDel(Map<String, Object> params);
-	void BookPointIns(Map<String, Object> params);
-	
-	void insertOffOrderLog(Map<String, Object> params);
+	public List getOrderListDB_0(Map keyName) {
+		return productOrderMapper.getOrderListDB_0(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int getOrderListCount_0(Map keyName) {
+		return productOrderMapper.getOrderListCount_0(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getOrderListDB_freelec(Map keyName) {
+		return productOrderMapper.getOrderListDB_freelec(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int getOrderListCount_freelec(Map keyName) {
+		return productOrderMapper.getOrderListCount_freelec(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getOrderListDB(Map keyName) {
+		return productOrderMapper.getOrderListDB(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int getOrderListCount(Map keyName) {
+		return productOrderMapper.getOrderListCount(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getTblOrderMgntListDB(Map keyName) {
+		return productOrderMapper.getTblOrderMgntListDB(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List<HashMap<String, String>> getOrderExcelListDB(HashMap<String, String> params) {
+		return productOrderMapper.getOrderExcelListDB(params);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int setPayKindUpdate(Map keyName) {
+		return productOrderMapper.setPayKindUpdate(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateDepositStatus1(Map keyName) {
+		return productOrderMapper.updateDepositStatus1(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int getDepositStatusCount(Map keyName) {
+		return productOrderMapper.getDepositStatusCount(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateDepositStatus2(Map keyName) {
+		return productOrderMapper.updateDepositStatus2(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateDepositStatus3(Map keyName) {
+		return productOrderMapper.updateDepositStatus3(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateDepositStatus4(Map keyName) {
+		return productOrderMapper.updateDepositStatus4(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateDepositStatus5(Map keyName) {
+		return productOrderMapper.updateDepositStatus5(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateBookStockPlus(Map keyName) {
+		return productOrderMapper.updateBookStockPlus(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getPmpdownloadListPop(Map keyName) {
+		return productOrderMapper.getPmpdownloadListPop(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getMobiledownloadListPop(Map keyName) {
+		return productOrderMapper.getMobiledownloadListPop(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getTblOrderList(Map keyName) {
+		return productOrderMapper.getTblOrderList(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getOrderListPopDB(Map keyName) {
+		return productOrderMapper.getOrderListPopDB(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getCourse_type_code(Map keyName) {
+		return productOrderMapper.getCourse_type_code(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getPlayyn(Map keyName) {
+		return productOrderMapper.getPlayyn(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getPoint(Map keyName) {
+		return productOrderMapper.getPoint(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getTblOrderMgntNoPopViewList(Map keyName) {
+		return productOrderMapper.getTblOrderMgntNoPopViewList(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int getTblOrderMgntNoPopViewCount(Map keyName) {
+		return productOrderMapper.getTblOrderMgntNoPopViewCount(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int getPrice_Sum(Map keyName) {
+		return productOrderMapper.getPrice_Sum(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int getOldRefundViewCount(Map keyName) {
+		return productOrderMapper.getOldRefundViewCount(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getRefund_Point(Map keyName) {
+		return productOrderMapper.getRefund_Point(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getOldRefundView(Map keyName) {
+		return productOrderMapper.getOldRefundView(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getTblDeliver_refund_list(Map keyName) {
+		return productOrderMapper.getTblDeliver_refund_list(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getTblApprovalsViewList(Map keyName) {
+		return productOrderMapper.getTblApprovalsViewList(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int getTblDeliversViewListCount(Map keyName) {
+		return productOrderMapper.getTblDeliversViewListCount(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getTblDeliversViewList(Map keyName) {
+		return productOrderMapper.getTblDeliversViewList(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getTblOrdersViewList(Map keyName) {
+		return productOrderMapper.getTblOrdersViewList(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getLecMstViewList(Map keyName) {
+		return productOrderMapper.getLecMstViewList(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateDelivers(Map keyName) {
+		return productOrderMapper.updateDelivers(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateApprovals(Map keyName) {
+		return productOrderMapper.updateApprovals(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateDeliversWmv(Map keyName) {
+		return productOrderMapper.updateDeliversWmv(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateMoney1(Map keyName) {
+		return productOrderMapper.updateMoney1(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateStudy_Per(Map keyName) {
+		return productOrderMapper.updateStudy_Per(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int getMoneySum(Map keyName) {
+		return productOrderMapper.getMoneySum(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateMoney2(Map keyName) {
+		return productOrderMapper.updateMoney2(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int refund_money_delete(Map keyName) {
+		return productOrderMapper.refund_money_delete(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getMylecture(Map keyName) {
+		return productOrderMapper.getMylecture(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateMylecture1(Map keyName) {
+		return productOrderMapper.updateMylecture1(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateMylecture2(Map keyName) {
+		return productOrderMapper.updateMylecture2(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateMylecture3(Map keyName) {
+		return productOrderMapper.updateMylecture3(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateMylecture4(Map keyName) {
+		return productOrderMapper.updateMylecture4(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateEndDateMyLecture(Map keyName) {
+		return productOrderMapper.updateEndDateMyLecture(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int getMylectureCount(Map keyName) {
+		return productOrderMapper.getMylectureCount(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateMylecture5(Map keyName) {
+		return productOrderMapper.updateMylecture5(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int insertMylecture6(Map keyName) {
+		return productOrderMapper.insertMylecture6(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int insertOrderMgntNo1(Map keyName) {
+		return productOrderMapper.insertOrderMgntNo1(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateOrderMgntNo2(Map keyName) {
+		return productOrderMapper.updateOrderMgntNo2(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateOrderMgntNo3(Map keyName) {
+		return productOrderMapper.updateOrderMgntNo3(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int insertOrderMgntNo2(Map keyName) {
+		return productOrderMapper.insertOrderMgntNo2(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateApprovals2(Map keyName) {
+		return productOrderMapper.updateApprovals2(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int insertMileageHistory(Map keyName) {
+		return productOrderMapper.insertMileageHistory(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int insertMileageHistory3(Map keyName) {
+		return productOrderMapper.insertMileageHistory3(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateMaMember(Map keyName) {
+		return productOrderMapper.updateMaMember(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateMylecture_1(Map keyName) {
+		return productOrderMapper.updateMylecture_1(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateMylecture_2(Map keyName) {
+		return productOrderMapper.updateMylecture_2(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateOrderMgntNo1(Map keyName) {
+		return productOrderMapper.updateOrderMgntNo1(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateMileageHistory(Map keyName) {
+		return productOrderMapper.updateMileageHistory(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateMaMember2(Map keyName) {
+		return productOrderMapper.updateMaMember2(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateApprovals3(Map keyName) {
+		return productOrderMapper.updateApprovals3(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int deleteOrderMgntNo(Map keyName) {
+		return productOrderMapper.deleteOrderMgntNo(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateMaMember3(Map keyName) {
+		return productOrderMapper.updateMaMember3(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateApprovals4(Map keyName) {
+		return productOrderMapper.updateApprovals4(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int insertMileageHistory2(Map keyName) {
+		return productOrderMapper.insertMileageHistory2(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateMylecture_3(Map keyName) {
+		return productOrderMapper.updateMylecture_3(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateApprovals5(Map keyName) {
+		return productOrderMapper.updateApprovals5(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int insertSendMsgMultiSendUser(Map keyName) {
+		return productOrderMapper.insertSendMsgMultiSendUser(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getTmMember_View(Map keyName) {
+		return productOrderMapper.getTmMember_View(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getCsccode(Map keyName) {
+		return productOrderMapper.getCsccode(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List Cs_board_list(Map keyName) {
+		return productOrderMapper.Cs_board_list(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int getCsBoardListCount(Map keyName) {
+		return productOrderMapper.getCsBoardListCount(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getTm_mycoupon_list_admin(Map keyName) {
+		return productOrderMapper.getTm_mycoupon_list_admin(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int getTm_mycoupon_listCount_admin(Map keyName) {
+		return productOrderMapper.getTm_mycoupon_listCount_admin(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List Tm_Class_List(Map keyName) {
+		return productOrderMapper.Tm_Class_List(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List Off_Class_List(Map keyName) {
+		return productOrderMapper.Off_Class_List(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int getTmClassListCount(Map keyName) {
+		return productOrderMapper.getTmClassListCount(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getMemoList(Map keyName) {
+		return productOrderMapper.getMemoList(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int getMemoListCount(Map keyName) {
+		return productOrderMapper.getMemoListCount(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int insertBoardCs(Map keyName) {
+		return productOrderMapper.insertBoardCs(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateMemo(Map keyName) {
+		return productOrderMapper.updateMemo(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int getSelectBefore_Point(Map keyName) {
+		return productOrderMapper.getSelectBefore_Point(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getTmCoupon(Map keyName) {
+		return productOrderMapper.getTmCoupon(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getTmCouponList(Map keyName) {
+		return productOrderMapper.getTmCouponList(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getTmMoCouponList(Map keyName) {
+		return productOrderMapper.getTmMoCouponList(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int getTmCouponCount(Map keyName) {
+		return productOrderMapper.getTmCouponCount(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int getTmMoCouponCount(Map keyName) {
+		return productOrderMapper.getTmMoCouponCount(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int getCouponCount(Map keyName) {
+		return productOrderMapper.getCouponCount(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int insertTmCoupon(Map keyName) {
+		return productOrderMapper.insertTmCoupon(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int insertMyCoupon(Map keyName) {
+		return productOrderMapper.insertMyCoupon(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getOffOrderListDB(Map keyName) {
+		return productOrderMapper.getOffOrderListDB(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int getOffOrderListCount(Map keyName) {
+		return productOrderMapper.getOffOrderListCount(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getOffTblOrderMgntListDB(Map keyName) {
+		return productOrderMapper.getOffTblOrderMgntListDB(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List<HashMap<String, String>> getOffOrderExcelListDB(HashMap<String, String> params) {
+		return productOrderMapper.getOffOrderExcelListDB(params);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getIdChk(Map keyName) {
+		return productOrderMapper.getIdChk(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getCaCatCdList(Map keyName) {
+		return productOrderMapper.getCaCatCdList(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getVwMenuMstTree_lec(Map keyName) {
+		return productOrderMapper.getVwMenuMstTree_lec(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getCaSubjectCdList(Map keyName) {
+		return productOrderMapper.getCaSubjectCdList(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getCbLecMstFreeOrderList(Map keyName) {
+		return productOrderMapper.getCbLecMstFreeOrderList(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int getCbLecMstListFreeOrderCount(Map keyName) {
+		return productOrderMapper.getCbLecMstListFreeOrderCount(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getChangePrice(Map keyName) {
+		return productOrderMapper.getChangePrice(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getUCount(Map keyName) {
+		return productOrderMapper.getUCount(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int insertCart(Map keyName) {
+		return productOrderMapper.insertCart(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getSubCode2(Map keyName) {
+		return productOrderMapper.getSubCode2(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int deleteCart(Map keyName) {
+		return productOrderMapper.deleteCart(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int deleteAllCart(Map keyName) {
+		return productOrderMapper.deleteAllCart(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getMCount(Map keyName) {
+		return productOrderMapper.getMCount(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int insertOffOrders(Map keyName) {
+		return productOrderMapper.insertOffOrders(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int insertOffApprovals(Map keyName) {
+		return productOrderMapper.insertOffApprovals(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int insertOffOrderMgntNo(Map keyName) {
+		return productOrderMapper.insertOffOrderMgntNo(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int insertOffMylecture(Map keyName) {
+		return productOrderMapper.insertOffMylecture(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int modifyOffMylecture(Map keyName) {
+		return productOrderMapper.modifyOffMylecture(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int insertOffMylecture_N(Map keyName) {
+		return productOrderMapper.insertOffMylecture_N(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getUpdateDetail(Map keyName) {
+		return productOrderMapper.getUpdateDetail(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getSubCodeUp(Map keyName) {
+		return productOrderMapper.getSubCodeUp(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getSubList(Map keyName) {
+		return productOrderMapper.getSubList(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateOffOrders(Map keyName) {
+		return productOrderMapper.updateOffOrders(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int Coupon_Del(Map keyName) {
+		return productOrderMapper.Coupon_Del(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateOffApprovals(Map keyName) {
+		return productOrderMapper.updateOffApprovals(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateOffMgntNo(Map keyName) {
+		return productOrderMapper.updateOffMgntNo(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateOffMgntNo_N(Map keyName) {
+		return productOrderMapper.updateOffMgntNo_N(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int deleteOffOrderMgntNo(Map keyName) {
+		return productOrderMapper.deleteOffOrderMgntNo(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int deleteOffMylecture(Map keyName) {
+		return productOrderMapper.deleteOffMylecture(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int deleteOffOrders(Map keyName) {
+		return productOrderMapper.deleteOffOrders(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int deleteOffApprovals(Map keyName) {
+		return productOrderMapper.deleteOffApprovals(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public List getPrintPop(Map keyName) {
+		return productOrderMapper.getPrintPop(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updatePrintOffOrders1(Map keyName) {
+		return productOrderMapper.updatePrintOffOrders1(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updatePrintOffOrders2(Map keyName) {
+		return productOrderMapper.updatePrintOffOrders2(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateOffRefund(Map keyName) {
+		return productOrderMapper.updateOffRefund(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int insertRefundOffOrderMgntNo(Map keyName) {
+		return productOrderMapper.insertRefundOffOrderMgntNo(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateOffMylecture(Map keyName) {
+		return productOrderMapper.updateOffMylecture(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateOffMylectureRefund(Map keyName) {
+		return productOrderMapper.updateOffMylectureRefund(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int insertOffRefund(Map keyName) {
+		return productOrderMapper.insertOffRefund(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int deleteOffCancelOrderMgntNo(Map keyName) {
+		return productOrderMapper.deleteOffCancelOrderMgntNo(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int deleteOffCancelRefund(Map keyName) {
+		return productOrderMapper.deleteOffCancelRefund(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int updateOffCancelMylecture(Map keyName) {
+		return productOrderMapper.updateOffCancelMylecture(keyName);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int Delete_Year_Package_Point(Map keyName) {
+		return productOrderMapper.Delete_Year_Package_Point(keyName);
+	}
+
+	public List<HashMap<String, String>> getTmPointHistory(HashMap<String, String> params) {
+		return productOrderMapper.getTmPointHistory(params);
+	}
+
+	public void insertTmBoard(Map<String, Object> searchMap) {
+		productOrderMapper.insertTmBoard(searchMap);
+	}
+
+	public List<HashMap<String, String>> getTmBoardList(Map<String, Object> searchMap) {
+		return productOrderMapper.getTmBoardList(searchMap);
+	}
+
+	public List<HashMap<String, String>> getVOCCODEList(HashMap<String, String> params) {
+		return productOrderMapper.getVOCCODEList(params);
+	}
+
+	public List<HashMap<String, String>> getDUTYCODEList(HashMap<String, String> params) {
+		return productOrderMapper.getDUTYCODEList(params);
+	}
+
+	public List<HashMap<String, String>> getOffApprovalsCount(Map<String, String> searchMap) {
+		return productOrderMapper.getOffApprovalsCount(searchMap);
+	}
+
+	public List<HashMap<String, String>> getCcode(HashMap<String, String> params) {
+		return productOrderMapper.getCcode(params);
+	}
+
+	public void insertMyLecture(Map<String, String> params) {
+		productOrderMapper.insertMyLecture(params);
+	}
+
+	public void insertMyLectureN(Map<String, String> params) {
+		productOrderMapper.insertMyLectureN(params);
+	}
+
+	@SuppressWarnings({ "rawtypes" })
+	public int getPlusPoint(Map keyName) {
+		return productOrderMapper.getPlusPoint(keyName);
+	}
+
+	public void BookPointDel(Map<String, Object> params) {
+		productOrderMapper.BookPointDel(params);
+	}
+
+	public void BookPointIns(Map<String, Object> params) {
+		productOrderMapper.BookPointIns(params);
+	}
+
+	public void insertOffOrderLog(Map<String, Object> params) {
+		productOrderMapper.insertOffOrderLog(params);
+	}
 }


### PR DESCRIPTION
Replaced service interfaces (`SeriesService`, `TeacherService`, `SubjectService`, etc.) with direct implementations using the `@Service` annotation. Updated mapper dependency injection to constructor-based, standardized method parameters to VO classes, and removed unused annotations and legacy code for consistency and maintainability.