### PR TITLE
refactor: replace raw `hashMap` parameter types with specific VO clas…

### DIFF
--- a/src/main/java/com/academy/common/file/web/FileDownloadController.java
+++ b/src/main/java/com/academy/common/file/web/FileDownloadController.java
@@ -1,11 +1,11 @@
 package com.academy.common.file.web;
 
 import java.io.File;
-import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
 
 import jakarta.servlet.http.HttpServletRequest;
 
-import org.apache.commons.io.IOUtils;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
@@ -65,13 +65,15 @@ public class FileDownloadController implements ApplicationContextAware {
 	}
 
 	@RequestMapping("imgFileView.do")
-	public ResponseEntity<byte[]>  imgFileView(@RequestParam("path")String path) throws Exception{
+	public ResponseEntity<byte[]> imgFileView(@RequestParam("path") String path) throws IOException {
 		String rootPath = uploadPath;
+		File file = new File(rootPath + path);
 
-		FileInputStream fin = new FileInputStream(new File(rootPath + path));
-	    final HttpHeaders headers = new HttpHeaders();
-	    headers.setContentType(MediaType.IMAGE_PNG);
-	    return new ResponseEntity<byte[]>(IOUtils.toByteArray(fin), headers, HttpStatus.CREATED);
+		byte[] imageBytes = Files.readAllBytes(file.toPath());
+
+		final HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.IMAGE_PNG);
+		return new ResponseEntity<>(imageBytes, headers, HttpStatus.OK);
 	}
 
 

--- a/src/main/java/com/academy/lecture/ProductEventApi.java
+++ b/src/main/java/com/academy/lecture/ProductEventApi.java
@@ -6,12 +6,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.Resource;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 
 import org.json.simple.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -30,19 +30,17 @@ import com.academy.lecture.service.ProductEventService;
 import com.academy.lecture.service.ProductEventVO;
 import com.academy.lecture.service.TeacherService;
 
-import egovframework.rte.fdl.property.EgovPropertyService;
-
 @RestController
 @RequestMapping("/api/productevent")
 public class ProductEventApi extends CORSFilter {
 
-    @Resource(name="propertiesService")
-    protected EgovPropertyService propertiesService;
+	@Value("${pageUnit:10}")
+	private int pageUnit;
 
-	private ProductEventService productevent;
-	private LectureService lectureservice;
-	private BookService bookservice;
-	private TeacherService teacherservice;
+	private final ProductEventService productevent;
+	private final LectureService lectureservice;
+	private final BookService bookservice;
+	private final TeacherService teacherservice;
 
 	@Autowired
 	public ProductEventApi(ProductEventService productevent, LectureService lectureservice,
@@ -169,7 +167,7 @@ public class ProductEventApi extends CORSFilter {
 		String keyword = CommonUtil.isNull(request.getParameter("keyword"), "");
 
 		int currentPage = Integer.parseInt(CommonUtil.isNull(request.getParameter("currentPage"), "1"));
-		int pageRow = Integer.parseInt(CommonUtil.isNull(request.getParameter("pageRow"), propertiesService.getInt("pageUnit")+""));
+		int pageRow = Integer.parseInt(CommonUtil.isNull(request.getParameter("pageRow"), String.valueOf(pageUnit)));
 
 		String s_cat_cd = CommonUtil.isNull(request.getParameter("s_cat_cd"), "");
 		String s_sjt_cd = CommonUtil.isNull(request.getParameter("s_sjt_cd"), "");
@@ -315,7 +313,7 @@ public class ProductEventApi extends CORSFilter {
 
 		vo.setEventId(CommonUtil.isNull(request.getParameter("EVENT_ID"), ""));
 		vo.setCurrentPage(Integer.parseInt(CommonUtil.isNull(request.getParameter("currentPage"), "1")));
-		vo.setPageRow(Integer.parseInt(CommonUtil.isNull(request.getParameter("pageRow"), propertiesService.getInt("pageUnit")+"")));
+		vo.setPageRow(Integer.parseInt(CommonUtil.isNull(request.getParameter("pageRow"), String.valueOf(pageUnit))));
 		vo.setEventNm(CommonUtil.isNull(request.getParameter("EVENT_NM"), ""));
 		vo.setEventType(CommonUtil.isNull(request.getParameter("EVENT_TYPE"), ""));
 

--- a/src/main/java/com/academy/lecture/TeacherApi.java
+++ b/src/main/java/com/academy/lecture/TeacherApi.java
@@ -3,7 +3,6 @@ package com.academy.lecture;
 import java.util.HashMap;
 import java.util.List;
 
-import javax.annotation.Resource;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 
@@ -28,26 +27,23 @@ import com.academy.common.file.FileUtil;
 import com.academy.lecture.service.TeacherService;
 import com.academy.lecture.service.TeacherVO;
 
-import egovframework.rte.fdl.property.EgovPropertyService;
-
 @RestController
 @RequestMapping("/api/teacher")
 public class TeacherApi extends CORSFilter {
 
-    @Resource(name="propertiesService")
-    protected EgovPropertyService propertiesService;
+	@Value("${pageUnit:10}")
+	private int pageUnit;
 
 	@Value("${file.upload.path:C:/upload/}")
 	private String uploadPath;
 
-	@Resource(name="fileUtil")
-	private FileUtil fileUtil;
-
-	private TeacherService teacherservice;
+	private final FileUtil fileUtil;
+	private final TeacherService teacherservice;
 
 	@Autowired
-	public TeacherApi(TeacherService teacherservice) {
+	public TeacherApi(TeacherService teacherservice, FileUtil fileUtil) {
 		this.teacherservice = teacherservice;
+		this.fileUtil = fileUtil;
 	}
 
 	/**
@@ -362,7 +358,7 @@ public class TeacherApi extends CORSFilter {
 		}
 
 		vo.setCurrentPage(Integer.parseInt(CommonUtil.isNull(request.getParameter("currentPage"), "1")));
-		vo.setPageRow(Integer.parseInt(CommonUtil.isNull(request.getParameter("pageRow"), propertiesService.getInt("pageUnit")+"")));
+		vo.setPageRow(Integer.parseInt(CommonUtil.isNull(request.getParameter("pageRow"), String.valueOf(pageUnit))));
         vo.setSearchCategory(CommonUtil.isNull(request.getParameter("SEARCHCATEGORY"), ""));
 		vo.setSearchType(CommonUtil.isNull(request.getParameter("SEARCHTYPE"), ""));
 		vo.setSearchText(CommonUtil.isNull(request.getParameter("SEARCHTEXT"), ""));

--- a/src/main/java/com/academy/lecture/service/LectureVO.java
+++ b/src/main/java/com/academy/lecture/service/LectureVO.java
@@ -70,7 +70,7 @@ public class LectureVO extends CommonVO implements Serializable {
 
     // Fields from LectureMstVO (integrated)
     private String mstcode;                     // MSTCODE - 마스터 코드
-    private String bridgeMstcode;               // BRIDGE_MSTCODE - 브릿지 마스터 코드
+    private String bridgeLeccode;               // BRIDGE_LECCODE - 브릿지 마스터 코드
     private String subjectCd;                   // SUBJECT_CD - 과목 코드
     private String teacherCd;                   // TEACHER_CD - 강사 코드
     private String formCd;                      // FORM_CD - 학습형태 코드
@@ -92,22 +92,17 @@ public class LectureVO extends CommonVO implements Serializable {
     private String useYn;                       // USE_YN - 사용 여부
     private String isOpen;                      // IS_OPEN - 공개 여부
 
-    // Additional fields for API
-    private String searchType;                  // SEARCHTYPE - 검색 타입
-    private String searchText;                  // SEARCHTEXT - 검색 텍스트
+    // Additional fields for API (searchType, searchText, searchKind, searchGubn, updateFlag inherited from CommonVO)
     private String searchPayYn;                 // SEARCHPAYYN - 검색 결제 여부
     private String searchPayType;               // SEARCHPAYTYPE - 검색 결제 타입
-    private String searchKind;                  // SEARCHKIND - 검색 종류
     private String searchForm;                  // SEARCHFORM - 검색 형태
     private String searchYear;                  // SEARCHYEAR - 검색 연도
     private String searchOpenPage;              // SEARCHOPENPAGE - 검색 오픈 페이지
-    private String searchGubn;                  // SEARCHGUBN - 검색 구분
     private String searchCodeIsuse;             // SEARCHCODEISUSE - 검색 코드 사용여부
     private String rscId;                       // RSC_ID - 리소스 ID
     private String prefix;                      // PREFIX - 접두어
     private String flag;                        // FLAG - 플래그
     private String flag2;                       // FLAG2 - 플래그2
-    private String updateFlag;                  // UPDATE_FLAG - 업데이트 플래그
     private String bridgeLec;                   // BRIDGE_LEC - 브릿지 강의
     private String getCode;                     // GET_CODE - 코드 조회
     private String rcode;                       // RCODE - R코드
@@ -599,23 +594,7 @@ public class LectureVO extends CommonVO implements Serializable {
         this.isUseNm = isUseNm;
     }
 
-    // Additional fields getters and setters
-    public String getSearchType() {
-        return searchType;
-    }
-
-    public void setSearchType(String searchType) {
-        this.searchType = searchType;
-    }
-
-    public String getSearchText() {
-        return searchText;
-    }
-
-    public void setSearchText(String searchText) {
-        this.searchText = searchText;
-    }
-
+    // Additional fields getters and setters (searchType, searchText, searchKind, searchGubn, updateFlag inherited from CommonVO)
     public String getSearchPayYn() {
         return searchPayYn;
     }
@@ -630,14 +609,6 @@ public class LectureVO extends CommonVO implements Serializable {
 
     public void setSearchPayType(String searchPayType) {
         this.searchPayType = searchPayType;
-    }
-
-    public String getSearchKind() {
-        return searchKind;
-    }
-
-    public void setSearchKind(String searchKind) {
-        this.searchKind = searchKind;
     }
 
     public String getSearchForm() {
@@ -662,14 +633,6 @@ public class LectureVO extends CommonVO implements Serializable {
 
     public void setSearchOpenPage(String searchOpenPage) {
         this.searchOpenPage = searchOpenPage;
-    }
-
-    public String getSearchGubn() {
-        return searchGubn;
-    }
-
-    public void setSearchGubn(String searchGubn) {
-        this.searchGubn = searchGubn;
     }
 
     public String getSearchCodeIsuse() {
@@ -710,14 +673,6 @@ public class LectureVO extends CommonVO implements Serializable {
 
     public void setFlag2(String flag2) {
         this.flag2 = flag2;
-    }
-
-    public String getUpdateFlag() {
-        return updateFlag;
-    }
-
-    public void setUpdateFlag(String updateFlag) {
-        this.updateFlag = updateFlag;
     }
 
     public String getBridgeLec() {
@@ -799,14 +754,6 @@ public class LectureVO extends CommonVO implements Serializable {
 
     public void setMstcode(String mstcode) {
         this.mstcode = mstcode;
-    }
-
-    public String getBridgeMstcode() {
-        return bridgeMstcode;
-    }
-
-    public void setBridgeMstcode(String bridgeMstcode) {
-        this.bridgeMstcode = bridgeMstcode;
     }
 
     public String getSubjectCd() {

--- a/src/main/java/com/academy/lecture/service/MacAddressManagerVO.java
+++ b/src/main/java/com/academy/lecture/service/MacAddressManagerVO.java
@@ -23,9 +23,7 @@ public class MacAddressManagerVO extends CommonVO implements Serializable {
     private String deviceType;      // DEVICE_TYPE - 디바이스 타입
     private String deviceName;      // DEVICE_NAME - 디바이스명
 
-    // Search 관련 fields
-    private String searchType;      // SEARCHTYPE - 검색 타입
-    private String searchText;      // SEARCHTEXT - 검색어
+    // Search 관련 fields (searchType, searchText inherited from CommonVO)
 
     // Getters and Setters
     public String getUserId() {
@@ -82,22 +80,6 @@ public class MacAddressManagerVO extends CommonVO implements Serializable {
 
     public void setDeviceName(String deviceName) {
         this.deviceName = deviceName;
-    }
-
-    public String getSearchType() {
-        return searchType;
-    }
-
-    public void setSearchType(String searchType) {
-        this.searchType = searchType;
-    }
-
-    public String getSearchText() {
-        return searchText;
-    }
-
-    public void setSearchText(String searchText) {
-        this.searchText = searchText;
     }
 
     @Override

--- a/src/main/java/com/academy/lecture/service/OpenLectureService.java
+++ b/src/main/java/com/academy/lecture/service/OpenLectureService.java
@@ -82,8 +82,8 @@ public class OpenLectureService {
         return openLectureMapper.openlectureViewBookList(lectureVO);
     }
 
-    public void openlectureBookDelete(LectureVO lectureVO){
-        openLectureMapper.openlectureBookDelete(lectureVO);
+    public void openlectureBookDelete(OpenLectureVO openLectureVO){
+        openLectureMapper.openlectureBookDelete(openLectureVO);
     }
 
     public void openlectureUpdate(LectureVO lectureVO){
@@ -94,12 +94,12 @@ public class OpenLectureService {
         openLectureMapper.openlectureIsUseUpdate(lectureVO);
     }
 
-    public void openlectureDelete(LectureVO lectureVO){
-        openLectureMapper.openlectureDelete(lectureVO);
+    public void openlectureDelete(OpenLectureVO openLectureVO){
+        openLectureMapper.openlectureDelete(openLectureVO);
     }
 
-    public void openlectureBridgeDelete(LectureVO lectureVO){
-        openLectureMapper.openlectureBridgeDelete(lectureVO);
+    public void openlectureBridgeDelete(OpenLectureVO openLectureVO){
+        openLectureMapper.openlectureBridgeDelete(openLectureVO);
     }
 
     public void lecMovUpdate(LectureVO lectureVO){

--- a/src/main/java/com/academy/lecture/service/OpenLectureVO.java
+++ b/src/main/java/com/academy/lecture/service/OpenLectureVO.java
@@ -28,13 +28,10 @@ public class OpenLectureVO extends CommonVO implements Serializable {
     private Integer openPoint;      // OPEN_POINT - 포인트
     private Integer openHit;        // OPEN_HIT - 조회수
 
-    // Display / Search fields
+    // Display / Search fields (searchType, searchText, searchKind inherited from CommonVO)
     private String categoryNm;      // CATEGORY_NM - 카테고리명
     private String subjectNm;       // SUBJECT_NM - 과목명
     private String teacherNm;       // TEACHER_NM - 강사명
-    private String searchType;      // SEARCHTYPE - 검색 타입
-    private String searchText;      // SEARCHTEXT - 검색어
-    private String searchKind;      // SEARCHKIND - 검색 종류
     private String searchForm;      // SEARCHFORM - 검색 형태
     private String searchYear;      // SEARCHYEAR - 검색 연도
     private String searchPayyn;     // SEARCHPAYYN - 검색 결제여부
@@ -181,30 +178,6 @@ public class OpenLectureVO extends CommonVO implements Serializable {
 
     public void setTeacherNm(String teacherNm) {
         this.teacherNm = teacherNm;
-    }
-
-    public String getSearchType() {
-        return searchType;
-    }
-
-    public void setSearchType(String searchType) {
-        this.searchType = searchType;
-    }
-
-    public String getSearchText() {
-        return searchText;
-    }
-
-    public void setSearchText(String searchText) {
-        this.searchText = searchText;
-    }
-
-    public String getSearchKind() {
-        return searchKind;
-    }
-
-    public void setSearchKind(String searchKind) {
-        this.searchKind = searchKind;
     }
 
     public String getSearchForm() {

--- a/src/main/java/com/academy/lecture/service/ProductEventVO.java
+++ b/src/main/java/com/academy/lecture/service/ProductEventVO.java
@@ -25,9 +25,7 @@ public class ProductEventVO extends CommonVO implements Serializable {
     // Lecture 관련 fields
     private String leccode;         // LECCODE - 강의 코드
 
-    // Search 관련 fields
-    private String searchType;      // SEARCHTYPE - 검색 타입
-    private String searchKeyword;   // SEARCHKEYWORD - 검색어
+    // Search 관련 fields (searchType, searchKeyword inherited from CommonVO)
     private String catCd;           // CAT_CD - 카테고리 코드
     private String sCatCd;          // S_CAT_CD - 카테고리 코드
     private String sjtCd;           // SJT_CD - 과목 코드
@@ -103,22 +101,6 @@ public class ProductEventVO extends CommonVO implements Serializable {
 
     public void setLeccode(String leccode) {
         this.leccode = leccode;
-    }
-
-    public String getSearchType() {
-        return searchType;
-    }
-
-    public void setSearchType(String searchType) {
-        this.searchType = searchType;
-    }
-
-    public String getSearchKeyword() {
-        return searchKeyword;
-    }
-
-    public void setSearchKeyword(String searchKeyword) {
-        this.searchKeyword = searchKeyword;
     }
 
     public String getCatCd() {

--- a/src/main/java/com/academy/lecture/service/SubjectService.java
+++ b/src/main/java/com/academy/lecture/service/SubjectService.java
@@ -1,5 +1,6 @@
 package com.academy.lecture.service;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
 
@@ -13,7 +14,9 @@ import com.academy.mapper.SubjectMapper;
  * 과목 관리 서비스 (직접 구현)
  */
 @Service(value="subjectservice")
-public class SubjectService {
+public class SubjectService implements Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     @Autowired
     private SubjectMapper subjectMapper;

--- a/src/main/java/com/academy/lecture/service/TeacherService.java
+++ b/src/main/java/com/academy/lecture/service/TeacherService.java
@@ -1,5 +1,6 @@
 package com.academy.lecture.service;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
 
@@ -13,7 +14,9 @@ import com.academy.mapper.TeacherMapper;
  * 강사 관리 서비스 (직접 구현)
  */
 @Service(value="teacherservice")
-public class TeacherService {
+public class TeacherService implements Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     @Autowired
     private TeacherMapper teacherMapper;
@@ -70,18 +73,17 @@ public class TeacherService {
     /**
      * Teacher 등록 (배열 처리 포함)
      */
-    @SuppressWarnings("unchecked")
-    public void teacherInsert(Object obj){
+    public void teacherInsert(TeacherVO teacherVO){
 
-        teacherMapper.teacherInsert(obj);
+        teacherMapper.teacherInsert(teacherVO);
 
-        String[] ORI_CATEGORY_CODE = (String[])((HashMap<String, Object>)obj).get("ORI_CATEGORY_CODE");
-        String[] CETCARR = (String[])((HashMap<String, Object>)obj).get("CETCARR");
+        String[] ORI_CATEGORY_CODE = teacherVO.getOriCategoryCode();
+        String[] CETCARR = teacherVO.getCetcarr();
 
         if(ORI_CATEGORY_CODE == null) { // 등록
             for(int i=0; i<CETCARR.length; i++){
-                ((HashMap<String, String>)obj).put("CATEGORY_CODE", CETCARR[i]);
-                teacherMapper.teacherCategoryInsert(obj);
+                teacherVO.setCategoryCode(CETCARR[i]);
+                teacherMapper.teacherCategoryInsert(teacherVO);
             }
         } else {    // 수정
             for(int i=0; i<ORI_CATEGORY_CODE.length;i++){
@@ -92,8 +94,8 @@ public class TeacherService {
                     }
                 }
                 if(isDel) {
-                    ((HashMap<String, String>)obj).put("DEL_CATEGORY_CODE", ORI_CATEGORY_CODE[i]);
-                    teacherMapper.teacherCategoryDelete(obj);
+                    teacherVO.setDelCategoryCode(ORI_CATEGORY_CODE[i]);
+                    teacherMapper.teacherCategoryDelete(teacherVO);
                 }
             }
 
@@ -105,38 +107,38 @@ public class TeacherService {
                     }
                 }
                 if(isIns) {
-                    ((HashMap<String, String>)obj).put("CATEGORY_CODE", CETCARR[i]);
-                    teacherMapper.teacherCategoryInsert(obj);
+                    teacherVO.setCategoryCode(CETCARR[i]);
+                    teacherMapper.teacherCategoryInsert(teacherVO);
                 }
             }
         }
 
-        teacherMapper.teacherSubjectDelete(obj);
+        teacherMapper.teacherSubjectDelete(teacherVO);
 
-        String[] SETCARR = (String[])((HashMap<String, Object>)obj).get("SETCARR");
+        String[] SETCARR = teacherVO.getSetcarr();
         if(SETCARR != null){
             for(int i=0; i<SETCARR.length; i++){
-                ((HashMap<String, String>)obj).put("SUBJECT_CD", SETCARR[i]);
-                int teacherMain_Category_Subject = teacherMapper.teacherMain_Category_Subject(obj);
-                int teacherIntro_Category_Subject = teacherMapper.teacherIntro_Category_Subject(obj);
-                teacherMapper.teacherSubjectInsert(obj);
+                teacherVO.setSubjectCdSingle(SETCARR[i]);
+                int teacherMain_Category_Subject = teacherMapper.teacherMain_Category_Subject(teacherVO);
+                int teacherIntro_Category_Subject = teacherMapper.teacherIntro_Category_Subject(teacherVO);
+                teacherMapper.teacherSubjectInsert(teacherVO);
 
                 if(ORI_CATEGORY_CODE == null) {
-                    teacherMapper.teacherMain_Category_Insert(obj);
-                    teacherMapper.teacherIntro_Category_Insert(obj);
-                    teacherMapper.teacherIntro_F_Category_Insert(obj);
+                    teacherMapper.teacherMain_Category_Insert(teacherVO);
+                    teacherMapper.teacherIntro_Category_Insert(teacherVO);
+                    teacherMapper.teacherIntro_F_Category_Insert(teacherVO);
                 }else{
 
                     if(teacherMain_Category_Subject == 0){
 
-                        teacherMapper.teacherMain_Category_Insert(obj);
+                        teacherMapper.teacherMain_Category_Insert(teacherVO);
                     }else{
 
                     }
                     if(teacherIntro_Category_Subject == 0){
 
-                        teacherMapper.teacherIntro_Category_Insert(obj);
-                        teacherMapper.teacherIntro_F_Category_Insert(obj);
+                        teacherMapper.teacherIntro_Category_Insert(teacherVO);
+                        teacherMapper.teacherIntro_F_Category_Insert(teacherVO);
                     }else{
 
                     }
@@ -155,17 +157,16 @@ public class TeacherService {
     /**
      * Teacher 수정 (배열 처리 포함)
      */
-    @SuppressWarnings("unchecked")
-    public void teacherUpdate(Object obj){
-        teacherMapper.teacherUpdate(obj);
+    public void teacherUpdate(TeacherVO teacherVO){
+        teacherMapper.teacherUpdate(teacherVO);
 
-        String[] ORI_CATEGORY_CODE = (String[])((HashMap<String, Object>)obj).get("ORI_CATEGORY_CODE");
-        String[] CETCARR = (String[])((HashMap<String, Object>)obj).get("CETCARR");
+        String[] ORI_CATEGORY_CODE = teacherVO.getOriCategoryCode();
+        String[] CETCARR = teacherVO.getCetcarr();
 
         if(ORI_CATEGORY_CODE == null) { // 등록
             for(int i=0; i<CETCARR.length; i++){
-                ((HashMap<String, String>)obj).put("CATEGORY_CODE", CETCARR[i]);
-                teacherMapper.teacherCategoryInsert(obj);
+                teacherVO.setCategoryCode(CETCARR[i]);
+                teacherMapper.teacherCategoryInsert(teacherVO);
             }
         } else {    // 수정
             for(int i=0; i<ORI_CATEGORY_CODE.length;i++){
@@ -176,8 +177,8 @@ public class TeacherService {
                     }
                 }
                 if(isDel) {
-                    ((HashMap<String, String>)obj).put("DEL_CATEGORY_CODE", ORI_CATEGORY_CODE[i]);
-                    teacherMapper.teacherCategoryDelete(obj);
+                    teacherVO.setDelCategoryCode(ORI_CATEGORY_CODE[i]);
+                    teacherMapper.teacherCategoryDelete(teacherVO);
                 }
             }
 
@@ -189,91 +190,91 @@ public class TeacherService {
                     }
                 }
                 if(isIns) {
-                    ((HashMap<String, String>)obj).put("CATEGORY_CODE", CETCARR[i]);
-                    teacherMapper.teacherCategoryInsert(obj);
+                    teacherVO.setCategoryCode(CETCARR[i]);
+                    teacherMapper.teacherCategoryInsert(teacherVO);
                 }
             }
         }
 
-        teacherMapper.teacherSubjectDelete(obj);
-        teacherMapper.teacherMain_Category_Delete(obj);
-        teacherMapper.teacherIntro_Category_Delete(obj);
-        teacherMapper.teacherIntro_F_Category_Delete(obj);
+        teacherMapper.teacherSubjectDelete(teacherVO);
+        teacherMapper.teacherMain_Category_Delete(teacherVO);
+        teacherMapper.teacherIntro_Category_Delete(teacherVO);
+        teacherMapper.teacherIntro_F_Category_Delete(teacherVO);
 
-        String[] SETCARR = (String[])((HashMap<String, Object>)obj).get("SETCARR");
-        String[] OFF_SETCARR = (String[])((HashMap<String, Object>)obj).get("OFF_SETCARR");
+        String[] SETCARR = teacherVO.getSetcarr();
+        String[] OFF_SETCARR = teacherVO.getOffSetcarr();
         String ON_SBJ = "";
         if(SETCARR != null && SETCARR.length > 0){
             for(int i=0; i<SETCARR.length; i++){
-                ((HashMap<String, String>)obj).put("SUBJECT_CD", SETCARR[i]);
-                ((HashMap<String, String>)obj).put("USE_ON", "Y");
-                ((HashMap<String, String>)obj).put("USE_OFF", "N");
-                teacherMapper.teacherSubjectInsert(obj);
+                teacherVO.setSubjectCdSingle(SETCARR[i]);
+                teacherVO.setUseOn("Y");
+                teacherVO.setUseOff("N");
+                teacherMapper.teacherSubjectInsert(teacherVO);
 
                 if(ORI_CATEGORY_CODE == null) {
-                    teacherMapper.teacherMain_Category_Insert(obj);
-                    teacherMapper.teacherIntro_Category_Insert(obj);
-                    teacherMapper.teacherIntro_F_Category_Insert(obj);
+                    teacherMapper.teacherMain_Category_Insert(teacherVO);
+                    teacherMapper.teacherIntro_Category_Insert(teacherVO);
+                    teacherMapper.teacherIntro_F_Category_Insert(teacherVO);
                 }else{
-                    int teacherMain_Category_Subject = teacherMapper.teacherMain_Category_Subject(obj);
-                    int teacherIntro_Category_Subject = teacherMapper.teacherIntro_Category_Subject(obj);
-                    int teacherIntro_F_Category_Subject = teacherMapper.teacherIntro_F_Category_Subject(obj);
+                    int teacherMain_Category_Subject = teacherMapper.teacherMain_Category_Subject(teacherVO);
+                    int teacherIntro_Category_Subject = teacherMapper.teacherIntro_Category_Subject(teacherVO);
+                    int teacherIntro_F_Category_Subject = teacherMapper.teacherIntro_F_Category_Subject(teacherVO);
                     if(teacherMain_Category_Subject == 0){
 
-                        teacherMapper.teacherMain_Category_Insert(obj);
+                        teacherMapper.teacherMain_Category_Insert(teacherVO);
 
                     }
                     if(teacherIntro_Category_Subject == 0){
-                        teacherMapper.teacherIntro_Category_Insert(obj);
+                        teacherMapper.teacherIntro_Category_Insert(teacherVO);
                     }
                     if(teacherIntro_F_Category_Subject == 0){
-                        teacherMapper.teacherIntro_F_Category_Insert(obj);
+                        teacherMapper.teacherIntro_F_Category_Insert(teacherVO);
                     }
 
                 }
                 ON_SBJ += SETCARR[i]+",";
           }
        }
-        ((HashMap<String, String>)obj).put("USE_ON", "");
-        ((HashMap<String, String>)obj).put("USE_OFF", "");
+        teacherVO.setUseOn("");
+        teacherVO.setUseOff("");
 
         if(OFF_SETCARR != null && OFF_SETCARR.length > 0){
             for(int j=0; j<OFF_SETCARR.length; j++){
                 if(ON_SBJ.contains(OFF_SETCARR[j])){
-                    ((HashMap<String, String>)obj).put("USE_OFF", "Y");
-                    teacherMapper.teacherSubjectUpdate(obj);
+                    teacherVO.setUseOff("Y");
+                    teacherMapper.teacherSubjectUpdate(teacherVO);
                 }else{
-                    ((HashMap<String, String>)obj).put("SUBJECT_CD", OFF_SETCARR[j]);
-                    ((HashMap<String, String>)obj).put("USE_ON", "N");
-                    ((HashMap<String, String>)obj).put("USE_OFF", "Y");
-                    int sbjCnt = teacherMapper.teacherSubjectCount(obj);
+                    teacherVO.setSubjectCdSingle(OFF_SETCARR[j]);
+                    teacherVO.setUseOn("N");
+                    teacherVO.setUseOff("Y");
+                    int sbjCnt = teacherMapper.teacherSubjectCount(teacherVO);
                     if(sbjCnt==0){
-                        teacherMapper.teacherSubjectInsert(obj);
+                        teacherMapper.teacherSubjectInsert(teacherVO);
 
                         if(ORI_CATEGORY_CODE == null && (SETCARR == null || SETCARR.length < 1)) {
-                            teacherMapper.teacherMain_Category_Insert(obj);
-                            teacherMapper.teacherIntro_Category_Insert(obj);
-                            teacherMapper.teacherIntro_F_Category_Insert(obj);
+                            teacherMapper.teacherMain_Category_Insert(teacherVO);
+                            teacherMapper.teacherIntro_Category_Insert(teacherVO);
+                            teacherMapper.teacherIntro_F_Category_Insert(teacherVO);
                         }else{
-                            int teacherMain_Category_Subject = teacherMapper.teacherMain_Category_Subject(obj);
-                            int teacherIntro_Category_Subject = teacherMapper.teacherIntro_Category_Subject(obj);
-                            int teacherIntro_F_Category_Subject = teacherMapper.teacherIntro_F_Category_Subject(obj);
+                            int teacherMain_Category_Subject = teacherMapper.teacherMain_Category_Subject(teacherVO);
+                            int teacherIntro_Category_Subject = teacherMapper.teacherIntro_Category_Subject(teacherVO);
+                            int teacherIntro_F_Category_Subject = teacherMapper.teacherIntro_F_Category_Subject(teacherVO);
                             if(teacherMain_Category_Subject == 0){
 
-                                teacherMapper.teacherMain_Category_Insert(obj);
+                                teacherMapper.teacherMain_Category_Insert(teacherVO);
 
                             }
                             if(teacherIntro_Category_Subject == 0){
-                                teacherMapper.teacherIntro_Category_Insert(obj);
+                                teacherMapper.teacherIntro_Category_Insert(teacherVO);
                             }
                             if(teacherIntro_F_Category_Subject == 0){
-                                teacherMapper.teacherIntro_F_Category_Insert(obj);
+                                teacherMapper.teacherIntro_F_Category_Insert(teacherVO);
                             }
                         }
                     }
                 }
-                ((HashMap<String, String>)obj).put("USE_ON", "");
-                ((HashMap<String, String>)obj).put("USE_OFF", "");
+                teacherVO.setUseOn("");
+                teacherVO.setUseOff("");
             }
         }
     }
@@ -295,15 +296,13 @@ public class TeacherService {
     /**
      * Teacher 사용 여부 수정 (배열 처리 포함)
      */
-    @SuppressWarnings("unchecked")
-    public void teacherIsUseUpdate(Object obj){
-        String[] DEL_ARR = (String[])((HashMap<String, Object>)obj).get("DEL_ARR");
+    public void teacherIsUseUpdate(TeacherVO teacherVO){
+        String[] DEL_ARR = teacherVO.getDelArr();
         if(DEL_ARR != null && DEL_ARR.length > 0){
             for(int i=0; i<DEL_ARR.length; i++){
-                HashMap<String, String> params = new  HashMap<String, String>();
-                params.put("USER_ID", DEL_ARR[i]);
-
-                teacherMapper.teacherIsUseUpdate(params);
+                TeacherVO paramVO = new TeacherVO();
+                paramVO.setUserId(DEL_ARR[i]);
+                teacherMapper.teacherIsUseUpdate(paramVO);
             }
         }
     }
@@ -332,24 +331,23 @@ public class TeacherService {
     /**
      * Teacher 순서 수정 (배열 처리 포함)
      */
-    @SuppressWarnings("unchecked")
-    public void teacherSeqUpdate(Object obj){
-        String[] NUM = (String[])((HashMap<String, Object>)obj).get("NUM");
-        String[] SEQARR = (String[])((HashMap<String, Object>)obj).get("SEQ");
-        String[] PROFESSOR_USER_IDARR = (String[])((HashMap<String, Object>)obj).get("USER_ID");
-        String[] SUBJECT_CD = (String[])((HashMap<String, Object>)obj).get("SUBJECT_CD");
+    public void teacherSeqUpdate(TeacherVO teacherVO){
+        String[] NUM = teacherVO.getNum();
+        String[] SEQARR = teacherVO.getSeq();
+        String[] PROFESSOR_USER_IDARR = teacherVO.getProfessorUserId();
+        String[] SUBJECT_CD = teacherVO.getSubjectCd();
 
         if(SEQARR != null && SEQARR.length > 0){
             for(int i=0; i<SEQARR.length; i++){
-                HashMap<String, String> params = new  HashMap<String, String>();
-                params.put("NUM", NUM[i]);
-                params.put("SEQ", SEQARR[i]);
-                params.put("USER_ID", PROFESSOR_USER_IDARR[i]);
-                params.put("SUBJECT_CD", SUBJECT_CD[i]);
-                params.put("ONOFFDIV", ((HashMap<String, Object>)obj).get("ONOFFDIV").toString());
-                params.put("SEARCHCATEGORY", ((HashMap<String, Object>)obj).get("SEARCHCATEGORY").toString());
+                TeacherVO paramVO = new TeacherVO();
+                paramVO.setNumSingle(NUM[i]);
+                paramVO.setSeqSingle(SEQARR[i]);
+                paramVO.setUserId(PROFESSOR_USER_IDARR[i]);
+                paramVO.setSubjectCdSingle(SUBJECT_CD[i]);
+                paramVO.setOnoffdiv(teacherVO.getOnoffdiv());
+                paramVO.setSearchCategory(teacherVO.getSearchCategory());
 
-                teacherMapper.teacherSeqUpdate(params);
+                teacherMapper.teacherSeqUpdate(paramVO);
             }
         }
     }

--- a/src/main/java/com/academy/lecture/service/TeacherVO.java
+++ b/src/main/java/com/academy/lecture/service/TeacherVO.java
@@ -74,6 +74,15 @@ public class TeacherVO extends CommonVO implements Serializable {
     private String[] professorUserId; // PROFESSOR_USER_ID - 교수 사용자 ID 배열
     // isUse, regDt, regId, updDt, updId inherited from CommonVO
 
+    // Single value fields for mapper operations
+    private String categoryCode;    // CATEGORY_CODE - 카테고리 코드 (단일)
+    private String delCategoryCode; // DEL_CATEGORY_CODE - 삭제할 카테고리 코드
+    private String subjectCdSingle; // SUBJECT_CD - 과목 코드 (단일)
+    private String useOn;           // USE_ON - 온라인 사용 여부
+    private String useOff;          // USE_OFF - 오프라인 사용 여부
+    private String numSingle;       // NUM - 번호 (단일)
+    private String seqSingle;       // SEQ - 순서 (단일)
+
     // Display fields
     private String isUseNm;         // ISUSENM - 사용여부명
     private String memTypeNm;       // MEM_TYPENM - 회원 유형명
@@ -556,6 +565,62 @@ public class TeacherVO extends CommonVO implements Serializable {
 
     public void setProfessorUserId(String[] professorUserId) {
         this.professorUserId = professorUserId;
+    }
+
+    public String getCategoryCode() {
+        return categoryCode;
+    }
+
+    public void setCategoryCode(String categoryCode) {
+        this.categoryCode = categoryCode;
+    }
+
+    public String getDelCategoryCode() {
+        return delCategoryCode;
+    }
+
+    public void setDelCategoryCode(String delCategoryCode) {
+        this.delCategoryCode = delCategoryCode;
+    }
+
+    public String getSubjectCdSingle() {
+        return subjectCdSingle;
+    }
+
+    public void setSubjectCdSingle(String subjectCdSingle) {
+        this.subjectCdSingle = subjectCdSingle;
+    }
+
+    public String getUseOn() {
+        return useOn;
+    }
+
+    public void setUseOn(String useOn) {
+        this.useOn = useOn;
+    }
+
+    public String getUseOff() {
+        return useOff;
+    }
+
+    public void setUseOff(String useOff) {
+        this.useOff = useOff;
+    }
+
+    public String getNumSingle() {
+        return numSingle;
+    }
+
+    public void setNumSingle(String numSingle) {
+        this.numSingle = numSingle;
+    }
+
+    public String getSeqSingle() {
+        return seqSingle;
+    }
+
+    public void setSeqSingle(String seqSingle) {
+        this.seqSingle = seqSingle;
     }
 
     @Override

--- a/src/main/java/com/academy/mapper/FormMapper.java
+++ b/src/main/java/com/academy/mapper/FormMapper.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import org.apache.ibatis.annotations.Mapper;
 
+import com.academy.lecture.service.FormVO;
+
 /**
  * Form Mapper Interface
  * lectureFormSQL.xml 매퍼 파일과 연동
@@ -15,12 +17,12 @@ public interface FormMapper {
     /**
      * 학습형태 목록 조회
      */
-    List<HashMap<String, String>> formList(HashMap<String, String> params);
+    List<HashMap<String, String>> formList(FormVO formVO);
 
     /**
      * 학습형태 목록 카운트
      */
-    int formListCount(HashMap<String, String> params);
+    int formListCount(FormVO formVO);
 
     /**
      * 학습형태 코드 생성
@@ -30,30 +32,30 @@ public interface FormMapper {
     /**
      * 학습형태 등록
      */
-    void formInsert(HashMap<String, String> params);
+    void formInsert(FormVO formVO);
 
     /**
      * 학습형태 상세 조회
      */
-    List<HashMap<String, String>> formView(HashMap<String, String> params);
+    List<HashMap<String, String>> formView(FormVO formVO);
 
     /**
      * 학습형태 수정
      */
-    void formUpdate(HashMap<String, String> params);
+    void formUpdate(FormVO formVO);
 
     /**
      * 학습형태 삭제
      */
-    void formDelete(HashMap<String, String> params);
+    void formDelete(FormVO formVO);
 
     /**
      * 학습형태 중복 체크
      */
-    int formCheck(HashMap<String, String> params);
+    int formCheck(FormVO formVO);
 
     /**
      * 코드 목록 조회
      */
-    List<HashMap<String, String>> getCodeList(HashMap<String, String> params);
+    List<HashMap<String, String>> getCodeList(FormVO formVO);
 }

--- a/src/main/java/com/academy/mapper/KindMapper.java
+++ b/src/main/java/com/academy/mapper/KindMapper.java
@@ -5,6 +5,9 @@ import java.util.List;
 
 import org.apache.ibatis.annotations.Mapper;
 
+import com.academy.lecture.service.CategoryVO;
+import com.academy.lecture.service.KindVO;
+
 /**
  * Kind Mapper Interface
  * lectureKindSQL.xml 매퍼 파일과 연동
@@ -15,42 +18,42 @@ public interface KindMapper {
     /**
      * Kind 목록 조회 (간단)
      */
-    List<HashMap<String, String>> getKindList(Object obj);
+    List<HashMap<String, String>> getKindList(KindVO kindVO);
 
     /**
      * Kind 목록 조회
      */
-    List<HashMap<String, String>> kindList(HashMap<String, String> params);
+    List<HashMap<String, String>> kindList(KindVO kindVO);
 
     /**
      * Kind 목록 카운트
      */
-    int kindListCount(HashMap<String, String> params);
+    int kindListCount(KindVO kindVO);
 
     /**
      * Kind 등록
      */
-    void kindInsert(HashMap<String, String> params);
+    void kindInsert(KindVO kindVO);
 
     /**
      * Kind 상세 조회
      */
-    List<HashMap<String, String>> kindView(HashMap<String, String> params);
+    List<HashMap<String, String>> kindView(KindVO kindVO);
 
     /**
      * Kind 수정
      */
-    void kindUpdate(HashMap<String, String> params);
+    void kindUpdate(KindVO kindVO);
 
     /**
      * Kind 삭제
      */
-    void kindDelete(HashMap<String, String> params);
+    void kindDelete(KindVO kindVO);
 
     /**
      * Kind 중복 체크
      */
-    int kindCheck(HashMap<String, String> params);
+    int kindCheck(KindVO kindVO);
 
     /**
      * Kind 코드 조회
@@ -60,7 +63,7 @@ public interface KindMapper {
     /**
      * 순서 업데이트
      */
-    void SeqUpdate(HashMap<String, String> params);
+    void SeqUpdate(KindVO kindVO);
 
     /**
      * 시리즈 카테고리 트리 조회
@@ -70,5 +73,5 @@ public interface KindMapper {
     /**
      * 최대 순서 조회
      */
-    HashMap<String, Object> getMaxOrdr(Object obj);
+    HashMap<String, Object> getMaxOrdr(CategoryVO categoryVO);
 }

--- a/src/main/java/com/academy/mapper/LectureMapper.java
+++ b/src/main/java/com/academy/mapper/LectureMapper.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import org.apache.ibatis.annotations.Mapper;
 
+import com.academy.lecture.service.LectureVO;
+
 /**
  * Lecture Mapper Interface
  * lectureLectureSQL.xml 매퍼 파일과 연동
@@ -13,96 +15,118 @@ import org.apache.ibatis.annotations.Mapper;
 public interface LectureMapper {
 
     // 강의 목록
-    List<HashMap<String, String>> lectureList(HashMap<String, String> params);
-    List<HashMap<String, String>> oldFreeToNewFree(HashMap<String, String> params);
-    List<HashMap<String, String>> oldBogangFreeToNewBogangFree(HashMap<String, String> params);
-    int lectureListCount(HashMap<String, String> params);
+    List<HashMap<String, String>> lectureList(LectureVO lectureVO);
+    List<HashMap<String, String>> oldFreeToNewFree(LectureVO lectureVO);
+    List<HashMap<String, String>> oldBogangFreeToNewBogangFree(LectureVO lectureVO);
+    int lectureListCount(LectureVO lectureVO);
 
     // 교재 목록
-    List<HashMap<String, String>> bookList(HashMap<String, String> params);
-    int bookListCount(HashMap<String, String> params);
-    List<HashMap<String, String>> bookView(HashMap<String, String> params);
+    List<HashMap<String, String>> bookList(LectureVO lectureVO);
+    int bookListCount(LectureVO lectureVO);
+    List<HashMap<String, String>> bookView(LectureVO lectureVO);
 
     // 강의 코드 관련
-    List<HashMap<String, String>> getBridgeLeccodeSeq(HashMap<String, String> params);
-    List<HashMap<String, String>> getJongLeccodeSeq(HashMap<String, String> params);
-    List<HashMap<String, String>> getLeccode(HashMap<String, String> params);
-    List<HashMap<String, String>> getBridgeLeccode(HashMap<String, String> params);
-    List<HashMap<String, String>> BridgeLeccode(HashMap<String, String> params);
-    String getRleccode(HashMap<String, String> params);
+    List<HashMap<String, String>> getBridgeLeccodeSeq(LectureVO lectureVO);
+    List<HashMap<String, String>> getJongLeccodeSeq(LectureVO lectureVO);
+    List<HashMap<String, String>> getLeccode(LectureVO lectureVO);
+    List<HashMap<String, String>> getBridgeLeccode(LectureVO lectureVO);
+    List<HashMap<String, String>> BridgeLeccode(LectureVO lectureVO);
+    String getRleccode(LectureVO lectureVO);
 
     // 강의 등록
-    void lectureInsert(HashMap<String, String> params);
-    void lectureBridgeInsert(HashMap<String, String> params);
-    void lectureBookInsert(HashMap<String, String> params);
-    void lectureBookInsert2(HashMap<String, String> params);
-    void oldFreeToNewFreeInsert(HashMap<String, String> params);
-    void oldBogangFreeToNewFreeBogangInsert(HashMap<String, String> params);
-    void oldTbmovieToNewTbmovieInsert(HashMap<String, String> params);
+    void lectureInsert(LectureVO lectureVO);
+    void lectureBridgeInsert(LectureVO lectureVO);
+    void lectureBookInsert(LectureVO lectureVO);
+    void lectureBookInsert2(LectureVO lectureVO);
+    void oldFreeToNewFreeInsert(LectureVO lectureVO);
+    void oldBogangFreeToNewFreeBogangInsert(LectureVO lectureVO);
+    void oldTbmovieToNewTbmovieInsert(LectureVO lectureVO);
 
     // 강의 조회
-    List<HashMap<String, String>> lectureViewList(HashMap<String, String> params);
-    List<HashMap<String, String>> lectureView(HashMap<String, String> params);
-    List<HashMap<String, String>> lectureViewBookList(HashMap<String, String> params);
-    HashMap<String, String> lectureOnDetailS(HashMap<String, String> params);
+    List<HashMap<String, String>> lectureViewList(LectureVO lectureVO);
+    List<HashMap<String, String>> lectureView(LectureVO lectureVO);
+    List<HashMap<String, String>> lectureViewBookList(LectureVO lectureVO);
+    HashMap<String, String> lectureOnDetailS(LectureVO lectureVO);
 
     // 강의 수정/삭제
-    void lectureUpdate(HashMap<String, String> params);
-    void lectureIsUseUpdate(HashMap<String, String> params);
-    void Modify_Lecture_On_Off(HashMap<String, String> params);
-    void lectureDelete(HashMap<String, String> params);
-    void lectureBridgeDelete(HashMap<String, String> params);
-    void lectureBookDelete(HashMap<String, String> params);
-    void lecMovUpdate(HashMap<String, String> params);
-    int lectureDeleteCheck(HashMap<String, String> params);
+    void lectureUpdate(LectureVO lectureVO);
+    void lectureIsUseUpdate(LectureVO lectureVO);
+    void Modify_Lecture_On_Off(LectureVO lectureVO);
+    void lectureDelete(LectureVO lectureVO);
+    void lectureBridgeDelete(LectureVO lectureVO);
+    void lectureBookDelete(LectureVO lectureVO);
+    void lecMovUpdate(LectureVO lectureVO);
+    int lectureDeleteCheck(LectureVO lectureVO);
 
     // 강의 순서
-    List<HashMap<String, String>> lectureSeqList(HashMap<String, String> params);
-    void lectureSeqUpdate(HashMap<String, String> params);
+    List<HashMap<String, String>> lectureSeqList(LectureVO lectureVO);
+    void lectureSeqUpdate(LectureVO lectureVO);
 
     // 종강 관련
-    List<HashMap<String, String>> lectureViewJongList(HashMap<String, String> params);
-    List<HashMap<String, String>> lectureJongList(HashMap<String, String> params);
-    int lectureJongListCount(HashMap<String, String> params);
-    List<HashMap<String, String>> lectureYearList(HashMap<String, String> params);
-    int lectureYearListCount(HashMap<String, String> params);
-    List<HashMap<String, String>> lectureJongView(HashMap<String, String> params);
-    List<HashMap<String, String>> lectureJongSubjectList(HashMap<String, String> params);
-    int lectureJongSubjectListCount(HashMap<String, String> params);
-    void lectureLecJongInsert(HashMap<String, String> params);
-    void lectureChoiceJongNoInsert(HashMap<String, String> params);
-    List<HashMap<String, String>> lectureViewLeccodeList(HashMap<String, String> params);
-    void lectureLecJongDelete(HashMap<String, String> params);
-    void lectureChoiceJongNoDelete(HashMap<String, String> params);
+    List<HashMap<String, String>> lectureViewJongList(LectureVO lectureVO);
+    List<HashMap<String, String>> lectureJongList(LectureVO lectureVO);
+    int lectureJongListCount(LectureVO lectureVO);
+    List<HashMap<String, String>> lectureYearList(LectureVO lectureVO);
+    int lectureYearListCount(LectureVO lectureVO);
+    List<HashMap<String, String>> lectureJongView(LectureVO lectureVO);
+    List<HashMap<String, String>> lectureJongSubjectList(LectureVO lectureVO);
+    int lectureJongSubjectListCount(LectureVO lectureVO);
+    void lectureLecJongInsert(LectureVO lectureVO);
+    void lectureChoiceJongNoInsert(LectureVO lectureVO);
+    List<HashMap<String, String>> lectureViewLeccodeList(LectureVO lectureVO);
+    void lectureLecJongDelete(LectureVO lectureVO);
+    void lectureChoiceJongNoDelete(LectureVO lectureVO);
 
     // 결제 관련
-    List<HashMap<String, String>> lecturePayList(HashMap<String, String> params);
-    List<HashMap<String, String>> lectureJongPayList(HashMap<String, String> params);
-    List<HashMap<String, String>> lectureFreePassPayList(HashMap<String, String> params);
-    List<HashMap<String, String>> YearIngList(HashMap<String, String> params);
-    List<HashMap<String, String>> MyYearIngList(HashMap<String, String> params);
+    List<HashMap<String, String>> lecturePayList(LectureVO lectureVO);
+    List<HashMap<String, String>> lectureJongPayList(LectureVO lectureVO);
+    List<HashMap<String, String>> lectureFreePassPayList(LectureVO lectureVO);
+    List<HashMap<String, String>> YearIngList(LectureVO lectureVO);
+    List<HashMap<String, String>> MyYearIngList(LectureVO lectureVO);
 
     // 강의 데이터
-    List<HashMap<String, String>> lectureDataMemoViewList(HashMap<String, String> params);
-    List<HashMap<String, String>> lectureDataViewList(HashMap<String, String> params);
-    List<HashMap<String, String>> lectureMobileList(HashMap<String, String> params);
-    List<HashMap<String, String>> lectureDataMovieViewList(HashMap<String, String> params);
-    List<HashMap<String, String>> lectureDataMovieList(HashMap<String, String> params);
+    List<HashMap<String, String>> lectureDataMemoViewList(LectureVO lectureVO);
+    List<HashMap<String, String>> lectureDataViewList(LectureVO lectureVO);
+    List<HashMap<String, String>> lectureMobileList(LectureVO lectureVO);
+    List<HashMap<String, String>> lectureDataMovieViewList(LectureVO lectureVO);
+    List<HashMap<String, String>> lectureDataMovieList(LectureVO lectureVO);
 
     // 동영상 관련
-    void lectureMovieInsert(HashMap<String, String> params);
-    void lectureMovieDelete(HashMap<String, String> params);
-    void lectureMovieUpdate(HashMap<String, String> params);
-    void lectureMovieFileDelete(HashMap<String, String> params);
-    void lectureMovieMemoInsert(HashMap<String, String> params);
-    void lectureMovieMemoUpdate(HashMap<String, String> params);
-    void lectureMovieMemoDelete(HashMap<String, String> params);
+    void lectureMovieInsert(LectureVO lectureVO);
+    void lectureMovieDelete(LectureVO lectureVO);
+    void lectureMovieUpdate(LectureVO lectureVO);
+    void lectureMovieFileDelete(LectureVO lectureVO);
+    void lectureMovieMemoInsert(LectureVO lectureVO);
+    void lectureMovieMemoUpdate(LectureVO lectureVO);
+    void lectureMovieMemoDelete(LectureVO lectureVO);
 
     // 재생 정보
-    List<HashMap<String, String>> playinfo(HashMap<String, String> params);
-    List<HashMap<String, String>> getCbMovie4_free_admin(HashMap<String, String> params);
-    int getCbMovie4_free_admin_count(HashMap<String, String> params);
-    void insertPmpDownLog(HashMap<String, String> params);
-    List<HashMap<String, String>> lectureWMV(HashMap<String, String> params);
-    List<HashMap<String, String>> lectureDown_Count(HashMap<String, String> params);
+    List<HashMap<String, String>> playinfo(LectureVO lectureVO);
+    List<HashMap<String, String>> getCbMovie4_free_admin(LectureVO lectureVO);
+    int getCbMovie4_free_admin_count(LectureVO lectureVO);
+    void insertPmpDownLog(LectureVO lectureVO);
+    List<HashMap<String, String>> lectureWMV(LectureVO lectureVO);
+    List<HashMap<String, String>> lectureDown_Count(LectureVO lectureVO);
+
+    // Legacy methods for complex logic (Object parameter)
+    @SuppressWarnings("rawtypes")
+    List<HashMap<String, String>> oldFreeToNewFree(Object params);
+    @SuppressWarnings("rawtypes")
+    List<HashMap<String, String>> oldBogangFreeToNewBogangFree(Object params);
+    @SuppressWarnings("rawtypes")
+    List<HashMap<String, String>> getBridgeLeccodeSeq(Object params);
+    @SuppressWarnings("rawtypes")
+    List<HashMap<String, String>> getBridgeLeccode(Object params);
+    @SuppressWarnings("rawtypes")
+    List<HashMap<String, String>> getLeccode(Object params);
+    @SuppressWarnings("rawtypes")
+    String getRleccode(Object params);
+    @SuppressWarnings("rawtypes")
+    void oldFreeToNewFreeInsert(Object params);
+    @SuppressWarnings("rawtypes")
+    void oldBogangFreeToNewFreeBogangInsert(Object params);
+    @SuppressWarnings("rawtypes")
+    void lectureBridgeInsert(Object params);
+    @SuppressWarnings("rawtypes")
+    void oldTbmovieToNewTbmovieInsert(Object params);
 }

--- a/src/main/java/com/academy/mapper/MacAddressManagerMapper.java
+++ b/src/main/java/com/academy/mapper/MacAddressManagerMapper.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import org.apache.ibatis.annotations.Mapper;
 
+import com.academy.lecture.service.MacAddressManagerVO;
+
 /**
  * MacAddressManager Mapper Interface
  * lectureMacAddressManagerSQL.xml 매퍼 파일과 연동
@@ -15,30 +17,30 @@ public interface MacAddressManagerMapper {
     /**
      * MAC 주소 관리자 목록 조회
      */
-    List<HashMap<String, String>> macaddressmanagerList(HashMap<String, String> params);
+    List<HashMap<String, String>> macaddressmanagerList(MacAddressManagerVO macAddressManagerVO);
 
     /**
      * 디바이스 목록 조회
      */
-    List<HashMap<String, String>> devicelist(HashMap<String, String> params);
+    List<HashMap<String, String>> devicelist(MacAddressManagerVO macAddressManagerVO);
 
     /**
      * MAC 주소 조회
      */
-    List<HashMap<String, String>> macaddressView(HashMap<String, String> params);
+    List<HashMap<String, String>> macaddressView(MacAddressManagerVO macAddressManagerVO);
 
     /**
      * MAC 주소 관리자 목록 카운트
      */
-    int macaddressmanagerListCount(HashMap<String, String> params);
+    int macaddressmanagerListCount(MacAddressManagerVO macAddressManagerVO);
 
     /**
      * MAC 주소 관리자 수정
      */
-    void macaddressmanagerUpdate(HashMap<String, String> params);
+    void macaddressmanagerUpdate(MacAddressManagerVO macAddressManagerVO);
 
     /**
      * MAC 주소 관리자 수정1
      */
-    void macaddressmanagerUpdate1(HashMap<String, String> params);
+    void macaddressmanagerUpdate1(MacAddressManagerVO macAddressManagerVO);
 }

--- a/src/main/java/com/academy/mapper/OpenLectureMapper.java
+++ b/src/main/java/com/academy/mapper/OpenLectureMapper.java
@@ -5,6 +5,9 @@ import java.util.List;
 
 import org.apache.ibatis.annotations.Mapper;
 
+import com.academy.lecture.service.LectureVO;
+import com.academy.lecture.service.OpenLectureVO;
+
 /**
  * OpenLecture Mapper Interface
  * lectureOffSQL.xml 매퍼 파일과 연동
@@ -15,285 +18,285 @@ public interface OpenLectureMapper {
     /**
      * 오픈강의 목록 조회
      */
-    List<HashMap<String, String>> openlectureList(HashMap<String, String> params);
+    List<HashMap<String, String>> openlectureList(LectureVO lectureVO);
 
     /**
      * 오픈강의 목록 카운트
      */
-    int openlectureListCount(HashMap<String, String> params);
+    int openlectureListCount(LectureVO lectureVO);
 
     /**
      * 교재 목록 조회
      */
-    List<HashMap<String, String>> bookList(HashMap<String, String> params);
+    List<HashMap<String, String>> bookList(LectureVO lectureVO);
 
     /**
      * 교재 목록 카운트
      */
-    int bookListCount(HashMap<String, String> params);
+    int bookListCount(LectureVO lectureVO);
 
     /**
      * 브릿지 강의코드 시퀀스 조회
      */
-    List<HashMap<String, String>> getBridgeLeccodeSeq(HashMap<String, String> params);
+    List<HashMap<String, String>> getBridgeLeccodeSeq(LectureVO lectureVO);
 
     /**
      * 종강 강의코드 시퀀스 조회
      */
-    List<HashMap<String, String>> getJongLeccodeSeq(HashMap<String, String> params);
+    List<HashMap<String, String>> getJongLeccodeSeq(LectureVO lectureVO);
 
     /**
      * 오픈강의 코드 조회
      */
-    List<HashMap<String, String>> getopenLeccode(HashMap<String, String> params);
+    List<HashMap<String, String>> getopenLeccode(LectureVO lectureVO);
 
     /**
      * 브릿지 강의코드 조회
      */
-    List<HashMap<String, String>> getBridgeLeccode(HashMap<String, String> params);
+    List<HashMap<String, String>> getBridgeLeccode(LectureVO lectureVO);
 
     /**
      * 브릿지 강의코드
      */
-    List<HashMap<String, String>> BridgeLeccode(HashMap<String, String> params);
+    List<HashMap<String, String>> BridgeLeccode(LectureVO lectureVO);
 
     /**
      * 오픈강의 등록
      */
-    void openlectureInsert(HashMap<String, String> params);
+    void openlectureInsert(LectureVO lectureVO);
 
     /**
      * 오픈강의 브릿지 등록
      */
-    void openlectureBridgeInsert(HashMap<String, String> params);
+    void openlectureBridgeInsert(LectureVO lectureVO);
 
     /**
      * 오픈강의 교재 등록
      */
-    void openlectureBookInsert(HashMap<String, String> params);
+    void openlectureBookInsert(LectureVO lectureVO);
 
     /**
      * 오픈강의 교재 등록2
      */
-    void openlectureBookInsert2(HashMap<String, String> params);
+    void openlectureBookInsert2(LectureVO lectureVO);
 
     /**
      * 오픈강의 뷰 목록
      */
-    List<HashMap<String, String>> openlectureViewList(HashMap<String, String> params);
+    List<HashMap<String, String>> openlectureViewList(LectureVO lectureVO);
 
     /**
      * 오픈강의 조회
      */
-    List<HashMap<String, String>> openlectureView(HashMap<String, String> params);
+    List<HashMap<String, String>> openlectureView(LectureVO lectureVO);
 
     /**
      * 오픈강의 뷰 교재 목록
      */
-    List<HashMap<String, String>> openlectureViewBookList(HashMap<String, String> params);
+    List<HashMap<String, String>> openlectureViewBookList(LectureVO lectureVO);
 
     /**
      * 오픈강의 교재 삭제
      */
-    void openlectureBookDelete(HashMap<String, String> params);
+    void openlectureBookDelete(OpenLectureVO openLectureVO);
 
     /**
      * 오픈강의 수정
      */
-    void openlectureUpdate(HashMap<String, String> params);
+    void openlectureUpdate(LectureVO lectureVO);
 
     /**
      * 오픈강의 사용여부 수정
      */
-    void openlectureIsUseUpdate(HashMap<String, String> params);
+    void openlectureIsUseUpdate(LectureVO lectureVO);
 
     /**
      * 강의 On/Off 수정
      */
-    void Modify_Lecture_On_Off(HashMap<String, String> params);
+    void Modify_Lecture_On_Off(LectureVO lectureVO);
 
     /**
      * 오픈강의 삭제
      */
-    void openlectureDelete(HashMap<String, String> params);
+    void openlectureDelete(OpenLectureVO openLectureVO);
 
     /**
      * 오픈강의 브릿지 삭제
      */
-    void openlectureBridgeDelete(HashMap<String, String> params);
+    void openlectureBridgeDelete(OpenLectureVO openLectureVO);
 
     /**
      * 강의 이동 수정
      */
-    void lecMovUpdate(HashMap<String, String> params);
+    void lecMovUpdate(LectureVO lectureVO);
 
     /**
      * 오픈강의 순서 목록
      */
-    List<HashMap<String, String>> openlectureSeqList(HashMap<String, String> params);
+    List<HashMap<String, String>> openlectureSeqList(LectureVO lectureVO);
 
     /**
      * 오픈강의 순서 수정
      */
-    void openlectureSeqUpdate(HashMap<String, String> params);
+    void openlectureSeqUpdate(LectureVO lectureVO);
 
     /**
      * 오픈강의 종강 뷰 목록
      */
-    List<HashMap<String, String>> openlectureViewJongList(HashMap<String, String> params);
+    List<HashMap<String, String>> openlectureViewJongList(LectureVO lectureVO);
 
     /**
      * 오픈강의 종강 목록
      */
-    List<HashMap<String, String>> openlectureJongList(HashMap<String, String> params);
+    List<HashMap<String, String>> openlectureJongList(LectureVO lectureVO);
 
     /**
      * 오픈강의 종강 목록 카운트
      */
-    int openlectureJongListCount(HashMap<String, String> params);
+    int openlectureJongListCount(LectureVO lectureVO);
 
     /**
      * 오픈강의 종강 조회
      */
-    List<HashMap<String, String>> openlectureJongView(HashMap<String, String> params);
+    List<HashMap<String, String>> openlectureJongView(LectureVO lectureVO);
 
     /**
      * 오픈강의 종강 과목 목록
      */
-    List<HashMap<String, String>> openlectureJongSubjectList(HashMap<String, String> params);
+    List<HashMap<String, String>> openlectureJongSubjectList(LectureVO lectureVO);
 
     /**
      * 오픈강의 종강 과목 목록 카운트
      */
-    int openlectureJongSubjectListCount(HashMap<String, String> params);
+    int openlectureJongSubjectListCount(LectureVO lectureVO);
 
     /**
      * 오픈강의 종강 등록
      */
-    void openlectureLecJongInsert(HashMap<String, String> params);
+    void openlectureLecJongInsert(LectureVO lectureVO);
 
     /**
      * 오픈강의 선택 종강 번호 등록
      */
-    void openlectureChoiceJongNoInsert(HashMap<String, String> params);
+    void openlectureChoiceJongNoInsert(LectureVO lectureVO);
 
     /**
      * 오픈강의 뷰 강의코드 목록
      */
-    List<HashMap<String, String>> openlectureViewLeccodeList(HashMap<String, String> params);
+    List<HashMap<String, String>> openlectureViewLeccodeList(LectureVO lectureVO);
 
     /**
      * 오픈강의 종강 삭제
      */
-    void openlectureLecJongDelete(HashMap<String, String> params);
+    void openlectureLecJongDelete(LectureVO lectureVO);
 
     /**
      * 오픈강의 선택 종강 번호 삭제
      */
-    void openlectureChoiceJongNoDelete(HashMap<String, String> params);
+    void openlectureChoiceJongNoDelete(LectureVO lectureVO);
 
     /**
      * 오픈강의 결제 목록
      */
-    List<HashMap<String, String>> openlecturePayList(HashMap<String, String> params);
+    List<HashMap<String, String>> openlecturePayList(LectureVO lectureVO);
 
     /**
      * 오픈강의 종강 결제 목록
      */
-    List<HashMap<String, String>> openlectureJongPayList(HashMap<String, String> params);
+    List<HashMap<String, String>> openlectureJongPayList(LectureVO lectureVO);
 
     /**
      * 오픈강의 데이터 메모 뷰 목록
      */
-    List<HashMap<String, String>> openlectureDataMemoViewList(HashMap<String, String> params);
+    List<HashMap<String, String>> openlectureDataMemoViewList(LectureVO lectureVO);
 
     /**
      * 오픈강의 데이터 뷰 목록
      */
-    List<HashMap<String, String>> openlectureDataViewList(HashMap<String, String> params);
+    List<HashMap<String, String>> openlectureDataViewList(LectureVO lectureVO);
 
     /**
      * 오픈강의 데이터 동영상 뷰 목록
      */
-    List<HashMap<String, String>> openlectureDataMovieViewList(HashMap<String, String> params);
+    List<HashMap<String, String>> openlectureDataMovieViewList(LectureVO lectureVO);
 
     /**
      * 오픈강의 데이터 동영상 목록
      */
-    List<HashMap<String, String>> openlectureDataMovieList(HashMap<String, String> params);
+    List<HashMap<String, String>> openlectureDataMovieList(LectureVO lectureVO);
 
     /**
      * 오픈강의 동영상 등록
      */
-    void openlectureMovieInsert(HashMap<String, String> params);
+    void openlectureMovieInsert(LectureVO lectureVO);
 
     /**
      * 오픈강의 동영상 삭제
      */
-    void openlectureMovieDelete(HashMap<String, String> params);
+    void openlectureMovieDelete(LectureVO lectureVO);
 
     /**
      * 오픈강의 동영상 수정
      */
-    void openlectureMovieUpdate(HashMap<String, String> params);
+    void openlectureMovieUpdate(LectureVO lectureVO);
 
     /**
      * 오픈강의 동영상 파일 삭제
      */
-    void openlectureMovieFileDelete(HashMap<String, String> params);
+    void openlectureMovieFileDelete(LectureVO lectureVO);
 
     /**
      * 오픈강의 동영상 메모 등록
      */
-    void openlectureMovieMemoInsert(HashMap<String, String> params);
+    void openlectureMovieMemoInsert(LectureVO lectureVO);
 
     /**
      * 오픈강의 동영상 메모 수정
      */
-    void openlectureMovieMemoUpdate(HashMap<String, String> params);
+    void openlectureMovieMemoUpdate(LectureVO lectureVO);
 
     /**
      * 오픈강의 동영상 메모 삭제
      */
-    void openlectureMovieMemoDelete(HashMap<String, String> params);
+    void openlectureMovieMemoDelete(LectureVO lectureVO);
 
     /**
      * 오픈강의 삭제 체크
      */
-    int openlectureDeleteCheck(HashMap<String, String> params);
+    int openlectureDeleteCheck(LectureVO lectureVO);
 
     /**
      * 재생 정보
      */
-    List<HashMap<String, String>> playinfo(HashMap<String, String> params);
+    List<HashMap<String, String>> playinfo(LectureVO lectureVO);
 
     /**
      * 무료 관리자 동영상 조회
      */
-    List<HashMap<String, String>> getCbMovie4_free_admin(HashMap<String, String> params);
+    List<HashMap<String, String>> getCbMovie4_free_admin(LectureVO lectureVO);
 
     /**
      * 무료 관리자 동영상 카운트
      */
-    int getCbMovie4_free_admin_count(HashMap<String, String> params);
+    int getCbMovie4_free_admin_count(LectureVO lectureVO);
 
     /**
      * 오픈강의 온라인 상세 조회
      */
-    HashMap<String, String> openlectureOnDetailS(HashMap<String, String> params);
+    HashMap<String, String> openlectureOnDetailS(LectureVO lectureVO);
 
     /**
      * PMP 다운로드 로그 등록
      */
-    void insertPmpDownLog(HashMap<String, String> params);
+    void insertPmpDownLog(LectureVO lectureVO);
 
     /**
      * 오픈강의 WMV
      */
-    List<HashMap<String, String>> openlectureWMV(HashMap<String, String> params);
+    List<HashMap<String, String>> openlectureWMV(LectureVO lectureVO);
 
     /**
      * 오픈강의 다운로드 카운트
      */
-    List<HashMap<String, String>> openlectureDown_Count(HashMap<String, String> params);
+    List<HashMap<String, String>> openlectureDown_Count(LectureVO lectureVO);
 }

--- a/src/main/java/com/academy/mapper/ProductEventMapper.java
+++ b/src/main/java/com/academy/mapper/ProductEventMapper.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import org.apache.ibatis.annotations.Mapper;
 
+import com.academy.lecture.service.ProductEventVO;
+
 /**
  * ProductEvent Mapper Interface
  * ProductEvent 관련 XML 매퍼 파일과 연동
@@ -15,40 +17,40 @@ public interface ProductEventMapper {
     /**
      * 상품 이벤트 목록 조회
      */
-    List<HashMap<String, String>> list(HashMap<String, String> params);
+    List<HashMap<String, String>> list(ProductEventVO productEventVO);
 
     /**
      * 상품 이벤트 목록 카운트
      */
-    int listCount(HashMap<String, String> params);
+    int listCount(ProductEventVO productEventVO);
 
     /**
      * 상품 이벤트 단건 조회
      */
-    HashMap<String, String> getOne(HashMap<String, String> params);
+    HashMap<String, String> getOne(ProductEventVO productEventVO);
 
     /**
      * 상품 목록 조회
      */
-    List<HashMap<String, String>> list_prd(HashMap<String, String> params);
+    List<HashMap<String, String>> list_prd(ProductEventVO productEventVO);
 
     /**
      * 상품 이벤트 등록
      */
-    void insert(HashMap<String, String> params);
+    void insert(ProductEventVO productEventVO);
 
     /**
      * 상품 이벤트 수정
      */
-    void update(HashMap<String, String> params);
+    void update(ProductEventVO productEventVO);
 
     /**
      * 강의 등록
      */
-    void lec_insert(HashMap<String, String> params);
+    void lec_insert(ProductEventVO productEventVO);
 
     /**
      * 강의 삭제
      */
-    void lec_delete(HashMap<String, String> params);
+    void lec_delete(ProductEventVO productEventVO);
 }

--- a/src/main/java/com/academy/mapper/SeriesMapper.java
+++ b/src/main/java/com/academy/mapper/SeriesMapper.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import org.apache.ibatis.annotations.Mapper;
 
+import com.academy.lecture.service.SeriesVO;
+
 /**
  * Series Mapper Interface
  * lectureSeriesSQL.xml 매퍼 파일과 연동
@@ -15,40 +17,40 @@ public interface SeriesMapper {
     /**
      * 시리즈 목록 조회
      */
-    List<HashMap<String, String>> seriesList(Object obj);
+    List<HashMap<String, String>> seriesList(SeriesVO seriesVO);
 
     /**
      * 시리즈 목록 카운트
      */
-    int seriesListCount(Object obj);
+    int seriesListCount(SeriesVO seriesVO);
 
     /**
      * 시리즈 등록
      */
-    void seriesInsert(Object obj);
+    int seriesInsert(SeriesVO seriesVO);
 
     /**
      * 시리즈 상세 조회
      */
-    List<HashMap<String, String>> seriesView(Object obj);
+    HashMap<String, Object> seriesView(SeriesVO seriesVO);
 
     /**
      * 시리즈 수정
      */
-    void seriesUpdate(Object obj);
+    void seriesUpdate(SeriesVO seriesVO);
 
     /**
      * 시리즈 삭제
      */
-    void seriesDelete(Object obj);
+    int seriesDelete(SeriesVO seriesVO);
 
     /**
      * 시리즈 중복 체크
      */
-    int seriesCheck(Object obj);
+    int seriesCheck(SeriesVO seriesVO);
 
     /**
      * 카테고리 삭제
      */
-    void categoryDelete(Object obj);
+    void categoryDelete(SeriesVO seriesVO);
 }

--- a/src/main/java/com/academy/mapper/SubjectMapper.java
+++ b/src/main/java/com/academy/mapper/SubjectMapper.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import org.apache.ibatis.annotations.Mapper;
 
+import com.academy.lecture.service.SubjectVO;
+
 /**
  * Subject Mapper Interface
  * lectureSubjectSQL.xml 매퍼 파일과 연동
@@ -15,100 +17,100 @@ public interface SubjectMapper {
     /**
      * 과목 목록 조회
      */
-    List<HashMap<String, String>> subjectList(HashMap<String, String> params);
+    List<HashMap<String, String>> subjectList(SubjectVO subjectVO);
 
     /**
      * 과목 목록 카운트
      */
-    int subjectListCount(HashMap<String, String> params);
+    int subjectListCount(SubjectVO subjectVO);
 
     /**
      * 과목 코드 생성
      */
-    String subjectGetCode(HashMap<String, String> params);
+    String subjectGetCode(SubjectVO subjectVO);
 
     /**
      * 과목 등록
      */
-    void subjectInsert(HashMap<String, String> params);
+    void subjectInsert(SubjectVO subjectVO);
 
     /**
      * 과목 상세 조회
      */
-    List<HashMap<String, String>> subjectView(HashMap<String, String> params);
+    List<HashMap<String, String>> subjectView(SubjectVO subjectVO);
 
     /**
      * 과목 수정
      */
-    void subjectUpdate(HashMap<String, String> params);
+    void subjectUpdate(SubjectVO subjectVO);
 
     /**
      * 과목 삭제
      */
-    void subjectDelete(HashMap<String, String> params);
+    void subjectDelete(SubjectVO subjectVO);
 
     /**
      * 과목 중복 체크
      */
-    int subjectCheck(HashMap<String, String> params);
+    int subjectCheck(SubjectVO subjectVO);
 
     /**
      * 과목 카테고리 등록
      */
-    void subjectCategoryInsert(HashMap<String, String> params);
+    void subjectCategoryInsert(SubjectVO subjectVO);
 
     /**
      * 과목 카테고리 삭제
      */
-    void subjectCategoryDelete(HashMap<String, String> params);
+    void subjectCategoryDelete(SubjectVO subjectVO);
 
     /**
      * 과목 카테고리 삭제 (카테고리별)
      */
-    void subjectCategoryDeleteByCat(HashMap<String, String> params);
+    void subjectCategoryDeleteByCat(SubjectVO subjectVO);
 
     /**
      * 과목 카테고리 순서 등록
      */
-    void subjectCategoryOrderInsert(HashMap<String, String> params);
+    void subjectCategoryOrderInsert(SubjectVO subjectVO);
 
     /**
      * 과목 카테고리 순서 개수 체크
      */
-    int chkSubjectCategoryOrderCnt(HashMap<String, String> params);
+    int chkSubjectCategoryOrderCnt(SubjectVO subjectVO);
 
     /**
      * 과목 카테고리 개수 체크
      */
-    int chkSubjectCategoryCnt(HashMap<String, String> params);
+    int chkSubjectCategoryCnt(SubjectVO subjectVO);
 
     /**
      * 과목 카테고리 순서 인덱스 조회
      */
-    String getSubjectCategoryOrderIdx(HashMap<String, String> params);
+    String getSubjectCategoryOrderIdx(SubjectVO subjectVO);
 
     /**
      * 과목 카테고리 순서 삭제 (On/Off별)
      */
-    void subjectCategoryOrderDeleteByOnoff(HashMap<String, String> params);
+    void subjectCategoryOrderDeleteByOnoff(SubjectVO subjectVO);
 
     /**
      * 과목 카테고리 순서 삭제
      */
-    void subjectCategoryOrderDelete(HashMap<String, String> params);
+    void subjectCategoryOrderDelete(SubjectVO subjectVO);
 
     /**
      * 과목 카테고리 상세 조회
      */
-    List<HashMap<String, String>> subjectCategoryView(HashMap<String, String> params);
+    List<HashMap<String, String>> subjectCategoryView(SubjectVO subjectVO);
 
     /**
      * 과목 카테고리 목록 조회
      */
-    List<HashMap<String, String>> findSubjectCategoryList(HashMap<String, String> params);
+    List<HashMap<String, String>> findSubjectCategoryList(SubjectVO subjectVO);
 
     /**
      * 메인 카테고리 과목 순서 등록
      */
-    void main_category_subject_order_Insert(HashMap<String, String> params);
+    void main_category_subject_order_Insert(SubjectVO subjectVO);
 }

--- a/src/main/java/com/academy/mapper/TeacherMapper.java
+++ b/src/main/java/com/academy/mapper/TeacherMapper.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import org.apache.ibatis.annotations.Mapper;
 
+import com.academy.lecture.service.TeacherVO;
+
 /**
  * Teacher Mapper Interface
  * lectureTeacherSQL.xml 매퍼 파일과 연동
@@ -15,180 +17,180 @@ public interface TeacherMapper {
     /**
      * Kind 목록 조회
      */
-    List<HashMap<String, String>> getKindList(HashMap<String, String> params);
+    List<HashMap<String, String>> getKindList(TeacherVO teacherVO);
 
     /**
      * 과목 목록 조회
      */
-    List<HashMap<String, String>> getSubjectList(HashMap<String, String> params);
+    List<HashMap<String, String>> getSubjectList(TeacherVO teacherVO);
 
     /**
      * 강사 목록 조회
      */
-    List<HashMap<String, String>> teacherList(HashMap<String, String> params);
+    List<HashMap<String, String>> teacherList(TeacherVO teacherVO);
 
     /**
      * 강사 목록 카운트
      */
-    int teacherListCount(HashMap<String, String> params);
+    int teacherListCount(TeacherVO teacherVO);
 
     /**
      * 강사 전체 목록 조회
      */
-    List<HashMap<String, String>> teacherAllList(HashMap<String, String> params);
+    List<HashMap<String, String>> teacherAllList(TeacherVO teacherVO);
 
     /**
      * 강사 ID 중복 체크
      */
-    int teacherIdCheck(HashMap<String, String> params);
+    int teacherIdCheck(TeacherVO teacherVO);
 
     /**
      * 강사 등록
      */
-    void teacherInsert(Object obj);
+    void teacherInsert(TeacherVO teacherVO);
 
     /**
      * 강사 상세 조회
      */
-    List<HashMap<String, String>> teacherView(HashMap<String, String> params);
+    List<HashMap<String, String>> teacherView(TeacherVO teacherVO);
 
     /**
      * 강사 수정
      */
-    void teacherUpdate(Object obj);
+    void teacherUpdate(TeacherVO teacherVO);
 
     /**
      * 강사 카테고리 등록
      */
-    void teacherCategoryInsert(Object obj);
+    void teacherCategoryInsert(TeacherVO teacherVO);
 
     /**
      * 강사 과목 등록
      */
-    void teacherSubjectInsert(Object obj);
+    void teacherSubjectInsert(TeacherVO teacherVO);
 
     /**
      * 강사 과목 수정
      */
-    void teacherSubjectUpdate(Object obj);
+    void teacherSubjectUpdate(TeacherVO teacherVO);
 
     /**
      * 강사 과목 개수
      */
-    int teacherSubjectCount(Object obj);
+    int teacherSubjectCount(TeacherVO teacherVO);
 
     /**
      * 강사 사용여부 수정
      */
-    void teacherIsUseUpdate(Object obj);
+    void teacherIsUseUpdate(TeacherVO teacherVO);
 
     /**
      * 강사 삭제
      */
-    void teacherDelete(HashMap<String, String> params);
+    void teacherDelete(TeacherVO teacherVO);
 
     /**
      * 강사 카테고리 삭제
      */
-    void teacherCategoryDelete(Object obj);
+    void teacherCategoryDelete(TeacherVO teacherVO);
 
     /**
      * 강사 과목 삭제
      */
-    void teacherSubjectDelete(Object obj);
+    void teacherSubjectDelete(TeacherVO teacherVO);
 
     /**
      * 강사 순서 업데이트
      */
-    void teacherSeqUpdate(Object obj);
+    void teacherSeqUpdate(TeacherVO teacherVO);
 
     /**
      * 강사 교재 로그
      */
-    List<HashMap<String, String>> teacherBookLog(HashMap<String, String> params);
+    List<HashMap<String, String>> teacherBookLog(TeacherVO teacherVO);
 
     /**
      * 강사 메인 카테고리 등록
      */
-    void teacherMain_Category_Insert(Object obj);
+    void teacherMain_Category_Insert(TeacherVO teacherVO);
 
     /**
      * 강사 메인 카테고리 삭제
      */
-    void teacherMain_Category_Delete(Object obj);
+    void teacherMain_Category_Delete(TeacherVO teacherVO);
 
     /**
      * 강사 소개 카테고리 등록
      */
-    void teacherIntro_Category_Insert(Object obj);
+    void teacherIntro_Category_Insert(TeacherVO teacherVO);
 
     /**
      * 강사 소개 F 카테고리 등록
      */
-    void teacherIntro_F_Category_Insert(Object obj);
+    void teacherIntro_F_Category_Insert(TeacherVO teacherVO);
 
     /**
      * 강사 소개 카테고리 삭제
      */
-    void teacherIntro_Category_Delete(Object obj);
+    void teacherIntro_Category_Delete(TeacherVO teacherVO);
 
     /**
      * 강사 소개 F 카테고리 삭제
      */
-    void teacherIntro_F_Category_Delete(Object obj);
+    void teacherIntro_F_Category_Delete(TeacherVO teacherVO);
 
     /**
      * 강사 메인 목록 조회
      */
-    List<HashMap<String, String>> teacherMainList(HashMap<String, String> params);
+    List<HashMap<String, String>> teacherMainList(TeacherVO teacherVO);
 
     /**
      * 강사 메인 목록 카운트
      */
-    int teacherMainListCount(HashMap<String, String> params);
+    int teacherMainListCount(TeacherVO teacherVO);
 
     /**
      * 강사 목록 검색
      */
-    List<HashMap<String, String>> findTeacherList(HashMap<String, String> params);
+    List<HashMap<String, String>> findTeacherList(TeacherVO teacherVO);
 
     /**
      * 강사 메인 카테고리 과목
      */
-    int teacherMain_Category_Subject(Object obj);
+    int teacherMain_Category_Subject(TeacherVO teacherVO);
 
     /**
      * 강사 소개 카테고리 과목
      */
-    int teacherIntro_Category_Subject(Object obj);
+    int teacherIntro_Category_Subject(TeacherVO teacherVO);
 
     /**
      * 강사 소개 F 카테고리 과목
      */
-    int teacherIntro_F_Category_Subject(Object obj);
+    int teacherIntro_F_Category_Subject(TeacherVO teacherVO);
 
     /**
      * 강사 소개 목록 조회
      */
-    List<HashMap<String, String>> teacherIntroList(HashMap<String, String> params);
+    List<HashMap<String, String>> teacherIntroList(TeacherVO teacherVO);
 
     /**
      * 강사 소개 목록 카운트
      */
-    int teacherIntroListCount(HashMap<String, String> params);
+    int teacherIntroListCount(TeacherVO teacherVO);
 
     /**
      * 강사 소개 OFF 목록 조회
      */
-    List<HashMap<String, String>> teacherIntro_offList(HashMap<String, String> params);
+    List<HashMap<String, String>> teacherIntro_offList(TeacherVO teacherVO);
 
     /**
      * 강사 소개 OFF 목록 카운트
      */
-    int teacherIntro_offListCount(HashMap<String, String> params);
+    int teacherIntro_offListCount(TeacherVO teacherVO);
 
     /**
      * 강사 전체 목록 카운트
      */
-    int teacherAllListCount(HashMap<String, String> params);
+    int teacherAllListCount(TeacherVO teacherVO);
 }

--- a/src/main/java/com/academy/productorder/service/ProductOrderVO.java
+++ b/src/main/java/com/academy/productorder/service/ProductOrderVO.java
@@ -13,13 +13,9 @@ public class ProductOrderVO extends CommonVO implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    // 페이징 및 검색 관련
-    private int currentPage = 1;
-    private int pageRow = 10;
-    private int startNo;
-    private int endNo;
-    private String searchText;
-    private String searchType;
+    // 페이징 및 검색 관련 (int 타입 - CommonVO의 String 타입과 별도 사용)
+    private int startNoInt;
+    private int endNoInt;
     private String schtype;
     private String keyword;
     private String searchkey;
@@ -56,10 +52,8 @@ public class ProductOrderVO extends CommonVO implements Serializable {
     private String zipCode;
     private String address1;
     private String address2;
-    private Date regDt;
-    private String regId;
-    private Date updDt;
-    private String updId;
+    private Date regDtDate;
+    private Date updDtDate;
 
     // 결제 정보
     private Integer price;
@@ -209,36 +203,20 @@ public class ProductOrderVO extends CommonVO implements Serializable {
         this.address2 = address2;
     }
 
-    public Date getRegDt() {
-        return regDt;
+    public Date getRegDtDate() {
+        return regDtDate;
     }
 
-    public void setRegDt(Date regDt) {
-        this.regDt = regDt;
+    public void setRegDtDate(Date regDtDate) {
+        this.regDtDate = regDtDate;
     }
 
-    public String getRegId() {
-        return regId;
+    public Date getUpdDtDate() {
+        return updDtDate;
     }
 
-    public void setRegId(String regId) {
-        this.regId = regId;
-    }
-
-    public Date getUpdDt() {
-        return updDt;
-    }
-
-    public void setUpdDt(Date updDt) {
-        this.updDt = updDt;
-    }
-
-    public String getUpdId() {
-        return updId;
-    }
-
-    public void setUpdId(String updId) {
-        this.updId = updId;
+    public void setUpdDtDate(Date updDtDate) {
+        this.updDtDate = updDtDate;
     }
 
     public Integer getPrice() {
@@ -657,53 +635,21 @@ public class ProductOrderVO extends CommonVO implements Serializable {
         this.priceSts = priceSts;
     }
 
-    // 페이징 및 검색 관련 getter/setter
-    public int getCurrentPage() {
-        return currentPage;
+    // 페이징 및 검색 관련 getter/setter (int 타입 별도 사용)
+    public int getStartNoInt() {
+        return startNoInt;
     }
 
-    public void setCurrentPage(int currentPage) {
-        this.currentPage = currentPage;
+    public void setStartNoInt(int startNoInt) {
+        this.startNoInt = startNoInt;
     }
 
-    public int getPageRow() {
-        return pageRow;
+    public int getEndNoInt() {
+        return endNoInt;
     }
 
-    public void setPageRow(int pageRow) {
-        this.pageRow = pageRow;
-    }
-
-    public int getStartNo() {
-        return startNo;
-    }
-
-    public void setStartNo(int startNo) {
-        this.startNo = startNo;
-    }
-
-    public int getEndNo() {
-        return endNo;
-    }
-
-    public void setEndNo(int endNo) {
-        this.endNo = endNo;
-    }
-
-    public String getSearchText() {
-        return searchText;
-    }
-
-    public void setSearchText(String searchText) {
-        this.searchText = searchText;
-    }
-
-    public String getSearchType() {
-        return searchType;
-    }
-
-    public void setSearchType(String searchType) {
-        this.searchType = searchType;
+    public void setEndNoInt(int endNoInt) {
+        this.endNoInt = endNoInt;
     }
 
     public String getSchtype() {

--- a/src/main/resources/mapper/lectureFormSQL.xml
+++ b/src/main/resources/mapper/lectureFormSQL.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.academy.mapper.FormMapper">
 
-	<select id="formList" parameterType="hashMap" resultType="hashMap">
+	<select id="formList" parameterType="com.academy.lecture.service.FormVO" resultType="hashMap">
 		SELECT * FROM 	(
 			SELECT A.*, ROWNUM rnum
 		  	FROM (
@@ -36,7 +36,7 @@
 		WHERE rnum &gt; #{startNo}
 	</select>
 
-	<select id="formListCount" parameterType="hashMap" resultType="int">
+	<select id="formListCount" parameterType="com.academy.lecture.service.FormVO" resultType="int">
 		SELECT
 			COUNT(CODE)
 		FROM TB_LEARNING_FORM_INFO
@@ -65,7 +65,7 @@
 		FROM TB_LEARNING_FORM_INFO
 	</select>
 
-	<select id="getCodeList" parameterType="hashMap" resultType="hashMap">
+	<select id="getCodeList" parameterType="com.academy.lecture.service.FormVO" resultType="hashMap">
 		SELECT
 			SYS_CD, SYS_NM, CODE_NO, CODE_CD, CODE_NM, CODE_VAL, CODE_INFO, ISUSE
 		FROM TB_BA_CONFIG_CD
@@ -81,12 +81,12 @@
 		</if>
 	</select>
 
-	<insert id="formInsert" parameterType="hashMap" flushCache="true">
+	<insert id="formInsert" parameterType="com.academy.lecture.service.FormVO" flushCache="true">
 		INSERT INTO TB_LEARNING_FORM_INFO(LEC_DIV, CODE, NAME, ISUSE, REG_DT, REG_ID, UPD_DT, UPD_ID)
 		VALUES (#{LEC_DIV}, #{CODE}, #{NAME}, #{ISUSE}, SYSDATE, #{REG_ID}, SYSDATE, #{UPD_ID})
 	</insert>
 
-	<select id="formView" parameterType="hashMap" resultType="hashMap">
+	<select id="formView" parameterType="com.academy.lecture.service.FormVO" resultType="hashMap">
 		SELECT
 			LEC_DIV, (SELECT CODE_NM FROM TB_BA_CONFIG_CD WHERE SYS_CD = 'LEC_FORM' AND CODE_CD = AA.LEC_DIV) AS LEC_DIVNM
 			, CODE, NAME, ISUSE
@@ -96,7 +96,7 @@
 		WHERE CODE = #{CODE}
 	</select>
 
-	<update id="formUpdate" parameterType="hashMap">
+	<update id="formUpdate" parameterType="com.academy.lecture.service.FormVO">
 		UPDATE TB_LEARNING_FORM_INFO
 		SET
 			LEC_DIV = #{LEC_DIV}
@@ -107,7 +107,7 @@
 		WHERE CODE = #{CODE}
 	</update>
 
-	<delete id="formDelete" parameterType="hashMap">
+	<delete id="formDelete" parameterType="com.academy.lecture.service.FormVO">
 		UPDATE TB_LEARNING_FORM_INFO
 		SET ISUSE = 'N'
 		WHERE CODE = #{CODE}
@@ -117,7 +117,7 @@
 		-->
 	</delete>
 
-	<select id="formCheck" parameterType="hashMap" resultType="int">
+	<select id="formCheck" parameterType="com.academy.lecture.service.FormVO" resultType="int">
 		SELECT
 			COUNT(CODE)
 		FROM TB_LEARNING_FORM_INFO

--- a/src/main/resources/mapper/lectureKindSQL.xml
+++ b/src/main/resources/mapper/lectureKindSQL.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.academy.mapper.KindMapper">
 
-  <select id="kindList" parameterType="hashMap" resultType="hashMap">
+  <select id="kindList" parameterType="com.academy.lecture.service.KindVO" resultType="hashMap">
     SELECT * FROM   (
       SELECT A.*, ROWNUM rnum
         FROM (
@@ -46,7 +46,7 @@
     WHERE rnum &gt; #{startNo}
   </select>
 
-  <select id="kindListCount" parameterType="hashMap" resultType="int">
+  <select id="kindListCount" parameterType="com.academy.lecture.service.KindVO" resultType="int">
     SELECT
       COUNT(CODE)
     FROM TB_CATEGORY_INFO
@@ -74,7 +74,7 @@
     </if>
   </select>
 
-  <insert id="kindInsert" parameterType="hashMap" flushCache="true">
+  <insert id="kindInsert" parameterType="com.academy.lecture.service.KindVO" flushCache="true">
     INSERT INTO TB_CATEGORY_INFO(
         ID, CODE, NAME, ISUSE, USE_ON, USE_OFF
         , REG_DT, REG_ID, UPD_DT, UPD_ID
@@ -96,7 +96,7 @@
     )
   </insert>
 
-  <select id="kindView" parameterType="hashMap" resultType="hashMap">
+  <select id="kindView" parameterType="com.academy.lecture.service.KindVO" resultType="hashMap">
     SELECT
       ID, CODE, NAME, ISUSE, DECODE(ISUSE, 'Y', '활성', 'N', '비활성') ISUSENM
       , USE_ON, USE_OFF
@@ -108,7 +108,7 @@
     AND P_CODE = 'CLASSCODE'
   </select>
 
-  <update id="kindUpdate" parameterType="hashMap">
+  <update id="kindUpdate" parameterType="com.academy.lecture.service.KindVO">
     UPDATE TB_CATEGORY_INFO
     SET
       NAME = #{NAME}
@@ -121,7 +121,7 @@
     WHERE CODE = #{CODE}
   </update>
 
-  <delete id="kindDelete" parameterType="hashMap">
+  <delete id="kindDelete" parameterType="com.academy.lecture.service.KindVO">
     UPDATE TB_CATEGORY_INFO
     SET ISUSE = 'N'
     WHERE CODE = #{CODE}
@@ -131,7 +131,7 @@
     -->
   </delete>
 
-  <select id="kindCheck" parameterType="hashMap" resultType="int">
+  <select id="kindCheck" parameterType="com.academy.lecture.service.KindVO" resultType="int">
     SELECT
       COUNT(CODE)
     FROM TB_CATEGORY_INFO
@@ -141,14 +141,14 @@
     </if>
   </select>
     
-	<update id="SeqUpdate" parameterType="hashMap">  
+	<update id="SeqUpdate" parameterType="com.academy.lecture.service.KindVO">  
 
 			UPDATE TB_CATEGORY_INFO 
 			SET ORDR = #{NUM} WHERE NAME = #{CODE_NM} AND CODE = #{CODE}
 				
 	</update>
     
-    <select id="selectKindCode" parameterType="hashMap" resultType="hashMap">
+    <select id="selectKindCode" parameterType="com.academy.lecture.service.KindVO" resultType="hashMap">
         SELECT
             CODE, NAME
         FROM TB_CATEGORY_INFO
@@ -179,14 +179,14 @@
         CONNECT BY PRIOR CODE = P_CODE
     </select>
 
-    <select id="getMaxOrdr" parameterType="hashMap" resultType="hashMap">
+    <select id="getMaxOrdr" parameterType="com.academy.lecture.service.KindVO" resultType="hashMap">
     SELECT
         ( SELECT (NVL(MAX(ORDR), 0) + 1)  ORDR FROM TB_CATEGORY_INFO WHERE P_CODE=#{CODE}) AS ORDR
         , ( SELECT NAME FROM TB_CATEGORY_INFO WHERE CODE=#{CODE}) AS P_NAME
     FROM DUAL
     </select>
 
-    <select id="getKindList" parameterType="hashMap" resultType="hashMap">
+    <select id="getKindList" parameterType="com.academy.lecture.service.KindVO" resultType="hashMap">
         <if test='SEARCHGUBN == "T"'>
             SELECT
                 ID, CODE, NAME, ISUSE, DECODE(ISUSE, 'Y', '활성', 'N', '비활성') ISUSENM

--- a/src/main/resources/mapper/lectureLectureSQL.xml
+++ b/src/main/resources/mapper/lectureLectureSQL.xml
@@ -9,7 +9,7 @@
 	</resultMap>
 
 <!-- 단과 start -->
-	<select id="lectureList" parameterType="hashMap" resultType="hashMap">
+	<select id="lectureList" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 	    SELECT TBL.*
 	    FROM (SELECT A.*, ROWNUM RNUM
 	          FROM (SELECT TBL.*, 
@@ -107,7 +107,7 @@
 	        WHERE RNUM <![CDATA[ > ]]> #{startNo}
 	</select>
 	
-	<select id="lectureListCount" parameterType="hashMap" resultType="int">
+	<select id="lectureListCount" parameterType="com.academy.lecture.service.LectureVO" resultType="int">
 		SELECT COUNT(TBL.LECCODE) FROM (	
 	                SELECT LM.SEQ, LM.LEC_TYPE_CHOICE, LM.LECCODE, AA.BRIDGE_LECCODE, LM.SUBJECT_OPTION,
 	                               LM.CATEGORY_CD, (SELECT NAME FROM TB_CATEGORY_INFO WHERE CODE = LM.CATEGORY_CD) AS CATEGORY_NM,
@@ -197,7 +197,7 @@
 	                    </if>        
 	</select>
 
-	<select id="bookList" parameterType="hashMap" resultType="hashMap">
+	<select id="bookList" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT LTBL.*
 			,(SELECT NAME FROM TB_CATEGORY_INFO WHERE ISUSE = 'Y' AND CODE = LTBL.CATEGORY_CD) CATEGORY_NM
 			,(SELECT NAME FROM TB_LEARNING_FORM_INFO WHERE ISUSE = 'Y' AND CODE = LTBL.LEARNING_CD) LEARNING_NM
@@ -223,7 +223,7 @@
 		WHERE rnum &gt; #{startNo}
 	</select>
 
-	<select id="bookListCount" parameterType="hashMap" resultType="int">
+	<select id="bookListCount" parameterType="com.academy.lecture.service.LectureVO" resultType="int">
 		SELECT
 		  COUNT(RSC_ID)
 		FROM TB_CA_BOOK WHERE USE_YN = 'Y'
@@ -238,29 +238,29 @@
 		</if>
 	</select>
 
-	<select id="getBridgeLeccodeSeq" parameterType="hashMap" resultType="hashMap">
+	<select id="getBridgeLeccodeSeq" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT TO_CHAR(NVL(MAX(seq),0)+1) AS SEQ FROM TB_LEC_BRIDGE
 	</select>
 
-	<select id="getJongLeccodeSeq" parameterType="hashMap" resultType="hashMap">
+	<select id="getJongLeccodeSeq" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT TO_CHAR(NVL(MAX(seq),0)+1) AS SEQ FROM TB_LEC_JONG
 	</select>
 
-	<select id="getLeccode" parameterType="hashMap" resultType="hashMap">
+	<select id="getLeccode" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT
   			TO_CHAR(NVL(MAX(substr(LECCODE,6,5)),0)+1,'00000') LECCODE
 		FROM TB_LEC_MST
 		WHERE LECCODE LIKE '%'||#{PREFIX}||'%'
 	</select>
 
-	<select id="getBridgeLeccode" parameterType="hashMap" resultType="hashMap">
+	<select id="getBridgeLeccode" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT
 			TO_CHAR(NVL(MAX(substr(BRIDGE_LECCODE,6,5)),0)+1,'00000') BRIDGE_LECCODE
 		FROM TB_LEC_BRIDGE
 		WHERE BRIDGE_LECCODE LIKE '%'||#{PREFIX}||'%'
 	</select>
 
-	<insert id="lectureInsert" parameterType="hashMap" flushCache="true">
+	<insert id="lectureInsert" parameterType="com.academy.lecture.service.LectureVO" flushCache="true">
 		INSERT INTO TB_LEC_MST(SEQ, LECCODE, CATEGORY_CD, LEARNING_CD, SUBJECT_TEACHER, SUBJECT_TEACHER_PAYMENT
 									 	<if test='ORG_LECCODE != null and ORG_LECCODE != ""'>
 										, ORG_LECCODE
@@ -293,12 +293,12 @@
 		)
 	</insert>
 
-	<insert id="lectureBridgeInsert" parameterType="hashMap" flushCache="true">
+	<insert id="lectureBridgeInsert" parameterType="com.academy.lecture.service.LectureVO" flushCache="true">
 		INSERT INTO TB_LEC_BRIDGE(SEQ, BRIDGE_LECCODE, LECCODE, REG_DT, REG_ID, UPD_DT, UPD_ID)
 		VALUES (#{SEQ}, #{BRIDGE_LECCODE}, #{LECCODE}, SYSDATE, #{REG_ID}, SYSDATE, #{UPD_ID})
 	</insert>
 
-	<insert id="lectureBookInsert" parameterType="hashMap" flushCache="true" statementType="CALLABLE">
+	<insert id="lectureBookInsert" parameterType="com.academy.lecture.service.LectureVO" flushCache="true" statementType="CALLABLE">
 
 		CALL SP_LECTURE_BOOK_INSERT(
 		        #{LECCODE, mode=IN},
@@ -308,12 +308,12 @@
 		        #{result, jdbcType=INTEGER, mode=OUT})
 	</insert>
 
-	<insert id="lectureBookInsert2" parameterType="hashMap" flushCache="true">
+	<insert id="lectureBookInsert2" parameterType="com.academy.lecture.service.LectureVO" flushCache="true">
 		INSERT INTO TB_PLUS_CA_BOOK(IDX, LECCODE, RSC_ID, FLAG)
 		VALUES ((SELECT NVL(MAX(IDX),0)+1 FROM TB_PLUS_CA_BOOK), #{LECCODE}, #{RSC_ID}, #{FLAG})
 	</insert>
 
-	<select id="lectureViewList" parameterType="hashMap" resultType="hashMap">
+	<select id="lectureViewList" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT
 	      (SELECT COUNT(C.ORDERNO) FROM TB_LEC_MST B LEFT OUTER JOIN
 	        (SELECT A.* FROM TB_ORDER_MGNT_NO A INNER JOIN
@@ -368,7 +368,7 @@
 		ORDER BY T2.CATEGORY_CD
 	</select>
 
-	<select id="lectureView" parameterType="hashMap" resultMap="lectureMap">
+	<select id="lectureView" parameterType="com.academy.lecture.service.LectureVO" resultMap="lectureMap">
 		SELECT
 			TBL.*, (SELECT NO FROM TB_CHOICE_JONG_NO WHERE LECCODE = TBL.LECCODE AND CATEGORY_CD = TBL.CATEGORY_CD) AS NO
 			, T2.SEQ AS BSEQ, T2.BRIDGE_LECCODE
@@ -380,7 +380,7 @@
 		WHERE TBL.LECCODE = #{LECCODE}
 	</select>
 
-	<select id="lectureViewBookList" parameterType="hashMap" resultType="hashMap">
+	<select id="lectureViewBookList" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT
 		  AA.*
 		  ,(SELECT NAME FROM TB_CATEGORY_INFO WHERE ISUSE = 'Y' AND CODE = BB.CATEGORY_CD) CATEGORY_NM
@@ -390,7 +390,7 @@
 		ON AA.RSC_ID = BB.RSC_ID WHERE AA.LECCODE = #{LECCODE}
 	</select>
 
-	<update id="lectureUpdate" parameterType="hashMap">
+	<update id="lectureUpdate" parameterType="com.academy.lecture.service.LectureVO">
 		UPDATE TB_LEC_MST
 			SET
 				LEARNING_CD = #{LEARNING_CD}
@@ -456,33 +456,33 @@
 		    </if>
 	</update>
 
-	<delete id="lectureBookDelete" parameterType="hashMap" flushCache="true">
+	<delete id="lectureBookDelete" parameterType="com.academy.lecture.service.LectureVO" flushCache="true">
 		DELETE FROM TB_PLUS_CA_BOOK
 		<if test='UPDATE_FLAG == "ALL" '>WHERE LECCODE IN (SELECT LECCODE FROM TB_LEC_BRIDGE WHERE BRIDGE_LECCODE = #{BRIDGE_LEC} )</if>
 		<if test='UPDATE_FLAG != "ALL" '>WHERE LECCODE = #{LECCODE}</if>
 
 	</delete>
 
-	<delete id="lectureIsUseUpdate" parameterType="hashMap" flushCache="true">
+	<delete id="lectureIsUseUpdate" parameterType="com.academy.lecture.service.LectureVO" flushCache="true">
 		UPDATE TB_LEC_MST SET SUBJECT_ISUSE = 'N' WHERE LECCODE = #{LECCODE}
 		<!-- DELETE FROM TB_LEC_MST WHERE LECCODE = #{LECCODE} -->
 	</delete>
 
-	<delete id="lectureDelete" parameterType="hashMap" flushCache="true">
+	<delete id="lectureDelete" parameterType="com.academy.lecture.service.LectureVO" flushCache="true">
 		DELETE FROM TB_LEC_MST WHERE LECCODE = #{LECCODE}
 	</delete>
 
-	<delete id="lectureBridgeDelete" parameterType="hashMap" flushCache="true">
+	<delete id="lectureBridgeDelete" parameterType="com.academy.lecture.service.LectureVO" flushCache="true">
 		DELETE FROM TB_LEC_BRIDGE WHERE BRIDGE_LECCODE = #{BRIDGE_LECCODE} AND LECCODE = #{LECCODE}
 	</delete>
 
-	<update id="lecMovUpdate" parameterType="hashMap">
+	<update id="lecMovUpdate" parameterType="com.academy.lecture.service.LectureVO">
 		UPDATE TB_LEC_MST
 			SET MOV_ING = #{MOV_ING}
 			WHERE LECCODE IN (SELECT LECCODE FROM TB_LEC_BRIDGE WHERE BRIDGE_LECCODE = #{BRIDGE_LECCODE})
 	</update>
 
-	<select id="lectureSeqList" parameterType="hashMap" resultType="hashMap">
+	<select id="lectureSeqList" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		<if test='LEC_TYPE_CHOICE == "D"'>
 			SELECT TBL.* FROM (
 				SELECT T1.BRIDGE_LECCODE, T2.*
@@ -545,13 +545,13 @@
 	 	ORDER BY TBL.SEQ DESC
 	</select>
 
-	<update id="lectureSeqUpdate" parameterType="hashMap">
+	<update id="lectureSeqUpdate" parameterType="com.academy.lecture.service.LectureVO">
 		UPDATE TB_LEC_MST SET SEQ = #{SEQ} WHERE LECCODE = #{LECCODE}
 	</update>
 <!-- 단과 end -->
 
 <!-- 종합반 start -->
-    <select id="lectureViewJongList" parameterType="hashMap" resultType="hashMap">
+    <select id="lectureViewJongList" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT
 			LTBL.*
 			,	(SELECT
@@ -661,7 +661,7 @@
 			) LTBL
 	</select>
     
-    <select id="lectureJongList" parameterType="hashMap" resultType="hashMap">
+    <select id="lectureJongList" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT
 			LTBL.*
 			,	(SELECT
@@ -807,7 +807,7 @@
 		WHERE rnum <![CDATA[ > ]]> #{startNo}
 	</select>
 
-    <select id="lectureJongListCount" parameterType="hashMap" resultType="int">
+    <select id="lectureJongListCount" parameterType="com.academy.lecture.service.LectureVO" resultType="int">
         SELECT
             COUNT(TBL.LECCODE)
         FROM
@@ -849,7 +849,7 @@
         </if>
     </select>
     
-    <select id="lectureYearList" parameterType="hashMap" resultType="hashMap">
+    <select id="lectureYearList" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT LTBL.* 
 	    FROM (
  		  	     SELECT LTB.*, ROWNUM rnum
@@ -913,7 +913,7 @@
 		WHERE rnum <![CDATA[ > ]]> #{startNo}
 	</select>
 
-    <select id="lectureYearListCount" parameterType="hashMap" resultType="int">
+    <select id="lectureYearListCount" parameterType="com.academy.lecture.service.LectureVO" resultType="int">
         SELECT
             COUNT(AA.LECCODE)
 					FROM TB_LEC_MST AA
@@ -936,7 +936,7 @@
 					</if>
     </select>
 
-    <select id="lectureJongList_All" parameterType="hashMap" resultType="hashMap">
+    <select id="lectureJongList_All" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
         SELECT
             LTBL.*
 			,	(SELECT
@@ -1082,14 +1082,14 @@
 		WHERE rnum <![CDATA[ > ]]> #{startNo}
 	</select>
 
-	<select id="lectureJongView" parameterType="hashMap" resultMap="lectureMap">
+	<select id="lectureJongView" parameterType="com.academy.lecture.service.LectureVO" resultMap="lectureMap">
 		SELECT
 			TBL.*, (SELECT NO FROM TB_CHOICE_JONG_NO WHERE LECCODE = TBL.LECCODE AND CATEGORY_CD = TBL.CATEGORY_CD) AS NO
 		FROM TB_LEC_MST TBL
 		WHERE TBL.LECCODE = #{LECCODE}
 	</select>
 
-	<select id="lectureJongSubjectList" parameterType="hashMap" resultType="hashMap">
+	<select id="lectureJongSubjectList" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT * FROM 	(
 			SELECT A.*, ROWNUM rnum
 		  	FROM (
@@ -1138,7 +1138,7 @@
 		WHERE rnum &gt; #{startNo}
 	</select>
 
-	<select id="lectureJongSubjectListCount" parameterType="hashMap" resultType="int">
+	<select id="lectureJongSubjectListCount" parameterType="com.academy.lecture.service.LectureVO" resultType="int">
   		SELECT COUNT(TBL.LECCODE) FROM (
 			SELECT T1.*
 				, (SELECT NAME FROM TB_CATEGORY_INFO WHERE CODE = T1.CATEGORY_CD) AS CATEGORY_NM
@@ -1179,12 +1179,12 @@
         </if>
 	</select>
 
-	<insert id="lectureLecJongInsert" parameterType="hashMap" flushCache="true">
+	<insert id="lectureLecJongInsert" parameterType="com.academy.lecture.service.LectureVO" flushCache="true">
 		INSERT INTO TB_LEC_JONG(SEQ, LECCODE, MST_LECCODE, SORT, GUBUN, REG_DT, REG_ID, UPD_DT, UPD_ID)
 		VALUES (#{SEQ}, #{LECCODE}, #{MST_LECCODE}, #{SORT}, #{GUBUN}, SYSDATE, #{REG_ID}, SYSDATE, #{UPD_ID})
 	</insert>
 
-	<select id="lectureViewLeccodeList" parameterType="hashMap" resultType="hashMap">
+	<select id="lectureViewLeccodeList" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT
 		  T1.MST_LECCODE, T1.SORT, T1.GUBUN
 		  , TBL.*
@@ -1198,11 +1198,11 @@
 		ORDER BY T1.SORT ASC
 	</select>
 
-	<delete id="lectureLecJongDelete" parameterType="hashMap" flushCache="true">
+	<delete id="lectureLecJongDelete" parameterType="com.academy.lecture.service.LectureVO" flushCache="true">
 		DELETE FROM TB_LEC_JONG WHERE LECCODE = #{LECCODE}
 	</delete>
 
-	<delete id="lectureChoiceJongNoDelete" parameterType="hashMap" flushCache="true">
+	<delete id="lectureChoiceJongNoDelete" parameterType="com.academy.lecture.service.LectureVO" flushCache="true">
 		DELETE FROM TB_CHOICE_JONG_NO WHERE LECCODE = #{LECCODE}
 	</delete>
 
@@ -1211,18 +1211,18 @@
 
 <!-- 선택형 종합반 start -->
 
-	<insert id="lectureChoiceJongNoInsert" parameterType="hashMap" flushCache="true">
+	<insert id="lectureChoiceJongNoInsert" parameterType="com.academy.lecture.service.LectureVO" flushCache="true">
 		INSERT INTO TB_CHOICE_JONG_NO(SEQ, LECCODE, NO, CATEGORY_CD)
 		VALUES (#{SEQ}, #{LECCODE}, #{NO}, #{CATEGORY_CD})
 	</insert>
 
 <!-- 선택형 종합반 end -->
 
-	<select id="lectureDeleteCheck" parameterType="hashMap" resultType="int">
+	<select id="lectureDeleteCheck" parameterType="com.academy.lecture.service.LectureVO" resultType="int">
 		SELECT COUNT(*) FROM TB_ORDER_MGNT_NO WHERE MGNTNO = #{LECCODE} AND STATUSCODE = 'DLV105'
 	</select>
 
-	<select id="lecturePayList" parameterType="hashMap" resultType="hashMap">
+	<select id="lecturePayList" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT C.USERID                                                              AS USERID
 		      ,(SELECT USER_NM  FROM TB_MA_MEMBER WHERE USER_ID = C.USERID)          AS USER_NM
 		      ,(SELECT PHONE_NO FROM TB_MA_MEMBER WHERE USER_ID = C.USERID)          AS PHONE_NO
@@ -1270,7 +1270,7 @@
 		ORDER BY B.STATUSCODE
 	</select>
 	
-	<select id="lectureFreePassPayList" parameterType="hashMap" resultType="hashMap">
+	<select id="lectureFreePassPayList" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT D.USER_ID, D.USER_NM, D.PHONE_NO,
 		       C.START_DATE, C.END_DATE, 
 		       (SELECT CODE_NM FROM TB_BA_CONFIG_CD WHERE CODE_VAL = B.STATUSCODE) AS STATUSCODE_NM,
@@ -1303,7 +1303,7 @@
 		ORDER BY B.ISCONFIRM DESC
 	</select>
 	
-	<select id="lectureJongPayList" parameterType="hashMap" resultType="hashMap">
+	<select id="lectureJongPayList" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT C.USERID                                                              AS USERID
 		      ,(SELECT USER_NM  FROM TB_MA_MEMBER WHERE USER_ID = C.USERID)          AS USER_NM
 		      ,(SELECT PHONE_NO FROM TB_MA_MEMBER WHERE USER_ID = C.USERID)          AS PHONE_NO
@@ -1354,7 +1354,7 @@
 		ORDER BY C.LECTURE_NO, B.STATUSCODE
 	</select>
 
-	<select id="lectureDataViewList" parameterType="hashMap" resultType="hashMap">
+	<select id="lectureDataViewList" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT B.SUBJECT_OPTION
 		      ,B.BRIDGE_LECCODE
 		      ,A.MOVIE_NAME
@@ -1405,7 +1405,7 @@
 		ORDER BY A.MOVIE_ORDER1, A.MOVIE_ORDER2
 
 	</select>
-	<select id="lectureMobileList" parameterType="hashMap" resultType="hashMap">
+	<select id="lectureMobileList" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT B.SUBJECT_OPTION
 		      ,B.BRIDGE_LECCODE
 		      ,A.MOVIE_NAME
@@ -1451,7 +1451,7 @@
 
 	</select>
 
-	<select id="lectureOnDetailS" parameterType="hashMap" resultMap="lectureMap">
+	<select id="lectureOnDetailS" parameterType="com.academy.lecture.service.LectureVO" resultMap="lectureMap">
         SELECT TBL.*
         FROM (
             SELECT A.LECCODE, A.CATEGORY_CD, A.LEARNING_CD, A.LEC_TYPE_CHOICE, A.SUBJECT_TITLE, A.SUBJECT_DESC, A.SUBJECT_MEMO,
@@ -1474,7 +1474,7 @@
  		) TBL WHERE TBL.LECCODE = #{LECCODE}
 	</select>
 
-	<insert id="insertPmpDownLog" parameterType="hashMap" flushCache="true">
+	<insert id="insertPmpDownLog" parameterType="com.academy.lecture.service.LectureVO" flushCache="true">
 		INSERT INTO TB_PMP_DOWNLOG(
 			IDX,
 			USERID,
@@ -1491,7 +1491,7 @@
 		)
 	</insert>
 
-	<select id="lectureDataMemoViewList" parameterType="hashMap" resultType="hashMap">
+	<select id="lectureDataMemoViewList" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT  NVL(BRIDGE_LECCODE,'')  AS RLECCODE
 		       ,MOVIE_ORDER1            AS MOVIE_ORDER1
 		       ,MOVIE_ORDER2            AS MOVIE_ORDER2
@@ -1502,7 +1502,7 @@
 		ORDER BY MOVIE_ORDER1 , MOVIE_ORDER2 ASC , POSITION DESC
 	</select>
 
-	<select id="lectureDataMovieViewList" parameterType="hashMap" resultType="hashMap">
+	<select id="lectureDataMovieViewList" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT B.SUBJECT_OPTION
 		      ,B.BRIDGE_LECCODE
 		      ,A.MOVIE_NAME
@@ -1544,7 +1544,7 @@
 		ORDER BY A.MOVIE_ORDER1, A.MOVIE_ORDER2
 	</select>
 
-	<select id="lectureDataMovieList" parameterType="hashMap" resultType="hashMap">
+	<select id="lectureDataMovieList" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT B.SUBJECT_OPTION
 		      ,B.BRIDGE_LECCODE
 		      ,A.MOVIE_NO
@@ -1586,7 +1586,7 @@
 		ORDER BY A.MOVIE_ORDER1, A.MOVIE_ORDER2
 	</select>
 
-	<insert id="lectureMovieInsert" parameterType="hashMap" flushCache="true">
+	<insert id="lectureMovieInsert" parameterType="com.academy.lecture.service.LectureVO" flushCache="true">
 		INSERT INTO TB_MOVIE(MOVIE_NO, LECCODE, MOVIE_NAME, MOVIE_DESC
 							, MOVIE_DATA_FILE_YN, MOVIE_DATA_FILENAME
 		                    , MOVIE_TIME, MOVIE_ORDER1, MOVIE_ORDER2, MOVIE_FREE_FLAG
@@ -1699,11 +1699,11 @@
 		          , 'Y')
 	</insert>
 
-	<delete id="lectureMovieDelete" parameterType="hashMap" flushCache="true">
+	<delete id="lectureMovieDelete" parameterType="com.academy.lecture.service.LectureVO" flushCache="true">
 		DELETE FROM TB_MOVIE WHERE MOVIE_NO = #{MOVIE_NO}
 	</delete>
 
-	<update id="lectureMovieUpdate" parameterType="hashMap">
+	<update id="lectureMovieUpdate" parameterType="com.academy.lecture.service.LectureVO">
 		UPDATE TB_MOVIE SET
 			MOVIE_NAME = #{MOVIE_NAME}
 			, MOVIE_ORDER1 = #{MOVIE_ORDER1}
@@ -1829,7 +1829,7 @@
 	</update>
 
 
-	<update id="lectureMovieFileDelete" parameterType="hashMap">
+	<update id="lectureMovieFileDelete" parameterType="com.academy.lecture.service.LectureVO">
 		UPDATE TB_MOVIE SET
 			MOVIE_DATA_FILE_YN = 'N'
 			, MOVIE_DATA_FILENAME = ''
@@ -1837,23 +1837,23 @@
 	</update>
 
 
-	<insert id="lectureMovieMemoInsert" parameterType="hashMap" flushCache="true">
+	<insert id="lectureMovieMemoInsert" parameterType="com.academy.lecture.service.LectureVO" flushCache="true">
 		INSERT INTO TB_LEC_MST_MEMO(BRIDGE_LECCODE, MOVIE_ORDER1, MOVIE_ORDER2, POSITION, MST_TEXT)
 		VALUES(#{BRIDGE_LECCODE}, #{MOVIE_ORDER1}, #{MOVIE_ORDER2}, #{POSITION}, #{MST_TEXT})
 	</insert>
 
-	<update id="lectureMovieMemoUpdate" parameterType="hashMap">
+	<update id="lectureMovieMemoUpdate" parameterType="com.academy.lecture.service.LectureVO">
 		UPDATE TB_LEC_MST_MEMO SET
 			MST_TEXT = #{MST_TEXT}
 		WHERE BRIDGE_LECCODE = #{BRIDGE_LECCODE} AND MOVIE_ORDER1 = #{MOVIE_ORDERS1} AND MOVIE_ORDER2 = #{MOVIE_ORDERS2}
 	</update>
 
-	<delete id="lectureMovieMemoDelete" parameterType="hashMap" flushCache="true">
+	<delete id="lectureMovieMemoDelete" parameterType="com.academy.lecture.service.LectureVO" flushCache="true">
 		DELETE FROM TB_LEC_MST_MEMO WHERE BRIDGE_LECCODE = #{BRIDGE_LECCODE} AND MOVIE_ORDER1 = #{MOVIE_ORDER1} AND MOVIE_ORDER2 = #{MOVIE_ORDER2} AND POSITION = #{POSITION}
 	</delete>
 
 
-	<select id="playinfo" parameterType="hashMap" resultType="hashMap">
+	<select id="playinfo" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		select subject_option,
 		a.leccode as rleccode, a.movie_no,a.movie_name,a.movie_desc,nvl(a.movie_url,'')as movie_url,nvl(a.wide_url,'')as wide_url,nvl(a.movie_filename1, '') as movie_filename1,nvl(a.movie_filename4, '') as movie_filename4,nvl(a.mp4_url,'')as mp4_url,nvl(a.movie_filename2, '') as movie_filename2,nvl(a.movie_filename3, '') as movie_filename3,a.movie_data_file_yn,a.movie_data_filename,a.movie_time,a.movie_order1,a.movie_order2,
 		a.movie_free_flag,nvl(a.pmp_url, '') as pmp_url,nvl(a.pmp_filename, '') as pmp_filename, nvl(b.subject_vod_default_path, '') as subject_vod_default_path, nvl(b.subject_wide_default_path, '') as subject_wide_default_path,nvl(b.subject_pmp_default_path, '') as subject_pmp_default_path, b.subject_price, nvl(a.stop,'N') as stop
@@ -1870,7 +1870,7 @@
 		order by a.movie_order1 , a.movie_order2 asc
 	</select>
 
-	<select id="getCbMovie4_free_admin" parameterType="hashMap" resultType="hashMap">
+	<select id="getCbMovie4_free_admin" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT * FROM 	(
 			SELECT A.*, ROWNUM rnum
 		  	FROM (
@@ -1892,7 +1892,7 @@
 		WHERE rnum &gt; #{startNo}
 	</select>
 
-	<select id="getCbMovie4_free_admin_count" parameterType="hashMap" resultType="int">
+	<select id="getCbMovie4_free_admin_count" parameterType="com.academy.lecture.service.LectureVO" resultType="int">
 		select  count(b.subject_option)
 		from
 		TB_MOVIE a ,
@@ -1905,22 +1905,22 @@
 		order by a.movie_order1 , a.movie_order2 asc
 	</select>
 
-	<select id="BridgeLeccode" parameterType="hashMap" resultType="hashMap">
+	<select id="BridgeLeccode" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT LECCODE FROM TB_LEC_BRIDGE
 		WHERE BRIDGE_LECCODE = #{RCODE}
 	</select>
 
-	<update id="Modify_Lecture_On_Off" parameterType="hashMap">
+	<update id="Modify_Lecture_On_Off" parameterType="com.academy.lecture.service.LectureVO">
 		UPDATE TB_LEC_MST SET SUBJECT_ISUSE = #{FLAG}
 		WHERE LECCODE = #{GET_CODE}
 	</update>
 
-	<select id="lectureWMV" parameterType="hashMap" resultType="hashMap">
+	<select id="lectureWMV" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT WMV_PMP FROM TB_ORDER_MGNT_NO
 		WHERE ORDERNO = #{ORDERNO}
 	</select>
 
-	<select id="lectureDown_Count" parameterType="hashMap" resultType="hashMap">
+	<select id="lectureDown_Count" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT DISTINCT A.CONTENTID FROM TB_PMP_DOWNLOG A, TB_MOVIE B
 		WHERE A.CONTENTID = B.MOVIE_NO
 		AND A.USERID = #{ORDERID}
@@ -1929,7 +1929,7 @@
 	</select>
 	
 	<!--  기존 무료강좌를 리뉴얼 되면서 무료강좌로 넣기 위함 -->
-	<select id="oldFreeToNewFree" parameterType="hashMap" resultType="hashMap">
+	<select id="oldFreeToNewFree" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 	    SELECT TBL.* FROM (
             SELECT A.LECCODE, A.CATEGORY_CD, A.LEC_TYPE_CHOICE, A.SUBJECT_PRICE,A.SUBJECT_TITLE,
                   (SELECT SUBJECT_NM FROM TB_SUBJECT_INFO WHERE SUBJECT_CD = A.SUBJECT_SJT_CD) AS SUBJECT_NM
@@ -1953,7 +1953,7 @@
 	</select>
 	
 		<!--  기존 무료강좌를 리뉴얼 되면서 무료강좌로 넣기 위함 -->
-	<select id="oldBogangFreeToNewBogangFree" parameterType="hashMap" resultType="hashMap">
+	<select id="oldBogangFreeToNewBogangFree" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 	    SELECT TBL.* FROM (
             SELECT A.LECCODE, A.CATEGORY_CD, A.LEC_TYPE_CHOICE, A.SUBJECT_PRICE,A.SUBJECT_TITLE,
                   (SELECT SUBJECT_NM FROM TB_SUBJECT_INFO WHERE SUBJECT_CD = A.SUBJECT_SJT_CD) AS SUBJECT_NM
@@ -1976,7 +1976,7 @@
        ORDER BY TBL.CATEGORY_CD, TBL.SUBJECT_NM asc
 	</select>
 	
-	<insert id="oldFreeToNewFreeInsert" parameterType="hashMap" flushCache="true">
+	<insert id="oldFreeToNewFreeInsert" parameterType="com.academy.lecture.service.LectureVO" flushCache="true">
 		INSERT INTO TB_LEC_MST ( CATEGORY_CD,
 		       COUPON_NAME,
 		       FIVE_SUBJECT,
@@ -2101,7 +2101,7 @@
 		       UPD_ID
 		  FROM TB_LEC_MST WHERE LECCODE = #{SHEARH_LECCODE}
 	</insert>
-	<insert id="oldBogangFreeToNewFreeBogangInsert" parameterType="hashMap" flushCache="true">
+	<insert id="oldBogangFreeToNewFreeBogangInsert" parameterType="com.academy.lecture.service.LectureVO" flushCache="true">
 		INSERT INTO TB_LEC_MST ( CATEGORY_CD,
 		       COUPON_NAME,
 		       FIVE_SUBJECT,
@@ -2226,7 +2226,7 @@
 		       UPD_ID
 		  FROM TB_LEC_MST WHERE LECCODE = #{SHEARH_LECCODE}
 	</insert>
-	<insert id="oldTbmovieToNewTbmovieInsert" parameterType="hashMap" flushCache="true">
+	<insert id="oldTbmovieToNewTbmovieInsert" parameterType="com.academy.lecture.service.LectureVO" flushCache="true">
 		INSERT INTO TB_MOVIE ( LECCODE,
 		       MOVIE_DATA_FILENAME,
 		       MOVIE_DATA_FILE_YN,
@@ -2270,17 +2270,17 @@
 		  FROM TB_MOVIE WHERE LECCODE = #{RLECCODE}
 	</insert>
 	
-	<select id="getSubject_monitormode" parameterType="hashMap" resultType="String">
+	<select id="getSubject_monitormode" parameterType="com.academy.lecture.service.LectureVO" resultType="String">
 		SELECT NVL(SUBJECT_MONITORMODE, 'NOMAL')  SUBJECT_MONITORMODE
         FROM TB_LEC_MST
 		WHERE LECCODE = #{LECCODE}
 	</select>
 	
-	<select id="getRleccode" parameterType="hashMap" resultType="String">
+	<select id="getRleccode" parameterType="com.academy.lecture.service.LectureVO" resultType="String">
 		SELECT DISTINCT MAX(BRIDGE_LECCODE) BRIDGE_LECCODE  from tb_lec_bridge where leccode = #{SHEARH_LECCODE}
 	</select>
 	
-	<select id="YearIngList" parameterType="hashMap" resultType="hashMap">
+	<select id="YearIngList" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT TY.*, A1.* FROM TB_ORDER_YEARPACKAGE TY
             INNER JOIN (
           SELECT T1.MST_LECCODE,
@@ -2300,7 +2300,7 @@
         WHERE  TY.ORDERNO = #{ORDERNO}	
 	</select>
 	
-	<select id="MyYearIngList" parameterType="hashMap" resultType="hashMap">
+	<select id="MyYearIngList" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 			SELECT A.*, ROWNUM rnum
               FROM (
                 select distinct bb.PLUS_BUY, aa.USER_ID, aa.ORDERNO, aa.WMV_PMP, bb.PARENT_ORDERNO,
@@ -2378,7 +2378,7 @@
                 ORDER BY A.REG_DT DESC ,LECCODE ASC
 	</select>
 	
-	<select id="bookView" parameterType="hashMap" resultMap="lectureMap">
+	<select id="bookView" parameterType="com.academy.lecture.service.LectureVO" resultMap="lectureMap">
 	        SELECT AA.*
 	            , TO_CHAR( (CASE WHEN AA.BOOK_STOCK <![CDATA[ < ]]> 0 THEN 0 WHEN AA.BOOK_STOCK <![CDATA[ >= ]]> 0 THEN BOOK_STOCK END)*3, '0000') B_STOCK
 	            , NVL(AA.MAIN_VIEW,'N') AS MAIN_VIEW, NVL(AA.NEW_BOOK,'N') AS NEW_BOOK

--- a/src/main/resources/mapper/lectureMacAddressManagerSQL.xml
+++ b/src/main/resources/mapper/lectureMacAddressManagerSQL.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.academy.mapper.MacAddressManagerMapper">
 
-	<select id="macaddressmanagerList" parameterType="hashMap" resultType="hashMap">
+	<select id="macaddressmanagerList" parameterType="com.academy.lecture.service.MacAddressManagerVO" resultType="hashMap">
 		SELECT * FROM 	(
 			SELECT A.*, ROWNUM rnum
 		  	FROM (
@@ -37,7 +37,7 @@
 			)
 		WHERE rnum &gt; #{startNo}
 	</select>
-	<select id="devicelist" parameterType="hashMap" resultType="hashMap">
+	<select id="devicelist" parameterType="com.academy.lecture.service.MacAddressManagerVO" resultType="hashMap">
 					SELECT 
 					A.USER_ID, A.DEVICE_ID, A.DEVICE_GUBUN, 
 					   A.PC_USEYN, A.PC_REG_DT, A.MOBILE_REG_DT, A.PC_CANCEL_DT, A.MOBILE_CANCEL_DT,
@@ -66,7 +66,7 @@
 				 	ORDER BY A.PC_REG_DT, A.MOBILE_REG_DT
 	</select>
 	
-	<select id="macaddressView" parameterType="hashMap" resultType="hashMap">
+	<select id="macaddressView" parameterType="com.academy.lecture.service.MacAddressManagerVO" resultType="hashMap">
 		SELECT 
 					A.USER_ID, A.DEVICE_ID, A.DEVICE_GUBUN, 
 					   A.PC_USEYN, A.PC_REG_DT,A.MOBILE_REG_DT, A.PC_CANCEL_DT, A.MOBILE_CANCEL_DT,
@@ -77,7 +77,7 @@
 	</select>
 	
 
-	<select id="macaddressmanagerListCount" parameterType="hashMap" resultType="int">
+	<select id="macaddressmanagerListCount" parameterType="com.academy.lecture.service.MacAddressManagerVO" resultType="int">
 		SELECT COUNT(*) FROM 	(
 			SELECT A.*, ROWNUM rnum
 		  	FROM (
@@ -114,13 +114,13 @@
 
 
 
-	<update id="macaddressmanagerUpdate" parameterType="hashMap">
+	<update id="macaddressmanagerUpdate" parameterType="com.academy.lecture.service.MacAddressManagerVO">
 		UPDATE TM_DEVICE_HISTORY
 		SET
 			PC_USEYN = 'N',PC_CANCEL_DT = SYSDATE
 		WHERE SEQ = #{SEQ}
 	</update>
-	<update id="macaddressmanagerUpdate1" parameterType="hashMap">
+	<update id="macaddressmanagerUpdate1" parameterType="com.academy.lecture.service.MacAddressManagerVO">
 		UPDATE TM_DEVICE_HISTORY
 		SET
 			MOBILE_USEYN = 'N', MOBILE_CANCEL_DT = SYSDATE

--- a/src/main/resources/mapper/lectureOffSQL.xml
+++ b/src/main/resources/mapper/lectureOffSQL.xml
@@ -10,7 +10,7 @@
 <!-- 단과 start -->
 
 
-	<select id="lectureList" parameterType="hashMap" resultType="hashMap">
+	<select id="lectureList" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT *
 		FROM (SELECT DA.*,
 				           (SELECT NAME FROM TB_CATEGORY_INFO WHERE CODE = DA.CATEGORY_CD) AS CATEGORY_NM,
@@ -98,7 +98,7 @@
 		WHERE rnum <![CDATA[ > ]]> #{startNo}
 	</select>
 
-	<select id="lectureListCount" parameterType="hashMap" resultType="int">
+	<select id="lectureListCount" parameterType="com.academy.lecture.service.LectureVO" resultType="int">
 		SELECT COUNT(*)
 				FROM (SELECT BA.LECCODE, BA.SUBJECT_ISUSE, BA.LEC_PROCESS,
 						     (SELECT SUBJECT_NM FROM TB_SUBJECT_INFO WHERE SUBJECT_CD = BA.SUBJECT_SJT_CD) AS SUBJECT_NM,
@@ -174,7 +174,7 @@
 		              </if>
 	</select>
 
-	<select id="bookList" parameterType="hashMap" resultType="hashMap">
+	<select id="bookList" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT LTBL.*
 			,(SELECT NAME FROM TB_CATEGORY_INFO WHERE ISUSE = 'Y' AND CODE = LTBL.CATEGORY_CD) CATEGORY_NM
 			,(SELECT NAME FROM TB_LEARNING_FORM_INFO WHERE ISUSE = 'Y' AND CODE = LTBL.LEARNING_CD) LEARNING_NM
@@ -200,7 +200,7 @@
 		WHERE rnum &gt; #{startNo}
 	</select>
 
-	<select id="bookListCount" parameterType="hashMap" resultType="int">
+	<select id="bookListCount" parameterType="com.academy.lecture.service.LectureVO" resultType="int">
 		SELECT
 		  COUNT(RSC_ID)
 		FROM TB_CA_BOOK WHERE USE_YN = 'Y'
@@ -215,29 +215,29 @@
 		</if>
 	</select>
 
-	<select id="getBridgeLeccodeSeq" parameterType="hashMap" resultType="hashMap">
+	<select id="getBridgeLeccodeSeq" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT TO_CHAR(NVL(MAX(seq),0)+1) AS SEQ FROM TB_OFF_LEC_BRIDGE
 	</select>
 
-	<select id="getJongLeccodeSeq" parameterType="hashMap" resultType="hashMap">
+	<select id="getJongLeccodeSeq" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT TO_CHAR(NVL(MAX(seq),0)+1) AS SEQ FROM TB_OFF_LEC_JONG
 	</select>
 
-	<select id="getLeccode" parameterType="hashMap" resultType="hashMap">
+	<select id="getLeccode" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT
   			TO_CHAR(NVL(MAX(substr(LECCODE,6,5)),0)+1,'00000') LECCODE
 		FROM TB_OFF_LEC_MST
 		WHERE LECCODE LIKE '%'||#{PREFIX}||'%'
 	</select>
 
-	<select id="getBridgeLeccode" parameterType="hashMap" resultType="hashMap">
+	<select id="getBridgeLeccode" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT
 			TO_CHAR(NVL(MAX(substr(BRIDGE_LECCODE,6,5)),0)+1,'00000') BRIDGE_LECCODE
 		FROM TB_OFF_LEC_BRIDGE
 		WHERE BRIDGE_LECCODE LIKE '%'||#{PREFIX}||'%'
 	</select>
 
-	<insert id="lectureInsert" parameterType="hashMap" flushCache="true">
+	<insert id="lectureInsert" parameterType="com.academy.lecture.service.LectureVO" flushCache="true">
 		INSERT INTO TB_OFF_LEC_MST(
 			SEQ, LECCODE, CATEGORY_CD, LEARNING_CD, SUBJECT_TYPE
 													, SUBJECT_GUBUN, SUBJECT_MEMBER_CNT , SUBJECT_TEACHER, SUBJECT_TEACHER_PAYMENT, SUBJECT_SJT_CD
@@ -257,12 +257,12 @@
 		)
 	</insert>
 
-	<insert id="lectureBridgeInsert" parameterType="hashMap" flushCache="true">
+	<insert id="lectureBridgeInsert" parameterType="com.academy.lecture.service.LectureVO" flushCache="true">
 		INSERT INTO TB_OFF_LEC_BRIDGE(SEQ, BRIDGE_LECCODE, LECCODE, REG_DT, REG_ID, UPD_DT, UPD_ID)
 		VALUES (#{SEQ}, #{BRIDGE_LECCODE}, #{LECCODE}, SYSDATE, #{REG_ID}, SYSDATE, #{UPD_ID})
 	</insert>
 
-	<insert id="lectureBookInsert" parameterType="hashMap" flushCache="true" statementType="CALLABLE">
+	<insert id="lectureBookInsert" parameterType="com.academy.lecture.service.LectureVO" flushCache="true" statementType="CALLABLE">
 		CALL PKG_LECTURE.SP_LECTURE_OFF_BOOK_INSERT(
 		        #{LECCODE, mode=IN},
 		        #{RSC_ID, mode=IN},
@@ -271,7 +271,7 @@
 		        #{SUBJECT_BOOK_MEMO, mode=IN})
 	</insert>
 
-	<insert id="lectureBookInsert2" parameterType="hashMap" flushCache="true">
+	<insert id="lectureBookInsert2" parameterType="com.academy.lecture.service.LectureVO" flushCache="true">
 		INSERT INTO TB_OFF_PLUS_CA_BOOK(IDX, LECCODE, RSC_ID, FLAG
 		<if test='SUBJECT_BOOK_MEMO != null and SUBJECT_BOOK_MEMO != ""'>
 		, SUBJECT_BOOK_MEMO
@@ -284,7 +284,7 @@
 		)
 	</insert>
 
-	<select id="lectureViewList" parameterType="hashMap" resultType="hashMap">
+	<select id="lectureViewList" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
         SELECT
           T1.BRIDGE_LECCODE, T2.*
           , (SELECT NAME FROM TB_CATEGORY_INFO WHERE CODE = T2.CATEGORY_CD) AS CATEGORY_NM
@@ -318,7 +318,7 @@
         ORDER BY T2.CATEGORY_CD
 	</select>
 
-	<select id="lectureView" parameterType="hashMap" resultMap="lectureMap">
+	<select id="lectureView" parameterType="com.academy.lecture.service.LectureVO" resultMap="lectureMap">
 		SELECT
 			TBL.*, (SELECT NO FROM TB_OFF_CHOICE_JONG_NO WHERE LECCODE = TBL.LECCODE AND CATEGORY_CD = TBL.CATEGORY_CD) AS NO
 			, T2.SEQ AS BSEQ, T2.BRIDGE_LECCODE
@@ -326,7 +326,7 @@
 		WHERE TBL.LECCODE = #{LECCODE}
 	</select>
 
-	<select id="lectureViewBookList" parameterType="hashMap" resultType="hashMap">
+	<select id="lectureViewBookList" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT
 		  AA.*
 		  ,(SELECT NAME FROM TB_CATEGORY_INFO WHERE ISUSE = 'Y' AND CODE = BB.CATEGORY_CD) CATEGORY_NM
@@ -336,7 +336,7 @@
 		ON AA.RSC_ID = BB.RSC_ID WHERE AA.LECCODE = #{LECCODE}
 	</select>
 
-	<update id="lectureUpdate" parameterType="hashMap">
+	<update id="lectureUpdate" parameterType="com.academy.lecture.service.LectureVO">
 		UPDATE TB_OFF_LEC_MST
 			SET
 				 LEARNING_CD = #{LEARNING_CD}
@@ -381,13 +381,13 @@
 		    <if test='UPDATE_FLAG != "ALL" '>WHERE LECCODE = #{LECCODE}</if>
 	</update>
 
-	<delete id="lectureBookDelete" parameterType="hashMap" flushCache="true">
+	<delete id="lectureBookDelete" parameterType="com.academy.lecture.service.LectureVO" flushCache="true">
 		DELETE FROM TB_OFF_PLUS_CA_BOOK
 		<if test='UPDATE_FLAG == "ALL" '>WHERE LECCODE IN (SELECT LECCODE FROM TB_OFF_LEC_BRIDGE WHERE BRIDGE_LECCODE = #{BRIDGE_LEC} )</if>
 		<if test='UPDATE_FLAG != "ALL" '>WHERE LECCODE = #{LECCODE}</if>
 	</delete>
 
-	<delete id="lectureIsUseUpdate" parameterType="hashMap" flushCache="true">
+	<delete id="lectureIsUseUpdate" parameterType="com.academy.lecture.service.LectureVO" flushCache="true">
 		UPDATE TB_OFF_LEC_MST SET 
 		<choose>
 			<when test='LEC_PROCESS != null and LEC_PROCESS != ""'>
@@ -434,15 +434,15 @@
 		<!-- DELETE FROM TB_LEC_MST WHERE LECCODE = #{LECCODE} -->
 	</delete>
 
-	<delete id="lectureDelete" parameterType="hashMap" flushCache="true">
+	<delete id="lectureDelete" parameterType="com.academy.lecture.service.LectureVO" flushCache="true">
 		DELETE FROM TB_OFF_LEC_MST WHERE LECCODE = #{LECCODE}
 	</delete>
 
-	<delete id="lectureBridgeDelete" parameterType="hashMap" flushCache="true">
+	<delete id="lectureBridgeDelete" parameterType="com.academy.lecture.service.LectureVO" flushCache="true">
 		DELETE FROM TB_OFF_LEC_BRIDGE WHERE BRIDGE_LECCODE = #{BRIDGE_LECCODE} AND LECCODE = #{LECCODE}
 	</delete>
 
-	<select id="lectureSeqList" parameterType="hashMap" resultType="hashMap">
+	<select id="lectureSeqList" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		<if test='LEC_TYPE_CHOICE == "D"'>
 			SELECT TBL.* FROM (
 				SELECT T1.BRIDGE_LECCODE, T2.*
@@ -503,7 +503,7 @@
 	 	ORDER BY TBL.SEQ DESC
 	</select>
 
-	<update id="lectureSeqUpdate" parameterType="hashMap">
+	<update id="lectureSeqUpdate" parameterType="com.academy.lecture.service.LectureVO">
 		UPDATE TB_OFF_LEC_MST SET SEQ = #{SEQ} WHERE LECCODE = #{LECCODE}
 	</update>
 
@@ -513,7 +513,7 @@
 
 <!-- 종합반 start -->
 
-	<select id="lectureViewJongList" parameterType="hashMap" resultType="hashMap">
+	<select id="lectureViewJongList" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT
 			LTBL.*
 			, (SELECT COUNT(A.ORDERNO) AS CNT	FROM TB_OFF_ORDER_MGNT_NO A
@@ -538,7 +538,7 @@
 			) LTBL
 	</select>
 
-	<select id="lectureJongList" parameterType="hashMap" resultType="hashMap">
+	<select id="lectureJongList" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT
 			LTBL.*
 		FROM 	(
@@ -600,7 +600,7 @@
 		WHERE rnum &gt; #{startNo}
 	</select>
 
-	<select id="lectureJongListCount" parameterType="hashMap" resultType="int">
+	<select id="lectureJongListCount" parameterType="com.academy.lecture.service.LectureVO" resultType="int">
 		SELECT
 			COUNT(TBL.LECCODE)
 		FROM
@@ -641,14 +641,14 @@
 		</if>
 	</select>
 
-	<select id="lectureJongView" parameterType="hashMap" resultMap="lectureMap">
+	<select id="lectureJongView" parameterType="com.academy.lecture.service.LectureVO" resultMap="lectureMap">
 		SELECT
 			TBL.*, (SELECT NO FROM TB_OFF_CHOICE_JONG_NO WHERE LECCODE = TBL.LECCODE AND CATEGORY_CD = TBL.CATEGORY_CD) AS NO
 		FROM TB_OFF_LEC_MST TBL
 		WHERE TBL.LECCODE = #{LECCODE}
 	</select>
 
-	<select id="lectureJongSubjectList" parameterType="hashMap" resultType="hashMap">
+	<select id="lectureJongSubjectList" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT * FROM 	(
 			SELECT A.*, ROWNUM rnum
 		  	FROM (
@@ -691,7 +691,7 @@
 		WHERE rnum &gt; #{startNo}
 	</select>
 
-	<select id="lectureJongSubjectListCount" parameterType="hashMap" resultType="int">
+	<select id="lectureJongSubjectListCount" parameterType="com.academy.lecture.service.LectureVO" resultType="int">
         SELECT COUNT(TBL.LECCODE) FROM (
             SELECT T1.*
                 , (SELECT NAME FROM TB_CATEGORY_INFO WHERE CODE = T1.CATEGORY_CD) AS CATEGORY_NM
@@ -726,12 +726,12 @@
 		</if>
 	</select>
 
-	<insert id="lectureLecJongInsert" parameterType="hashMap" flushCache="true">
+	<insert id="lectureLecJongInsert" parameterType="com.academy.lecture.service.LectureVO" flushCache="true">
 		INSERT INTO TB_OFF_LEC_JONG(SEQ, LECCODE, MST_LECCODE, SORT, GUBUN, REG_DT, REG_ID, UPD_DT, UPD_ID)
 		VALUES (#{SEQ}, #{LECCODE}, #{MST_LECCODE}, #{SORT}, #{GUBUN}, SYSDATE, #{REG_ID}, SYSDATE, #{UPD_ID})
 	</insert>
 
-	<select id="lectureViewLeccodeList" parameterType="hashMap" resultType="hashMap">
+	<select id="lectureViewLeccodeList" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT
 		  T1.MST_LECCODE, T1.SORT, T1.GUBUN
 		  , TBL.*
@@ -745,11 +745,11 @@
 		ORDER BY T1.SORT ASC
 	</select>
 
-	<delete id="lectureLecJongDelete" parameterType="hashMap" flushCache="true">
+	<delete id="lectureLecJongDelete" parameterType="com.academy.lecture.service.LectureVO" flushCache="true">
 		DELETE FROM TB_OFF_LEC_JONG WHERE LECCODE = #{LECCODE}
 	</delete>
 
-	<delete id="lectureChoiceJongNoDelete" parameterType="hashMap" flushCache="true">
+	<delete id="lectureChoiceJongNoDelete" parameterType="com.academy.lecture.service.LectureVO" flushCache="true">
 		DELETE FROM TB_OFF_CHOICE_JONG_NO WHERE LECCODE = #{LECCODE}
 	</delete>
 
@@ -758,7 +758,7 @@
 
 <!-- 선택형 종합반 start -->
 
-	<insert id="lectureChoiceJongNoInsert" parameterType="hashMap" flushCache="true">
+	<insert id="lectureChoiceJongNoInsert" parameterType="com.academy.lecture.service.LectureVO" flushCache="true">
 		INSERT INTO TB_OFF_CHOICE_JONG_NO(SEQ, LECCODE, NO, CATEGORY_CD)
 		VALUES (#{SEQ}, #{LECCODE}, #{NO}, #{CATEGORY_CD})
 	</insert>
@@ -766,11 +766,11 @@
 <!-- 선택형 종합반 end -->
 
 
-	<select id="lectureDeleteCheck" parameterType="hashMap" resultType="int">
+	<select id="lectureDeleteCheck" parameterType="com.academy.lecture.service.LectureVO" resultType="int">
 		SELECT COUNT(*) FROM TB_OFF_ORDER_MGNT_NO WHERE MGNTNO = #{LECCODE} AND STATUSCODE = 'DLV105'
 	</select>
 
-	<select id="lecturePayList" parameterType="hashMap" resultType="hashMap">
+	<select id="lecturePayList" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT DISTINCT C.USERID                                                AS USERID
 		 	  ,B.ORDERNO                                                               AS ORDERNO
 		      ,NVL((SELECT USER_NM  FROM TB_MA_MEMBER WHERE USER_ID = C.USERID), (SELECT DISTINCT USER_NM FROM TB_OFF_ORDERS WHERE ORDERNO = C.ORDERNO))         AS USER_NM
@@ -829,7 +829,7 @@
 		ORDER BY B.STATUSCODE
 	</select>
 
-	<select id="off_lecturePayList" parameterType="hashMap" resultType="hashMap">
+	<select id="off_lecturePayList" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
         <choose>
 				<when test='LEC_TYPE == "JONG"'>
         SELECT M1.ORDERNO, M1.MGNTNO, M4.LECCODE, M3.USER_ID USERID, M3.USER_NM, M3.PHONE_NO,
@@ -908,7 +908,7 @@
 		</choose>
 	</select>
 
-	<select id="lectureJongPayList" parameterType="hashMap" resultType="hashMap">
+	<select id="lectureJongPayList" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT C.USERID                                                              AS USERID
 		      ,(SELECT USER_NM  FROM TB_MA_MEMBER WHERE USER_ID = C.USERID)          AS USER_NM
 		      ,(SELECT PHONE_NO FROM TB_MA_MEMBER WHERE USER_ID = C.USERID)          AS PHONE_NO
@@ -949,7 +949,7 @@
 		ORDER BY C.LECTURE_NO
 	</select>
 
-	<select id="lectureDataViewList" parameterType="hashMap" resultType="hashMap">
+	<select id="lectureDataViewList" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT B.SUBJECT_OPTION
 		      ,B.BRIDGE_LECCODE
 		      ,A.MOVIE_NAME
@@ -992,7 +992,7 @@
 
 	</select>
 
-	<select id="lectureDataMemoViewList" parameterType="hashMap" resultType="hashMap">
+	<select id="lectureDataMemoViewList" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT  NVL(BRIDGE_LECCODE,'')  AS RLECCODE
 		       ,MOVIE_ORDER1            AS MOVIE_ORDER1
 		       ,MOVIE_ORDER2            AS MOVIE_ORDER2
@@ -1003,13 +1003,13 @@
 		ORDER BY MOVIE_ORDER1 , MOVIE_ORDER2 ASC , POSITION DESC
 	</select>
 
-	<delete id="lectureOffDayDelete" parameterType="hashMap" flushCache="true">
+	<delete id="lectureOffDayDelete" parameterType="com.academy.lecture.service.LectureVO" flushCache="true">
 		DELETE FROM TB_OFF_LECTURE_DATE
 		<if test='UPDATE_FLAG == "ALL" '>WHERE LECCODE IN (SELECT LECCODE FROM TB_OFF_LEC_BRIDGE WHERE BRIDGE_LECCODE = #{BRIDGE_LEC} )</if>
 		<if test='UPDATE_FLAG != "ALL" '>WHERE LECCODE = #{LECCODE}</if>
 	</delete>
 
-	<insert id="lectureOffDayInsert" parameterType="hashMap" flushCache="true" statementType="CALLABLE">
+	<insert id="lectureOffDayInsert" parameterType="com.academy.lecture.service.LectureVO" flushCache="true" statementType="CALLABLE">
 
 		CALL SP_LECTURE_OFF_DAY_INSERT(
 		        #{NUM,  mode=IN},
@@ -1018,12 +1018,12 @@
 		        #{result, jdbcType=INTEGER, mode=OUT})
 	</insert>
 
-	<insert id="lectureOffDayInsert2" parameterType="hashMap" flushCache="true">
+	<insert id="lectureOffDayInsert2" parameterType="com.academy.lecture.service.LectureVO" flushCache="true">
 		INSERT INTO TB_OFF_LECTURE_DATE(LECCODE, NUM, LEC_DATE)
 		VALUES (#{LECCODE}, #{NUM}, TO_DATE(#{LEC_DATE} , 'yyyymmdd'))
 	</insert>
 
-	<select id="lectureOffDayList" parameterType="hashMap" resultType="hashMap">
+	<select id="lectureOffDayList" parameterType="com.academy.lecture.service.LectureVO" resultType="hashMap">
 		SELECT LECCODE, NUM, TO_CHAR(LEC_DATE,'YYYYMMDD') AS LEC_DATE FROM TB_OFF_LECTURE_DATE
 		WHERE LECCODE = #{LECCODE} ORDER BY NUM ASC
 	</select>

--- a/src/main/resources/mapper/lectureSeriesSQL.xml
+++ b/src/main/resources/mapper/lectureSeriesSQL.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.academy.mapper.SeriesMapper">
 
-  <select id="seriesList" parameterType="hashMap" resultType="hashMap">
+  <select id="seriesList" parameterType="com.academy.lecture.service.SeriesVO" resultType="hashMap">
     SELECT * FROM   (
         SELECT A.*, ROWNUM rnum
         FROM (
@@ -38,7 +38,7 @@
     WHERE rnum &gt; #{startNo}
   </select>
 
-  <select id="seriesListCount" parameterType="hashMap" resultType="int">
+  <select id="seriesListCount" parameterType="com.academy.lecture.service.SeriesVO" resultType="int">
     SELECT
       COUNT(SRS_CD)
     FROM TB_SERIES_INFO
@@ -61,7 +61,7 @@
     </if>
   </select>
 
-  <insert id="seriesInsert" parameterType="hashMap" flushCache="true">
+  <insert id="seriesInsert" parameterType="com.academy.lecture.service.SeriesVO" flushCache="true">
     INSERT INTO TB_CATEGORY_INFO (
         ID
         , CODE
@@ -87,7 +87,7 @@
     )
   </insert>
 
-  <select id="seriesView" parameterType="hashMap" resultType="hashMap">
+  <select id="seriesView" parameterType="com.academy.lecture.service.SeriesVO" resultType="hashMap">
     SELECT
         CODE, NAME, ISUSE, DECODE(ISUSE, 'Y', '활성', 'N', '비활성') ISUSENM
         , USE_ON, USE_OFF, REG_DT, REG_ID, UPD_DT, UPD_ID
@@ -98,7 +98,7 @@
     WHERE CODE = #{CODE}
   </select>
 
-  <update id="seriesUpdate" parameterType="hashMap">
+  <update id="seriesUpdate" parameterType="com.academy.lecture.service.SeriesVO">
     UPDATE TB_CATEGORY_INFO
     SET
       NAME = #{NAME}
@@ -111,17 +111,17 @@
     WHERE CODE = #{CODE}
   </update>
 
-  <delete id="categoryDelete" parameterType="hashMap">
+  <delete id="categoryDelete" parameterType="com.academy.lecture.service.SeriesVO">
     DELETE FROM TB_CATEGORY_INFO
     WHERE P_CODE = #{CODE}
   </delete>
 
-  <delete id="seriesDelete" parameterType="hashMap">
+  <delete id="seriesDelete" parameterType="com.academy.lecture.service.SeriesVO">
     DELETE FROM TB_CATEGORY_INFO
     WHERE CODE = #{CODE}
   </delete>
 
-  <select id="seriesCheck" parameterType="hashMap" resultType="int">
+  <select id="seriesCheck" parameterType="com.academy.lecture.service.SeriesVO" resultType="int">
     SELECT
       COUNT(CODE)
     FROM CODE

--- a/src/main/resources/mapper/lectureSubjectSQL.xml
+++ b/src/main/resources/mapper/lectureSubjectSQL.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.academy.mapper.SubjectMapper">
 
-	<select id="subjectList" parameterType="hashMap" resultType="hashMap">
+	<select id="subjectList" parameterType="com.academy.lecture.service.SubjectVO" resultType="hashMap">
 		SELECT * FROM 	(
 			SELECT A.*, ROWNUM rnum
 		  	FROM (
@@ -40,7 +40,7 @@
 		WHERE rnum &gt; #{startNo}
 	</select>
 
-	<select id="subjectListCount" parameterType="hashMap" resultType="int">
+	<select id="subjectListCount" parameterType="com.academy.lecture.service.SubjectVO" resultType="int">
 		SELECT
 			COUNT(SUBJECT_CD)
 		FROM TB_SUBJECT_INFO
@@ -63,31 +63,31 @@
 		</if>
 	</select>
 
-	<select id="subjectGetCode" parameterType="hashMap" resultType="String">
+	<select id="subjectGetCode" parameterType="com.academy.lecture.service.SubjectVO" resultType="String">
 		SELECT
 			REPLACE(TO_CHAR(NVL(MAX(SUBJECT_CD),1000)+1 ,'0000'),' ','') CODE
 		FROM TB_SUBJECT_INFO
 	</select>
 
-	<insert id="subjectInsert" parameterType="hashMap" flushCache="true">
+	<insert id="subjectInsert" parameterType="com.academy.lecture.service.SubjectVO" flushCache="true">
 		INSERT INTO TB_SUBJECT_INFO(SUBJECT_CD, SUBJECT_NM, SUBJECT_SHORT_NM, ISUSE, REG_DT, REG_ID, UPD_DT, UPD_ID)
 		VALUES (#{SUBJECT_CD}, #{SUBJECT_NM}, #{SUBJECT_SHORT_NM}, #{ISUSE}, SYSDATE, #{REG_ID}, SYSDATE, #{UPD_ID})
 	</insert>
 
-	<insert id="subjectCategoryInsert" parameterType="hashMap" flushCache="true">
+	<insert id="subjectCategoryInsert" parameterType="com.academy.lecture.service.SubjectVO" flushCache="true">
 		INSERT INTO TB_SUBJECT_CATEGORY(SUBJECT_CD, CATEGORY_CODE)
 		VALUES (#{SUBJECT_CD}, #{CATEGORY_CODE})
 	</insert>
 
-	<update id="subjectCategoryDelete" parameterType="hashMap" flushCache="true">
+	<update id="subjectCategoryDelete" parameterType="com.academy.lecture.service.SubjectVO" flushCache="true">
 		DELETE FROM TB_SUBJECT_CATEGORY WHERE SUBJECT_CD = #{SUBJECT_CD}
 	</update>
 	
-	<delete id="subjectCategoryDeleteByCat" parameterType="hashMap" flushCache="true">
+	<delete id="subjectCategoryDeleteByCat" parameterType="com.academy.lecture.service.SubjectVO" flushCache="true">
 		DELETE FROM TB_SUBJECT_CATEGORY WHERE SUBJECT_CD = #{SUBJECT_CD} AND CATEGORY_CODE = #{CATEGORY_CODE}
 	</delete>
 	
-	<insert id="subjectCategoryOrderInsert" parameterType="hashMap" flushCache="true">
+	<insert id="subjectCategoryOrderInsert" parameterType="com.academy.lecture.service.SubjectVO" flushCache="true">
 		INSERT INTO TB_CATEGORY_SUBJECT_ORDER(ONOFF_DIV, CATEGORY_CODE, SUBJECT_CD, IDX)
 		VALUES (#{ONOFF_DIV}, #{CATEGORY_CODE}, #{SUBJECT_CD} 
 		<choose>
@@ -102,7 +102,7 @@
 		)
 	</insert>
 	
-	<select id="chkSubjectCategoryOrderCnt" parameterType="hashMap" resultType="int">
+	<select id="chkSubjectCategoryOrderCnt" parameterType="com.academy.lecture.service.SubjectVO" resultType="int">
 		SELECT 
 			COUNT(*)  
 		FROM TB_CATEGORY_SUBJECT_ORDER			
@@ -114,7 +114,7 @@
 		AND SUBJECT_CD = #{SUBJECT_CD}
 	</select>
 	
-	<select id="chkSubjectCategoryCnt" parameterType="hashMap" resultType="int">
+	<select id="chkSubjectCategoryCnt" parameterType="com.academy.lecture.service.SubjectVO" resultType="int">
 		SELECT 
 			COUNT(*)  
 		FROM TB_SUBJECT_CATEGORY			
@@ -123,7 +123,7 @@
 		AND SUBJECT_CD = #{SUBJECT_CD}
 	</select>
 	
-	<select id="getSubjectCategoryOrderIdx" parameterType="hashMap" resultType="String">
+	<select id="getSubjectCategoryOrderIdx" parameterType="com.academy.lecture.service.SubjectVO" resultType="String">
 		SELECT 
 			NVL(MIN(IDX),
 			(SELECT NVL(MAX(G.IDX)+1,1) 
@@ -137,11 +137,11 @@
 		GROUP BY ONOFF_DIV,SUBJECT_CD,CATEGORY_CODE
 	</select>
 	
-	<update id="subjectCategoryOrderDelete" parameterType="hashMap" flushCache="true">
+	<update id="subjectCategoryOrderDelete" parameterType="com.academy.lecture.service.SubjectVO" flushCache="true">
 		DELETE FROM TB_CATEGORY_SUBJECT_ORDER WHERE SUBJECT_CD = #{SUBJECT_CD}
 	</update>
 	
-	<delete id="subjectCategoryOrderDeleteByOnoff" parameterType="hashMap" flushCache="true">
+	<delete id="subjectCategoryOrderDeleteByOnoff" parameterType="com.academy.lecture.service.SubjectVO" flushCache="true">
 		DELETE FROM TB_CATEGORY_SUBJECT_ORDER 
 		WHERE ONOFF_DIV = #{ONOFF_DIV}
 		AND SUBJECT_CD = #{SUBJECT_CD}
@@ -150,7 +150,7 @@
         </if>
 	</delete>
 
-	<select id="subjectView" parameterType="hashMap" resultType="hashMap">
+	<select id="subjectView" parameterType="com.academy.lecture.service.SubjectVO" resultType="hashMap">
 		SELECT
 			SUBJECT_CD, SUBJECT_NM, SUBJECT_SHORT_NM, ISUSE
 			, DECODE(ISUSE, 'Y', '활성', 'N', '비활성') ISUSENM
@@ -159,7 +159,7 @@
 		WHERE SUBJECT_CD = #{SUBJECT_CD}
 	</select>
 
-	<select id="subjectCategoryView" parameterType="hashMap" resultType="hashMap">
+	<select id="subjectCategoryView" parameterType="com.academy.lecture.service.SubjectVO" resultType="hashMap">
 		SELECT
             AA.SUBJECT_CD, AA.CATEGORY_CODE
         FROM TB_SUBJECT_CATEGORY AA,(  SELECT SUBJECT_CD,CATEGORY_CODE
@@ -173,7 +173,7 @@
         AND AA.SUBJECT_CD = #{SUBJECT_CD}
 	</select>
 
-	<update id="subjectUpdate" parameterType="hashMap">
+	<update id="subjectUpdate" parameterType="com.academy.lecture.service.SubjectVO">
 		UPDATE TB_SUBJECT_INFO
 		SET
 			SUBJECT_NM = #{SUBJECT_NM}
@@ -184,7 +184,7 @@
 		WHERE SUBJECT_CD = #{SUBJECT_CD}
 	</update>
 
-	<delete id="subjectDelete" parameterType="hashMap">
+	<delete id="subjectDelete" parameterType="com.academy.lecture.service.SubjectVO">
 		UPDATE TB_SUBJECT_INFO
 		SET ISUSE = 'N'
 		WHERE SUBJECT_CD = #{SUBJECT_CD}
@@ -194,7 +194,7 @@
 		-->
 	</delete>
 
-    <select id="findSubjectCategoryList" parameterType="hashMap" resultType="hashMap">
+    <select id="findSubjectCategoryList" parameterType="com.academy.lecture.service.SubjectVO" resultType="hashMap">
         SELECT
             C.CODE AS CATEGORY_CODE, C.NAME AS CATEGORY_NM
             , A.SUBJECT_CD, A.SUBJECT_NM, A.SUBJECT_SHORT_NM, A.ISUSE
@@ -210,7 +210,7 @@
         ORDER BY A.SUBJECT_CD
     </select>
     
-	<select id="subjectCheck" parameterType="hashMap" resultType="int">
+	<select id="subjectCheck" parameterType="com.academy.lecture.service.SubjectVO" resultType="int">
 		SELECT 
 			COUNT(SUBJECT_CD)  
 		FROM TB_SUBJECT_INFO			
@@ -223,7 +223,7 @@
 		</if>		
 	</select>	
 	
-	<insert id="main_category_subject_order_Insert" parameterType="hashMap" flushCache="true">
+	<insert id="main_category_subject_order_Insert" parameterType="com.academy.lecture.service.SubjectVO" flushCache="true">
 		INSERT INTO TB_MAIN_CATEGORY_SUBJECT_ORDER(ONOFF_DIV, CATEGORY_CODE, SUBJECT_CD, IDX) 
 		VALUES ('M', 'main', #{SUBJECT_CD}, (SELECT NVL(MAX(IDX)+1,1) FROM TB_MAIN_CATEGORY_SUBJECT_ORDER))	
 	</insert>

--- a/src/main/resources/mapper/lectureTeacherSQL.xml
+++ b/src/main/resources/mapper/lectureTeacherSQL.xml
@@ -12,7 +12,7 @@
        <result column="OFF_LECINFO" property="OFF_LECINFO" javaType="java.lang.String" jdbcType="CLOB"/>
     </resultMap>
 
-    <select id="getKindList" parameterType="hashMap" resultType="hashMap">
+    <select id="getKindList" parameterType="com.academy.lecture.service.TeacherVO" resultType="hashMap">
         <if test='SEARCHGUBN == "T"'>
             SELECT
                 ID, CODE, NAME, ISUSE, DECODE(ISUSE, 'Y', '활성', 'N', '비활성') ISUSENM
@@ -30,7 +30,7 @@
     </select>
 
     <!-- T:전체 , E:선택된것 제외된 전체 , M:강사가 선택한것만 -->
-    <select id="getSubjectList" parameterType="hashMap" resultType="hashMap">
+    <select id="getSubjectList" parameterType="com.academy.lecture.service.TeacherVO" resultType="hashMap">
         <if test='SEARCHGUBN == "T"'>
             SELECT
                 A.SUBJECT_CD, A.SUBJECT_NM, A.SUBJECT_SHORT_NM, A.ISUSE
@@ -93,7 +93,7 @@
         </if>
     </select>
 
-    <select id="teacherList" parameterType="hashMap" resultType="hashMap">
+    <select id="teacherList" parameterType="com.academy.lecture.service.TeacherVO" resultType="hashMap">
         <if test="SEARCHCATEGORY == null or SEARCHCATEGORY == ''">
         SELECT * FROM   (
             SELECT A.*, ROWNUM rnum
@@ -176,7 +176,7 @@
         </if>
     </select>
 
-    <select id="teacherListCount" parameterType="hashMap" resultType="int">
+    <select id="teacherListCount" parameterType="com.academy.lecture.service.TeacherVO" resultType="int">
         SELECT COUNT(*) FROM (
             SELECT
                 COUNT(AA.USER_ID)
@@ -226,7 +226,7 @@
         ) TBL
     </select>
 
-    <select id="teacherAllList" parameterType="hashMap" resultType="hashMap">
+    <select id="teacherAllList" parameterType="com.academy.lecture.service.TeacherVO" resultType="hashMap">
           SELECT * FROM   (
           	<if test='SEARCH_TEACHER == "Y"'>
             SELECT G.*, ROWNUM rnum FROM(
@@ -279,7 +279,7 @@
         </if>
     </select>
     
-    <select id="teacherAllListCount" parameterType="hashMap" resultType="int">
+    <select id="teacherAllListCount" parameterType="com.academy.lecture.service.TeacherVO" resultType="int">
         SELECT COUNT(*)
         FROM   (
             SELECT
@@ -313,19 +313,19 @@
         AND DD.CATEGORY_CD = CC.CATEGORY_CODE
     </select>
 
-    <select id="teacherView" parameterType="hashMap" resultMap="teacherMap">
+    <select id="teacherView" parameterType="com.academy.lecture.service.TeacherVO" resultMap="teacherMap">
         SELECT * FROM TB_MA_MEMBER
         WHERE USER_ID = #{USER_ID}
     </select>
 
-    <select id="teacherIdCheck" parameterType="hashMap" resultType="int">
+    <select id="teacherIdCheck" parameterType="com.academy.lecture.service.TeacherVO" resultType="int">
         SELECT
             COUNT(USER_ID)
         FROM TB_MA_MEMBER
         WHERE USER_ID = #{USER_ID}
     </select>
 
-    <insert id="teacherInsert" parameterType="hashMap" flushCache="true">
+    <insert id="teacherInsert" parameterType="com.academy.lecture.service.TeacherVO" flushCache="true">
         INSERT INTO TB_MA_MEMBER(
             USER_ID, USER_NM, USER_NICKNM, USER_POSITION
             , USER_ROLE, USER_PWD, BIRTH_DAY
@@ -356,7 +356,7 @@
         )
     </insert>
 
-    <insert id="teacherCategoryInsert" parameterType="hashMap" flushCache="true">
+    <insert id="teacherCategoryInsert" parameterType="com.academy.lecture.service.TeacherVO" flushCache="true">
         INSERT INTO TB_MA_MEMBER_CATEGORY(
             USER_ID, CATEGORY_CODE
             , SEQ
@@ -368,7 +368,7 @@
         )
     </insert>
 
-    <insert id="teacherSubjectInsert" parameterType="hashMap" flushCache="true">
+    <insert id="teacherSubjectInsert" parameterType="com.academy.lecture.service.TeacherVO" flushCache="true">
         INSERT INTO TB_MA_MEMBER_SUBJECT(
             USER_ID, SUBJECT_CD, REG_DT, REG_ID, UPD_DT, UPD_ID
             <if test='USE_ON != null and USE_ON != ""'>
@@ -388,18 +388,18 @@
         )
     </insert>
 	
-	<update id="teacherSubjectUpdate" parameterType="hashMap" flushCache="true">
+	<update id="teacherSubjectUpdate" parameterType="com.academy.lecture.service.TeacherVO" flushCache="true">
         update TB_MA_MEMBER_SUBJECT 
         SET USE_OFF = #{USE_OFF} 
         WHERE USER_ID = #{USER_ID} 
         AND SUBJECT_CD = #{SUBJECT_CD}
     </update>
 	
-	<select id="teacherSubjectCount" parameterType="hashMap" resultType="int">
+	<select id="teacherSubjectCount" parameterType="com.academy.lecture.service.TeacherVO" resultType="int">
 	SELECT COUNT(*) FROM TB_MA_MEMBER_SUBJECT WHERE USER_ID = #{USER_ID} AND SUBJECT_CD = #{SUBJECT_CD}
 	</select>
 	
-    <update id="teacherUpdate" parameterType="hashMap">
+    <update id="teacherUpdate" parameterType="com.academy.lecture.service.TeacherVO">
         UPDATE TB_MA_MEMBER
             SET USER_NM = #{USER_NM}
             , USER_NICKNM = #{USER_NICKNM}
@@ -520,24 +520,24 @@
         WHERE USER_ID = #{USER_ID}
     </update>
 
-    <delete id="teacherIsUseUpdate" parameterType="hashMap" flushCache="true">
+    <delete id="teacherIsUseUpdate" parameterType="com.academy.lecture.service.TeacherVO" flushCache="true">
         UPDATE TB_MA_MEMBER SET ISUSE = 'N', ON_OPENYN = 'N', OFF_OPENYN = 'N' WHERE USER_ID = #{USER_ID}
         <!-- DELETE FROM TB_MA_MEMBER WHERE USER_ID = #{USER_ID} -->
     </delete>
 
-    <delete id="teacherDelete" parameterType="hashMap" flushCache="true">
+    <delete id="teacherDelete" parameterType="com.academy.lecture.service.TeacherVO" flushCache="true">
         DELETE FROM TB_MA_MEMBER WHERE USER_ID = #{USER_ID}
     </delete>
 
-    <delete id="teacherCategoryDelete" parameterType="hashMap" flushCache="true">
+    <delete id="teacherCategoryDelete" parameterType="com.academy.lecture.service.TeacherVO" flushCache="true">
         DELETE FROM TB_MA_MEMBER_CATEGORY WHERE USER_ID = #{USER_ID}    AND CATEGORY_CODE = #{DEL_CATEGORY_CODE}
     </delete>
 
-    <delete id="teacherSubjectDelete" parameterType="hashMap" flushCache="true">
+    <delete id="teacherSubjectDelete" parameterType="com.academy.lecture.service.TeacherVO" flushCache="true">
         DELETE FROM TB_MA_MEMBER_SUBJECT WHERE USER_ID = #{USER_ID}
     </delete>
 
-    <update id="teacherSeqUpdate" parameterType="hashMap">
+    <update id="teacherSeqUpdate" parameterType="com.academy.lecture.service.TeacherVO">
 		<choose>
             <when test="SEARCHCATEGORY == 'main'">
                 UPDATE TB_MA_MEMBER_MAIN_CATEGORY
@@ -566,39 +566,39 @@
         </choose>
     </update>
 
-    <select id="teacherBookLog" parameterType="hashMap" resultMap="teacherMap">
+    <select id="teacherBookLog" parameterType="com.academy.lecture.service.TeacherVO" resultMap="teacherMap">
         SELECT * FROM TB_CA_BOOK WHERE SUBJECT_SJT_CD LIKE '%'||#{USER_ID}||'%'
     </select>
 
-	<insert id="teacherMain_Category_Insert" parameterType="hashMap" flushCache="true">
+	<insert id="teacherMain_Category_Insert" parameterType="com.academy.lecture.service.TeacherVO" flushCache="true">
 		INSERT INTO TB_MA_MEMBER_MAIN_CATEGORY(USER_ID, CATEGORY_CODE, SEQ, REG_DT, REG_ID, UPD_DT, UPD_ID, SUBJECT_CD)
 		VALUES (#{USER_ID}, 'main', (SELECT NVL(MAX(SEQ), 0) + 1 FROM TB_MA_MEMBER_MAIN_CATEGORY), SYSDATE, #{UPD_ID}, SYSDATE, #{UPD_ID}, #{SUBJECT_CD})
 	</insert>
 
-	<delete id="teacherMain_Category_Delete" parameterType="hashMap" flushCache="true">
+	<delete id="teacherMain_Category_Delete" parameterType="com.academy.lecture.service.TeacherVO" flushCache="true">
 		DELETE FROM TB_MA_MEMBER_MAIN_CATEGORY WHERE USER_ID = #{USER_ID}
 	</delete>
 	
-	<insert id="teacherIntro_Category_Insert" parameterType="hashMap" flushCache="true">
+	<insert id="teacherIntro_Category_Insert" parameterType="com.academy.lecture.service.TeacherVO" flushCache="true">
 		INSERT INTO TB_MA_MEMBER_INTRO_CATEGORY(USER_ID, CATEGORY_CODE, SEQ, REG_DT, REG_ID, UPD_DT, UPD_ID, SUBJECT_CD)
 		VALUES (#{USER_ID}, 'intro', (SELECT NVL(MAX(SEQ), 0) + 1 FROM TB_MA_MEMBER_INTRO_CATEGORY), SYSDATE, #{UPD_ID}, SYSDATE, #{UPD_ID}, #{SUBJECT_CD})
 	</insert>
 	
-	<insert id="teacherIntro_F_Category_Insert" parameterType="hashMap" flushCache="true">
+	<insert id="teacherIntro_F_Category_Insert" parameterType="com.academy.lecture.service.TeacherVO" flushCache="true">
 		INSERT INTO TB_MA_MEMBER_INTRO_F_CATEGORY(USER_ID, CATEGORY_CODE, SEQ, REG_DT, REG_ID, UPD_DT, UPD_ID, SUBJECT_CD)
 		VALUES (#{USER_ID}, 'intro_off', (SELECT NVL(MAX(SEQ), 0) + 1 FROM TB_MA_MEMBER_INTRO_F_CATEGORY), SYSDATE, #{UPD_ID}, SYSDATE, #{UPD_ID}, #{SUBJECT_CD})
 	</insert>
 
-	<delete id="teacherIntro_Category_Delete" parameterType="hashMap" flushCache="true">
+	<delete id="teacherIntro_Category_Delete" parameterType="com.academy.lecture.service.TeacherVO" flushCache="true">
 		DELETE FROM TB_MA_MEMBER_INTRO_CATEGORY WHERE USER_ID = #{USER_ID}
 	</delete>
 	
-	<delete id="teacherIntro_F_Category_Delete" parameterType="hashMap" flushCache="true">
+	<delete id="teacherIntro_F_Category_Delete" parameterType="com.academy.lecture.service.TeacherVO" flushCache="true">
 		DELETE FROM TB_MA_MEMBER_INTRO_F_CATEGORY WHERE USER_ID = #{USER_ID}
 	</delete>
 	
 
-	<select id="teacherMainListCount" parameterType="hashMap" resultType="int">
+	<select id="teacherMainListCount" parameterType="com.academy.lecture.service.TeacherVO" resultType="int">
 		SELECT COUNT(*)
         FROM(
 		SELECT COUNT(A.USER_ID)
@@ -632,7 +632,7 @@
 
 	</select>
 
-	<select id="teacherIntroListCount" parameterType="hashMap" resultType="int">
+	<select id="teacherIntroListCount" parameterType="com.academy.lecture.service.TeacherVO" resultType="int">
 		SELECT COUNT(*)
         FROM(
 		SELECT COUNT(A.USER_ID)
@@ -666,7 +666,7 @@
 
 	</select>
 	
-	<select id="teacherIntro_offListCount" parameterType="hashMap" resultType="int">
+	<select id="teacherIntro_offListCount" parameterType="com.academy.lecture.service.TeacherVO" resultType="int">
 		SELECT COUNT(*)
         FROM(
 		SELECT COUNT(A.USER_ID)
@@ -701,7 +701,7 @@
 	</select>
 
 
-	<select id="teacherMainList" parameterType="hashMap" resultType="hashMap">
+	<select id="teacherMainList" parameterType="com.academy.lecture.service.TeacherVO" resultType="hashMap">
 
 		SELECT A.USER_ID, B.USER_NM, B.ISUSE, B.EMAIL, B.PHONE_NO
                    , DECODE(B.ISUSE, 'Y', '공개', 'N', '비공개') ISUSENM
@@ -748,7 +748,7 @@
             ORDER BY MIN(D.IDX), C.SUBJECT_CD, A.SEQ
 	</select>
 
-	<select id="teacherIntroList" parameterType="hashMap" resultType="hashMap">
+	<select id="teacherIntroList" parameterType="com.academy.lecture.service.TeacherVO" resultType="hashMap">
 
 		SELECT A.USER_ID, B.USER_NM, B.ISUSE, B.EMAIL, B.PHONE_NO
                    , DECODE(B.ISUSE, 'Y', '공개', 'N', '비공개') ISUSENM
@@ -795,7 +795,7 @@
             ORDER BY MIN(D.IDX), C.SUBJECT_CD, A.SEQ
 	</select>
 
-	<select id="teacherIntro_offList" parameterType="hashMap" resultType="hashMap">
+	<select id="teacherIntro_offList" parameterType="com.academy.lecture.service.TeacherVO" resultType="hashMap">
 
 		SELECT A.USER_ID, B.USER_NM, B.ISUSE, B.EMAIL, B.PHONE_NO
                    , DECODE(B.ISUSE, 'Y', '공개', 'N', '비공개') ISUSENM
@@ -842,7 +842,7 @@
             ORDER BY MIN(D.IDX), C.SUBJECT_CD, A.SEQ
 	</select>
 
-    <select id="findTeacherList" parameterType="hashMap" resultType="hashMap">
+    <select id="findTeacherList" parameterType="com.academy.lecture.service.TeacherVO" resultType="hashMap">
         SELECT *
         FROM (
             SELECT
@@ -886,19 +886,19 @@
         ORDER BY USER_NM
     </select>
     
-    <select id="teacherMain_Category_Subject" parameterType="hashMap" resultType="int">
+    <select id="teacherMain_Category_Subject" parameterType="com.academy.lecture.service.TeacherVO" resultType="int">
 		SELECT COUNT(*) FROM TB_MA_MEMBER_MAIN_CATEGORY
 		WHERE USER_ID = #{USER_ID}
 		AND SUBJECT_CD = #{SUBJECT_CD}
 	</select>
 	
-    <select id="teacherIntro_Category_Subject" parameterType="hashMap" resultType="int">
+    <select id="teacherIntro_Category_Subject" parameterType="com.academy.lecture.service.TeacherVO" resultType="int">
 		SELECT COUNT(*) FROM TB_MA_MEMBER_INTRO_CATEGORY
 		WHERE USER_ID = #{USER_ID}
 		AND SUBJECT_CD = #{SUBJECT_CD}
 	</select>	
 	
-	<select id="teacherIntro_F_Category_Subject" parameterType="hashMap" resultType="int">
+	<select id="teacherIntro_F_Category_Subject" parameterType="com.academy.lecture.service.TeacherVO" resultType="int">
 		SELECT COUNT(*) FROM TB_MA_MEMBER_INTRO_F_CATEGORY
 		WHERE USER_ID = #{USER_ID}
 		AND SUBJECT_CD = #{SUBJECT_CD}

--- a/src/main/resources/mapper/productEventSQL.xml
+++ b/src/main/resources/mapper/productEventSQL.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ProductEvent">
+<mapper namespace="com.academy.mapper.ProductEventMapper">
 
-	<select id="list" parameterType="hashMap" resultType="hashMap">
+	<select id="list" parameterType="com.academy.lecture.service.ProductEventVO" resultType="hashMap">
 		SELECT A.*, (SELECT COUNT(LECCODE) FROM PRD_EVENT_DET WHERE EVENT_ID = A.EVENT_ID) CNT
 		FROM PRD_EVENT A
 	</select>
 	
-	<select id="listCount" parameterType="hashMap" resultType="int">
+	<select id="listCount" parameterType="com.academy.lecture.service.ProductEventVO" resultType="int">
 		SELECT COUNT(*) 
 		FROM PRD_EVENT 
 	</select>
 
-	<select id="getOne" parameterType="hashMap" resultType="hashMap">
+	<select id="getOne" parameterType="com.academy.lecture.service.ProductEventVO" resultType="hashMap">
 		SELECT * 
 		FROM PRD_EVENT
 		WHERE EVENT_ID = #{EVENT_ID}
 	</select>
 
-	<insert id="insert" parameterType="hashMap" flushCache="true">
+	<insert id="insert" parameterType="com.academy.lecture.service.ProductEventVO" flushCache="true">
 		INSERT INTO PRD_EVENT(
 			EVENT_ID, EVENT_NM, EVENT_TYPE, EVENT_AMOUNT, ST_DATE, ED_DATE, EVENT_YN
 		) VALUES (
@@ -26,7 +26,7 @@
 		)
 	</insert>
 
-	<update id="update" parameterType="hashMap">
+	<update id="update" parameterType="com.academy.lecture.service.ProductEventVO">
 		UPDATE PRD_EVENT
 			SET 
 				EVENT_NM = #{EVENT_NM}
@@ -38,7 +38,7 @@
 			WHERE EVENT_ID = #{EVENT_ID}
 	</update>
 
-	<select id="list_prd" parameterType="hashMap" resultType="hashMap">
+	<select id="list_prd" parameterType="com.academy.lecture.service.ProductEventVO" resultType="hashMap">
 		SELECT A.EVENT_ID, A.EVENT_NM, B.LECCODE, C.SUBJECT_TITLE
 		FROM PRD_EVENT A, PRD_EVENT_DET B, TB_LEC_MST C
 		WHERE A.EVENT_ID = B.EVENT_ID
@@ -46,12 +46,12 @@
 		AND A.EVENT_ID = #{EVENT_ID}
 	</select>
 
-	<insert id="lec_insert" parameterType="hashMap" flushCache="true">
+	<insert id="lec_insert" parameterType="com.academy.lecture.service.ProductEventVO" flushCache="true">
 		INSERT INTO PRD_EVENT_DET(EVENT_ID, LECCODE, OBJ_CD) 
 		VALUES (#{EVENT_ID}, #{LECCODE}, 'L')
 	</insert>
 
-	<update id="lec_delete" parameterType="hashMap">
+	<update id="lec_delete" parameterType="com.academy.lecture.service.ProductEventVO">
 		DELETE PRD_EVENT_DET
 		WHERE EVENT_ID = #{EVENT_ID}
 		AND LECCODE = #{LECCODE}


### PR DESCRIPTION
…ses across mappers

Updated MyBatis mapper files to use specific VO classes (e.g., `LectureVO`, `KindVO`, `SeriesVO`, etc.) instead of generic `hashMap`. Improved type safety, readability, and consistency across the application. Modified relevant VO classes and database operation methods accordingly.