### PR TITLE
feat: implement Banner management APIs and MyBatis mappers

### DIFF
--- a/src/main/java/com/academy/banner/BannerApi.java
+++ b/src/main/java/com/academy/banner/BannerApi.java
@@ -1,0 +1,350 @@
+package com.academy.banner;
+
+import java.util.HashMap;
+import java.util.List;
+
+import org.json.simple.JSONObject;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.academy.banner.service.BannerItemVO;
+import com.academy.banner.service.BannerService;
+import com.academy.banner.service.BannerVO;
+import com.academy.common.CORSFilter;
+import com.academy.common.PaginationInfo;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * 배너 관리 API Controller
+ * @author system
+ * @version 1.0
+ * @see
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *    수정일           수정자                수정내용
+ *  ---------------    --------------    ---------------------------
+ *  2025.12.10         system            배너 관리 등록
+ * </pre>
+ */
+@Tag(name = "Banner", description = "배너 관리 API")
+@RestController
+@RequestMapping("/api/banner")
+public class BannerApi extends CORSFilter {
+
+    private final BannerService bannerService;
+
+    public BannerApi(BannerService bannerService) {
+        this.bannerService = bannerService;
+    }
+
+    // =====================================================
+    // 배너 마스터 (TB_BANNER) API
+    // =====================================================
+
+    /**
+     * 배너 목록 조회
+     */
+    @Operation(summary = "배너 목록 조회", description = "페이징 처리된 배너 목록을 조회합니다.")
+    @GetMapping(value = "/getBannerList")
+    public JSONObject getBannerList(@ModelAttribute("BannerVO") BannerVO bannerVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        // paging
+        PaginationInfo paginationInfo = new PaginationInfo();
+        paginationInfo.setCurrentPageNo(bannerVO.getPageIndex());
+        paginationInfo.setRecordCountPerPage(bannerVO.getPageUnit());
+        paginationInfo.setPageSize(bannerVO.getPageSize());
+
+        bannerVO.setFirstIndex(paginationInfo.getFirstRecordIndex());
+        bannerVO.setLastIndex(paginationInfo.getLastRecordIndex());
+        bannerVO.setRecordCountPerPage(paginationInfo.getRecordCountPerPage());
+
+        jsonObject.put("bannerList", bannerService.selectBannerList(bannerVO));
+
+        int totCnt = bannerService.selectBannerListCount(bannerVO);
+        paginationInfo.setTotalRecordCount(totCnt);
+        jsonObject.put("paginationInfo", paginationInfo);
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    /**
+     * 배너 상세 조회
+     */
+    @Operation(summary = "배너 상세 조회", description = "배너 상세 정보를 조회합니다.")
+    @GetMapping(value = "/getBannerDetail")
+    public JSONObject getBannerDetail(@ModelAttribute("BannerVO") BannerVO bannerVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        jsonObject.put("bannerDetail", bannerService.selectBannerDetail(bannerVO));
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    /**
+     * 배너 등록
+     */
+    @Operation(summary = "배너 등록", description = "새로운 배너를 등록합니다.")
+    @PostMapping(value = "/insertBanner")
+    public JSONObject insertBanner(@ModelAttribute("BannerVO") BannerVO bannerVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        try {
+            bannerService.insertBanner(bannerVO);
+            jsonObject.put("retMsg", "OK");
+            jsonObject.put("seq", bannerVO.getSeq());
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            e.printStackTrace();
+        }
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    /**
+     * 배너 수정
+     */
+    @Operation(summary = "배너 수정", description = "배너 정보를 수정합니다.")
+    @PostMapping(value = "/updateBanner")
+    public JSONObject updateBanner(@ModelAttribute("BannerVO") BannerVO bannerVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        try {
+            bannerService.updateBanner(bannerVO);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            e.printStackTrace();
+        }
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    /**
+     * 배너 타입 일괄 변경
+     */
+    @Operation(summary = "배너 타입 일괄 변경", description = "배너 타입을 일괄 변경합니다.")
+    @PostMapping(value = "/updateBannerTypeList")
+    public JSONObject updateBannerTypeList(@RequestBody List<BannerVO> bannerVOList) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        try {
+            bannerService.updateBannerTypeList(bannerVOList);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            e.printStackTrace();
+        }
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    /**
+     * 배너 삭제
+     */
+    @Operation(summary = "배너 삭제", description = "배너를 삭제합니다. (연결된 아이템도 함께 삭제)")
+    @PostMapping(value = "/deleteBanner")
+    public JSONObject deleteBanner(@ModelAttribute("BannerVO") BannerVO bannerVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        try {
+            bannerService.deleteBanner(bannerVO);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            e.printStackTrace();
+        }
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    // =====================================================
+    // 배너 아이템 (TB_BANNER_ITEM) API
+    // =====================================================
+
+    /**
+     * 배너 아이템 목록 조회
+     */
+    @Operation(summary = "배너 아이템 목록 조회", description = "페이징 처리된 배너 아이템 목록을 조회합니다.")
+    @GetMapping(value = "/getBannerItemList")
+    public JSONObject getBannerItemList(@ModelAttribute("BannerItemVO") BannerItemVO bannerItemVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        // paging
+        PaginationInfo paginationInfo = new PaginationInfo();
+        paginationInfo.setCurrentPageNo(bannerItemVO.getPageIndex());
+        paginationInfo.setRecordCountPerPage(bannerItemVO.getPageUnit());
+        paginationInfo.setPageSize(bannerItemVO.getPageSize());
+
+        bannerItemVO.setFirstIndex(paginationInfo.getFirstRecordIndex());
+        bannerItemVO.setLastIndex(paginationInfo.getLastRecordIndex());
+        bannerItemVO.setRecordCountPerPage(paginationInfo.getRecordCountPerPage());
+
+        // 부모 배너 정보도 함께 조회
+        BannerVO parentBannerVO = new BannerVO();
+        parentBannerVO.setSeq(bannerItemVO.getpSeq());
+        jsonObject.put("parentBanner", bannerService.selectBannerDetail(parentBannerVO));
+
+        jsonObject.put("bannerItemList", bannerService.selectBannerItemList(bannerItemVO));
+
+        int totCnt = bannerService.selectBannerItemListCount(bannerItemVO);
+        paginationInfo.setTotalRecordCount(totCnt);
+        jsonObject.put("paginationInfo", paginationInfo);
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    /**
+     * 배너 아이템 상세 조회
+     */
+    @Operation(summary = "배너 아이템 상세 조회", description = "배너 아이템 상세 정보를 조회합니다.")
+    @GetMapping(value = "/getBannerItemDetail")
+    public JSONObject getBannerItemDetail(@ModelAttribute("BannerItemVO") BannerItemVO bannerItemVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        jsonObject.put("bannerItemDetail", bannerService.selectBannerItemDetail(bannerItemVO));
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    /**
+     * 배너 아이템 등록
+     */
+    @Operation(summary = "배너 아이템 등록", description = "새로운 배너 아이템을 등록합니다.")
+    @PostMapping(value = "/insertBannerItem")
+    public JSONObject insertBannerItem(@ModelAttribute("BannerItemVO") BannerItemVO bannerItemVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        try {
+            bannerService.insertBannerItem(bannerItemVO);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            e.printStackTrace();
+        }
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    /**
+     * 배너 아이템 수정
+     */
+    @Operation(summary = "배너 아이템 수정", description = "배너 아이템 정보를 수정합니다.")
+    @PostMapping(value = "/updateBannerItem")
+    public JSONObject updateBannerItem(@ModelAttribute("BannerItemVO") BannerItemVO bannerItemVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        try {
+            bannerService.updateBannerItem(bannerItemVO);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            e.printStackTrace();
+        }
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    /**
+     * 배너 아이템 순서/사용여부 일괄 수정
+     */
+    @Operation(summary = "배너 아이템 순서 일괄 수정", description = "배너 아이템 순서 및 사용여부를 일괄 수정합니다.")
+    @PostMapping(value = "/updateBannerItemOrderList")
+    public JSONObject updateBannerItemOrderList(@RequestBody List<BannerItemVO> bannerItemVOList) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        try {
+            bannerService.updateBannerItemOrderList(bannerItemVOList);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            e.printStackTrace();
+        }
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    /**
+     * 배너 아이템 삭제
+     */
+    @Operation(summary = "배너 아이템 삭제", description = "배너 아이템을 삭제합니다.")
+    @PostMapping(value = "/deleteBannerItem")
+    public JSONObject deleteBannerItem(@ModelAttribute("BannerItemVO") BannerItemVO bannerItemVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        try {
+            bannerService.deleteBannerItem(bannerItemVO);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            e.printStackTrace();
+        }
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    /**
+     * 배너 아이템 일괄 삭제
+     */
+    @Operation(summary = "배너 아이템 일괄 삭제", description = "배너 아이템을 일괄 삭제합니다.")
+    @PostMapping(value = "/deleteBannerItemList")
+    public JSONObject deleteBannerItemList(@RequestBody List<BannerItemVO> bannerItemVOList) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        try {
+            bannerService.deleteBannerItemList(bannerItemVOList);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            e.printStackTrace();
+        }
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+}

--- a/src/main/java/com/academy/banner/service/BannerItemVO.java
+++ b/src/main/java/com/academy/banner/service/BannerItemVO.java
@@ -1,0 +1,310 @@
+package com.academy.banner.service;
+
+import java.io.Serializable;
+
+import com.academy.common.CommonVO;
+
+/**
+ * 배너 아이템 VO 클래스 (TB_BANNER_ITEM 테이블 매핑)
+ * @author system
+ * @version 1.0
+ * @see
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *    수정일           수정자                수정내용
+ *  ---------------    --------------    ---------------------------
+ *  2025.12.10         system            배너 아이템 관리 등록
+ * </pre>
+ */
+public class BannerItemVO extends CommonVO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** 배너 아이템 SEQ (Primary Key) */
+    private String seq;
+
+    /** 부모 배너 SEQ (TB_BANNER.SEQ) */
+    private String pSeq;
+
+    /** 노출 순서 */
+    private int rolIdx;
+
+    /** 배너 부제목 */
+    private String bannerSubtitle;
+
+    /** 배너 설명 */
+    private String bannerNote;
+
+    /** 배너 이미지 경로 */
+    private String bannerImage;
+
+    /** 배너 썸네일 이미지 경로 */
+    private String bannerThumbnailImage;
+
+    /** 배너 링크 URL */
+    private String bannerLink;
+
+    /** 배너 링크 타겟 (_blank, _self 등) */
+    private String bannerLinkTarget;
+
+    /** 배너 링크 텍스트 (조회용) */
+    private String bannerLinkTxt;
+
+    /** 배너 시작일 */
+    private String bannerSdt;
+
+    /** 배너 종료일 */
+    private String bannerEdt;
+
+    /** 클릭수 */
+    private int clickCnt;
+
+    /** 그룹 SEQ (카테고리 일괄 등록용) */
+    private String gSeq;
+
+    /** 배너 타입 (부모에서 가져옴, 조회용) */
+    private String bannerTyp;
+
+    /** 온/오프라인 구분 (조회용) */
+    private String onoffDiv;
+
+    /** 화면 구분 (조회용) */
+    private String screenGubun;
+
+    /** 카테고리 코드 (조회용) */
+    private String categoryCd;
+
+    /** 배너 번호 (조회용) */
+    private String bannerNo;
+
+    /** 카테고리 코드 목록 (일괄 등록용, / 구분자) */
+    private String categoryCds;
+
+    /** 원래 카테고리 코드 목록 (수정용) */
+    private String orgCategoryCds;
+
+    /** 검색 조건 - 검색어 */
+    private String searchText;
+
+    /** 검색 조건 - 노출순서 */
+    private String searchRolIdx;
+
+    /** 검색 조건 - 사용여부 */
+    private String searchIsUse;
+
+    /** 검색 조건 - 서브카테고리 */
+    private String searchSubCategory;
+
+    /** 메뉴타입 (FM_ROOT: 오프라인, OM_ROOT: 온라인) */
+    private String menuType;
+
+    // Getters and Setters
+    public String getSeq() {
+        return seq;
+    }
+
+    public void setSeq(String seq) {
+        this.seq = seq;
+    }
+
+    public String getpSeq() {
+        return pSeq;
+    }
+
+    public void setpSeq(String pSeq) {
+        this.pSeq = pSeq;
+    }
+
+    public int getRolIdx() {
+        return rolIdx;
+    }
+
+    public void setRolIdx(int rolIdx) {
+        this.rolIdx = rolIdx;
+    }
+
+    public String getBannerSubtitle() {
+        return bannerSubtitle;
+    }
+
+    public void setBannerSubtitle(String bannerSubtitle) {
+        this.bannerSubtitle = bannerSubtitle;
+    }
+
+    public String getBannerNote() {
+        return bannerNote;
+    }
+
+    public void setBannerNote(String bannerNote) {
+        this.bannerNote = bannerNote;
+    }
+
+    public String getBannerImage() {
+        return bannerImage;
+    }
+
+    public void setBannerImage(String bannerImage) {
+        this.bannerImage = bannerImage;
+    }
+
+    public String getBannerThumbnailImage() {
+        return bannerThumbnailImage;
+    }
+
+    public void setBannerThumbnailImage(String bannerThumbnailImage) {
+        this.bannerThumbnailImage = bannerThumbnailImage;
+    }
+
+    public String getBannerLink() {
+        return bannerLink;
+    }
+
+    public void setBannerLink(String bannerLink) {
+        this.bannerLink = bannerLink;
+    }
+
+    public String getBannerLinkTarget() {
+        return bannerLinkTarget;
+    }
+
+    public void setBannerLinkTarget(String bannerLinkTarget) {
+        this.bannerLinkTarget = bannerLinkTarget;
+    }
+
+    public String getBannerLinkTxt() {
+        return bannerLinkTxt;
+    }
+
+    public void setBannerLinkTxt(String bannerLinkTxt) {
+        this.bannerLinkTxt = bannerLinkTxt;
+    }
+
+    public String getBannerSdt() {
+        return bannerSdt;
+    }
+
+    public void setBannerSdt(String bannerSdt) {
+        this.bannerSdt = bannerSdt;
+    }
+
+    public String getBannerEdt() {
+        return bannerEdt;
+    }
+
+    public void setBannerEdt(String bannerEdt) {
+        this.bannerEdt = bannerEdt;
+    }
+
+    public int getClickCnt() {
+        return clickCnt;
+    }
+
+    public void setClickCnt(int clickCnt) {
+        this.clickCnt = clickCnt;
+    }
+
+    public String getgSeq() {
+        return gSeq;
+    }
+
+    public void setgSeq(String gSeq) {
+        this.gSeq = gSeq;
+    }
+
+    public String getBannerTyp() {
+        return bannerTyp;
+    }
+
+    public void setBannerTyp(String bannerTyp) {
+        this.bannerTyp = bannerTyp;
+    }
+
+    public String getOnoffDiv() {
+        return onoffDiv;
+    }
+
+    public void setOnoffDiv(String onoffDiv) {
+        this.onoffDiv = onoffDiv;
+    }
+
+    public String getScreenGubun() {
+        return screenGubun;
+    }
+
+    public void setScreenGubun(String screenGubun) {
+        this.screenGubun = screenGubun;
+    }
+
+    public String getCategoryCd() {
+        return categoryCd;
+    }
+
+    public void setCategoryCd(String categoryCd) {
+        this.categoryCd = categoryCd;
+    }
+
+    public String getBannerNo() {
+        return bannerNo;
+    }
+
+    public void setBannerNo(String bannerNo) {
+        this.bannerNo = bannerNo;
+    }
+
+    public String getCategoryCds() {
+        return categoryCds;
+    }
+
+    public void setCategoryCds(String categoryCds) {
+        this.categoryCds = categoryCds;
+    }
+
+    public String getOrgCategoryCds() {
+        return orgCategoryCds;
+    }
+
+    public void setOrgCategoryCds(String orgCategoryCds) {
+        this.orgCategoryCds = orgCategoryCds;
+    }
+
+    public String getSearchText() {
+        return searchText;
+    }
+
+    public void setSearchText(String searchText) {
+        this.searchText = searchText;
+    }
+
+    public String getSearchRolIdx() {
+        return searchRolIdx;
+    }
+
+    public void setSearchRolIdx(String searchRolIdx) {
+        this.searchRolIdx = searchRolIdx;
+    }
+
+    public String getSearchIsUse() {
+        return searchIsUse;
+    }
+
+    public void setSearchIsUse(String searchIsUse) {
+        this.searchIsUse = searchIsUse;
+    }
+
+    public String getSearchSubCategory() {
+        return searchSubCategory;
+    }
+
+    public void setSearchSubCategory(String searchSubCategory) {
+        this.searchSubCategory = searchSubCategory;
+    }
+
+    public String getMenuType() {
+        return menuType;
+    }
+
+    public void setMenuType(String menuType) {
+        this.menuType = menuType;
+    }
+}

--- a/src/main/java/com/academy/banner/service/BannerService.java
+++ b/src/main/java/com/academy/banner/service/BannerService.java
@@ -1,0 +1,210 @@
+package com.academy.banner.service;
+
+import java.io.Serializable;
+import java.util.List;
+
+import org.json.simple.JSONObject;
+import org.springframework.stereotype.Service;
+
+import com.academy.mapper.BannerMapper;
+
+/**
+ * 배너 관리 Service 클래스
+ * @author system
+ * @version 1.0
+ * @see
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *    수정일           수정자                수정내용
+ *  ---------------    --------------    ---------------------------
+ *  2025.12.10         system            배너 관리 등록
+ * </pre>
+ */
+@Service
+public class BannerService implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final BannerMapper bannerMapper;
+
+    public BannerService(BannerMapper bannerMapper) {
+        this.bannerMapper = bannerMapper;
+    }
+
+    // =====================================================
+    // 배너 마스터 (TB_BANNER) 관련
+    // =====================================================
+
+    /**
+     * 배너 목록 조회
+     * @param bannerVO 검색조건
+     * @return List 배너 목록
+     */
+    public List<JSONObject> selectBannerList(BannerVO bannerVO) {
+        return bannerMapper.selectBannerList(bannerVO);
+    }
+
+    /**
+     * 배너 목록 건수 조회
+     * @param bannerVO 검색조건
+     * @return int 배너 목록 건수
+     */
+    public int selectBannerListCount(BannerVO bannerVO) {
+        return bannerMapper.selectBannerListCount(bannerVO);
+    }
+
+    /**
+     * 배너 상세 조회
+     * @param bannerVO 검색조건
+     * @return JSONObject 배너 상세정보
+     */
+    public JSONObject selectBannerDetail(BannerVO bannerVO) {
+        return bannerMapper.selectBannerDetail(bannerVO);
+    }
+
+    /**
+     * 배너 등록
+     * @param bannerVO 배너정보
+     */
+    public void insertBanner(BannerVO bannerVO) {
+        bannerMapper.insertBanner(bannerVO);
+    }
+
+    /**
+     * 배너 수정
+     * @param bannerVO 배너정보
+     */
+    public void updateBanner(BannerVO bannerVO) {
+        bannerMapper.updateBanner(bannerVO);
+    }
+
+    /**
+     * 배너 타입 일괄 변경
+     * @param bannerVOList 배너정보 목록
+     */
+    public void updateBannerTypeList(List<BannerVO> bannerVOList) {
+        if (bannerVOList != null && !bannerVOList.isEmpty()) {
+            for (BannerVO bannerVO : bannerVOList) {
+                bannerMapper.updateBannerType(bannerVO);
+                // 배너 타입 변경 시 연결된 아이템 삭제
+                bannerMapper.deleteBannerItemByParent(bannerVO);
+            }
+        }
+    }
+
+    /**
+     * 배너 삭제 (연결된 아이템도 함께 삭제)
+     * @param bannerVO 배너정보
+     */
+    public void deleteBanner(BannerVO bannerVO) {
+        // 연결된 아이템 먼저 삭제
+        bannerMapper.deleteBannerItemByParent(bannerVO);
+        // 배너 삭제
+        bannerMapper.deleteBanner(bannerVO);
+    }
+
+    // =====================================================
+    // 배너 아이템 (TB_BANNER_ITEM) 관련
+    // =====================================================
+
+    /**
+     * 배너 아이템 목록 조회
+     * @param bannerItemVO 검색조건
+     * @return List 배너 아이템 목록
+     */
+    public List<JSONObject> selectBannerItemList(BannerItemVO bannerItemVO) {
+        return bannerMapper.selectBannerItemList(bannerItemVO);
+    }
+
+    /**
+     * 배너 아이템 목록 건수 조회
+     * @param bannerItemVO 검색조건
+     * @return int 배너 아이템 목록 건수
+     */
+    public int selectBannerItemListCount(BannerItemVO bannerItemVO) {
+        return bannerMapper.selectBannerItemListCount(bannerItemVO);
+    }
+
+    /**
+     * 배너 아이템 상세 조회
+     * @param bannerItemVO 검색조건
+     * @return JSONObject 배너 아이템 상세정보
+     */
+    public JSONObject selectBannerItemDetail(BannerItemVO bannerItemVO) {
+        return bannerMapper.selectBannerItemDetail(bannerItemVO);
+    }
+
+    /**
+     * 배너 아이템 등록 (카테고리 일괄 등록 지원)
+     * @param bannerItemVO 배너 아이템 정보
+     */
+    public void insertBannerItem(BannerItemVO bannerItemVO) {
+        // G_SEQ 설정
+        int gSeq = bannerMapper.selectMaxGSeq();
+        bannerItemVO.setgSeq(String.valueOf(gSeq));
+
+        // 서브페이지이고 카테고리 목록이 있는 경우 일괄 등록
+        if ("S".equals(bannerItemVO.getScreenGubun()) &&
+            bannerItemVO.getCategoryCds() != null && !bannerItemVO.getCategoryCds().isEmpty()) {
+
+            String[] categoryCdArr = bannerItemVO.getCategoryCds().split("/");
+            for (String categoryCd : categoryCdArr) {
+                bannerItemVO.setCategoryCd(categoryCd);
+
+                // 해당 카테고리에 배너가 존재하는지 확인
+                int count = bannerMapper.selectBannerCountByCategory(bannerItemVO);
+                if (count > 0) {
+                    // 기존 배너에 아이템 추가
+                    bannerMapper.insertBannerItemByBannerNo(bannerItemVO);
+                } else {
+                    // 일반 등록
+                    bannerMapper.insertBannerItem(bannerItemVO);
+                }
+            }
+        } else {
+            // 일반 등록
+            bannerMapper.insertBannerItem(bannerItemVO);
+        }
+    }
+
+    /**
+     * 배너 아이템 수정
+     * @param bannerItemVO 배너 아이템 정보
+     */
+    public void updateBannerItem(BannerItemVO bannerItemVO) {
+        bannerMapper.updateBannerItem(bannerItemVO);
+    }
+
+    /**
+     * 배너 아이템 순서/사용여부 일괄 수정
+     * @param bannerItemVOList 배너 아이템 정보 목록
+     */
+    public void updateBannerItemOrderList(List<BannerItemVO> bannerItemVOList) {
+        if (bannerItemVOList != null && !bannerItemVOList.isEmpty()) {
+            for (BannerItemVO bannerItemVO : bannerItemVOList) {
+                bannerMapper.updateBannerItemOrder(bannerItemVO);
+            }
+        }
+    }
+
+    /**
+     * 배너 아이템 삭제
+     * @param bannerItemVO 배너 아이템 정보
+     */
+    public void deleteBannerItem(BannerItemVO bannerItemVO) {
+        bannerMapper.deleteBannerItem(bannerItemVO);
+    }
+
+    /**
+     * 배너 아이템 일괄 삭제
+     * @param bannerItemVOList 배너 아이템 정보 목록
+     */
+    public void deleteBannerItemList(List<BannerItemVO> bannerItemVOList) {
+        if (bannerItemVOList != null && !bannerItemVOList.isEmpty()) {
+            for (BannerItemVO bannerItemVO : bannerItemVOList) {
+                bannerMapper.deleteBannerItem(bannerItemVO);
+            }
+        }
+    }
+}

--- a/src/main/java/com/academy/banner/service/BannerVO.java
+++ b/src/main/java/com/academy/banner/service/BannerVO.java
@@ -1,0 +1,200 @@
+package com.academy.banner.service;
+
+import java.io.Serializable;
+
+import com.academy.common.CommonVO;
+
+/**
+ * 배너 VO 클래스 (TB_BANNER 테이블 매핑)
+ * @author system
+ * @version 1.0
+ * @see
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *    수정일           수정자                수정내용
+ *  ---------------    --------------    ---------------------------
+ *  2025.12.10         system            배너 관리 등록
+ * </pre>
+ */
+public class BannerVO extends CommonVO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** 배너 SEQ (Primary Key) */
+    private String seq;
+
+    /** 온/오프라인 구분 (O: 온라인, F: 오프라인) */
+    private String onoffDiv;
+
+    /** 화면 구분 (M: 메인홈, H: 모바일홈, S: 서브페이지) */
+    private String screenGubun;
+
+    /** 카테고리 코드 */
+    private String categoryCd;
+
+    /** 카테고리명 (조회용) */
+    private String categoryNm;
+
+    /** 배너 번호 */
+    private String bannerNo;
+
+    /** 배너 제목 */
+    private String bannerTitle;
+
+    /** 배너 타입 (I: 이미지, L: 강의, B: 게시판, P: 사람, T: 모의고사) */
+    private String bannerTyp;
+
+    /** 게시 시작일 */
+    private String openStartdate;
+
+    /** 게시 종료일 */
+    private String openEnddate;
+
+    /** 조회수 */
+    private int viewCount;
+
+    /** 연결된 배너아이템 수 (조회용) */
+    private int linkCount;
+
+    /** 검색 조건 - 메뉴타입 (FM_ROOT: 오프라인, OM_ROOT: 온라인) */
+    private String menuType;
+
+    /** 검색 조건 - 카테고리 */
+    private String searchCategory;
+
+    /** 검색 조건 - 배너번호 */
+    private String searchBannerNo;
+
+    /** 검색 조건 - 사용여부 */
+    private String searchIsUse;
+
+    // Getters and Setters
+    public String getSeq() {
+        return seq;
+    }
+
+    public void setSeq(String seq) {
+        this.seq = seq;
+    }
+
+    public String getOnoffDiv() {
+        return onoffDiv;
+    }
+
+    public void setOnoffDiv(String onoffDiv) {
+        this.onoffDiv = onoffDiv;
+    }
+
+    public String getScreenGubun() {
+        return screenGubun;
+    }
+
+    public void setScreenGubun(String screenGubun) {
+        this.screenGubun = screenGubun;
+    }
+
+    public String getCategoryCd() {
+        return categoryCd;
+    }
+
+    public void setCategoryCd(String categoryCd) {
+        this.categoryCd = categoryCd;
+    }
+
+    public String getCategoryNm() {
+        return categoryNm;
+    }
+
+    public void setCategoryNm(String categoryNm) {
+        this.categoryNm = categoryNm;
+    }
+
+    public String getBannerNo() {
+        return bannerNo;
+    }
+
+    public void setBannerNo(String bannerNo) {
+        this.bannerNo = bannerNo;
+    }
+
+    public String getBannerTitle() {
+        return bannerTitle;
+    }
+
+    public void setBannerTitle(String bannerTitle) {
+        this.bannerTitle = bannerTitle;
+    }
+
+    public String getBannerTyp() {
+        return bannerTyp;
+    }
+
+    public void setBannerTyp(String bannerTyp) {
+        this.bannerTyp = bannerTyp;
+    }
+
+    public String getOpenStartdate() {
+        return openStartdate;
+    }
+
+    public void setOpenStartdate(String openStartdate) {
+        this.openStartdate = openStartdate;
+    }
+
+    public String getOpenEnddate() {
+        return openEnddate;
+    }
+
+    public void setOpenEnddate(String openEnddate) {
+        this.openEnddate = openEnddate;
+    }
+
+    public int getViewCount() {
+        return viewCount;
+    }
+
+    public void setViewCount(int viewCount) {
+        this.viewCount = viewCount;
+    }
+
+    public int getLinkCount() {
+        return linkCount;
+    }
+
+    public void setLinkCount(int linkCount) {
+        this.linkCount = linkCount;
+    }
+
+    public String getMenuType() {
+        return menuType;
+    }
+
+    public void setMenuType(String menuType) {
+        this.menuType = menuType;
+    }
+
+    public String getSearchCategory() {
+        return searchCategory;
+    }
+
+    public void setSearchCategory(String searchCategory) {
+        this.searchCategory = searchCategory;
+    }
+
+    public String getSearchBannerNo() {
+        return searchBannerNo;
+    }
+
+    public void setSearchBannerNo(String searchBannerNo) {
+        this.searchBannerNo = searchBannerNo;
+    }
+
+    public String getSearchIsUse() {
+        return searchIsUse;
+    }
+
+    public void setSearchIsUse(String searchIsUse) {
+        this.searchIsUse = searchIsUse;
+    }
+}

--- a/src/main/java/com/academy/mapper/BannerMapper.java
+++ b/src/main/java/com/academy/mapper/BannerMapper.java
@@ -1,0 +1,151 @@
+package com.academy.mapper;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.json.simple.JSONObject;
+
+import com.academy.banner.service.BannerItemVO;
+import com.academy.banner.service.BannerVO;
+
+/**
+ * 배너정보에 관한 데이터 접근 클래스를 정의한다.
+ * @author system
+ * @since 2025.12.10
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일          수정자           수정내용
+ *  ----------------    --------    ---------------------------
+ *   2025.12.10         system          최초 생성
+ * </pre>
+ */
+@Mapper
+public interface BannerMapper {
+
+    // =====================================================
+    // 배너 마스터 (TB_BANNER) 관련
+    // =====================================================
+
+    /**
+     * 배너 목록 조회
+     * @param bannerVO 검색조건
+     * @return List 배너 목록정보
+     */
+    List<JSONObject> selectBannerList(BannerVO bannerVO);
+
+    /**
+     * 배너 목록 건수 조회
+     * @param bannerVO 검색조건
+     * @return int 배너 목록 건수
+     */
+    int selectBannerListCount(BannerVO bannerVO);
+
+    /**
+     * 배너 상세 조회
+     * @param bannerVO 검색조건
+     * @return JSONObject 배너 상세정보
+     */
+    JSONObject selectBannerDetail(BannerVO bannerVO);
+
+    /**
+     * 배너 등록
+     * @param bannerVO 배너정보
+     */
+    void insertBanner(BannerVO bannerVO);
+
+    /**
+     * 배너 수정
+     * @param bannerVO 배너정보
+     */
+    void updateBanner(BannerVO bannerVO);
+
+    /**
+     * 배너 타입 일괄 변경
+     * @param bannerVO 배너정보
+     */
+    void updateBannerType(BannerVO bannerVO);
+
+    /**
+     * 배너 삭제
+     * @param bannerVO 배너정보
+     */
+    void deleteBanner(BannerVO bannerVO);
+
+    // =====================================================
+    // 배너 아이템 (TB_BANNER_ITEM) 관련
+    // =====================================================
+
+    /**
+     * 배너 아이템 목록 조회
+     * @param bannerItemVO 검색조건
+     * @return List 배너 아이템 목록정보
+     */
+    List<JSONObject> selectBannerItemList(BannerItemVO bannerItemVO);
+
+    /**
+     * 배너 아이템 목록 건수 조회
+     * @param bannerItemVO 검색조건
+     * @return int 배너 아이템 목록 건수
+     */
+    int selectBannerItemListCount(BannerItemVO bannerItemVO);
+
+    /**
+     * 배너 아이템 상세 조회
+     * @param bannerItemVO 검색조건
+     * @return JSONObject 배너 아이템 상세정보
+     */
+    JSONObject selectBannerItemDetail(BannerItemVO bannerItemVO);
+
+    /**
+     * 배너 아이템 등록
+     * @param bannerItemVO 배너 아이템 정보
+     */
+    void insertBannerItem(BannerItemVO bannerItemVO);
+
+    /**
+     * 배너 아이템 수정
+     * @param bannerItemVO 배너 아이템 정보
+     */
+    void updateBannerItem(BannerItemVO bannerItemVO);
+
+    /**
+     * 배너 아이템 순서/사용여부 수정
+     * @param bannerItemVO 배너 아이템 정보
+     */
+    void updateBannerItemOrder(BannerItemVO bannerItemVO);
+
+    /**
+     * 배너 아이템 삭제
+     * @param bannerItemVO 배너 아이템 정보
+     */
+    void deleteBannerItem(BannerItemVO bannerItemVO);
+
+    /**
+     * 배너 아이템 일괄 삭제 (부모 배너 기준)
+     * @param bannerVO 배너 정보
+     */
+    void deleteBannerItemByParent(BannerVO bannerVO);
+
+    /**
+     * 카테고리별 배너 존재 여부 확인
+     * @param bannerItemVO 검색조건
+     * @return int 배너 수
+     */
+    int selectBannerCountByCategory(BannerItemVO bannerItemVO);
+
+    /**
+     * 배너번호 기준 아이템 일괄 등록 (카테고리 복사용)
+     * @param bannerItemVO 배너 아이템 정보
+     */
+    void insertBannerItemByBannerNo(BannerItemVO bannerItemVO);
+
+    /**
+     * 최대 G_SEQ 조회
+     * @return int 최대 G_SEQ
+     */
+    int selectMaxGSeq();
+}

--- a/src/main/resources/mapper/banner.xml
+++ b/src/main/resources/mapper/banner.xml
@@ -1,0 +1,500 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    수정일              수정자           수정내용
+  ===========      =========    =================
+ *2025.12.10       system       배너 관리 매퍼 생성 (MySQL 버전)
+-->
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.academy.mapper.BannerMapper">
+
+    <!-- =====================================================
+         배너 마스터 (TB_BANNER) 관련
+         ===================================================== -->
+
+    <!-- 배너 목록 조회 -->
+    <select id="selectBannerList" parameterType="com.academy.banner.service.BannerVO" resultType="org.json.simple.JSONObject">
+        SELECT
+            A.SEQ,
+            A.ONOFF_DIV,
+            A.SCREEN_GUBUN,
+            A.CATEGORY_CD,
+            CASE
+                WHEN A.SCREEN_GUBUN = 'M' THEN '메인홈'
+                WHEN A.SCREEN_GUBUN = 'H' THEN '모바일홈'
+                ELSE A.CATEGORY_CD
+            END AS CATEGORY_NM,
+            A.BANNER_NO,
+            A.BANNER_TITLE,
+            A.BANNER_TYP,
+            DATE_FORMAT(A.OPEN_STARTDATE, '%Y-%m-%d') AS OPEN_STARTDATE,
+            DATE_FORMAT(A.OPEN_ENDDATE, '%Y-%m-%d') AS OPEN_ENDDATE,
+            A.IS_USE,
+            A.VIEW_COUNT,
+            DATE_FORMAT(A.REG_DT, '%Y-%m-%d') AS REG_DT,
+            A.REG_ID,
+            DATE_FORMAT(A.UPD_DT, '%Y-%m-%d') AS UPD_DT,
+            A.UPD_ID,
+            (SELECT COUNT(B.SEQ) FROM TB_BANNER_ITEM B WHERE B.P_SEQ = A.SEQ) AS LINK_COUNT
+        FROM TB_BANNER A
+        WHERE 1=1
+        <if test="menuType != null and menuType != ''">
+            <choose>
+                <when test='menuType == "FM_ROOT"'>
+                    AND A.ONOFF_DIV = 'F'
+                </when>
+                <when test='menuType == "OM_ROOT"'>
+                    AND A.ONOFF_DIV = 'O'
+                </when>
+            </choose>
+        </if>
+        <if test="searchCategory != null and searchCategory != ''">
+            <choose>
+                <when test='searchCategory == "H"'>
+                    AND A.SCREEN_GUBUN = #{searchCategory}
+                </when>
+                <when test='searchCategory != "000"'>
+                    AND A.CATEGORY_CD = #{searchCategory}
+                </when>
+            </choose>
+        </if>
+        <if test="searchBannerNo != null and searchBannerNo != ''">
+            AND A.BANNER_NO = #{searchBannerNo}
+        </if>
+        <if test="searchIsUse != null and searchIsUse != ''">
+            AND A.IS_USE = #{searchIsUse}
+        </if>
+        ORDER BY A.IS_USE DESC, A.CATEGORY_CD DESC, A.BANNER_NO ASC
+        LIMIT #{recordCountPerPage} OFFSET #{firstIndex}
+    </select>
+
+    <!-- 배너 목록 건수 조회 -->
+    <select id="selectBannerListCount" parameterType="com.academy.banner.service.BannerVO" resultType="int">
+        SELECT COUNT(*) AS CNT
+        FROM TB_BANNER A
+        WHERE 1=1
+        <if test="menuType != null and menuType != ''">
+            <choose>
+                <when test='menuType == "FM_ROOT"'>
+                    AND A.ONOFF_DIV = 'F'
+                </when>
+                <when test='menuType == "OM_ROOT"'>
+                    AND A.ONOFF_DIV = 'O'
+                </when>
+            </choose>
+        </if>
+        <if test="searchCategory != null and searchCategory != ''">
+            <choose>
+                <when test='searchCategory == "H"'>
+                    AND A.SCREEN_GUBUN = #{searchCategory}
+                </when>
+                <when test='searchCategory != "000"'>
+                    AND A.CATEGORY_CD = #{searchCategory}
+                </when>
+            </choose>
+        </if>
+        <if test="searchBannerNo != null and searchBannerNo != ''">
+            AND A.BANNER_NO = #{searchBannerNo}
+        </if>
+        <if test="searchIsUse != null and searchIsUse != ''">
+            AND A.IS_USE = #{searchIsUse}
+        </if>
+    </select>
+
+    <!-- 배너 상세 조회 -->
+    <select id="selectBannerDetail" parameterType="com.academy.banner.service.BannerVO" resultType="org.json.simple.JSONObject">
+        SELECT
+            A.SEQ,
+            A.ONOFF_DIV,
+            A.SCREEN_GUBUN,
+            A.CATEGORY_CD,
+            CASE
+                WHEN A.SCREEN_GUBUN = 'M' THEN '메인홈'
+                WHEN A.SCREEN_GUBUN = 'H' THEN '모바일홈'
+                ELSE A.CATEGORY_CD
+            END AS CATEGORY_NM,
+            A.BANNER_NO,
+            A.BANNER_TITLE,
+            A.BANNER_TYP,
+            DATE_FORMAT(A.OPEN_STARTDATE, '%Y%m%d') AS OPEN_STARTDATE,
+            DATE_FORMAT(A.OPEN_ENDDATE, '%Y%m%d') AS OPEN_ENDDATE,
+            A.IS_USE,
+            A.VIEW_COUNT,
+            A.REG_DT,
+            A.REG_ID,
+            A.UPD_DT,
+            A.UPD_ID
+        FROM TB_BANNER A
+        WHERE A.SEQ = #{seq}
+    </select>
+
+    <!-- 배너 등록 -->
+    <insert id="insertBanner" parameterType="com.academy.banner.service.BannerVO">
+        <selectKey keyProperty="seq" resultType="String" order="BEFORE">
+            SELECT REPLACE(UUID(),'-','')
+        </selectKey>
+        INSERT INTO TB_BANNER (
+            SEQ,
+            ONOFF_DIV,
+            SCREEN_GUBUN,
+            CATEGORY_CD,
+            BANNER_NO,
+            BANNER_TITLE,
+            BANNER_TYP,
+            <if test="openStartdate != null and openStartdate != ''">
+            OPEN_STARTDATE,
+            </if>
+            <if test="openEnddate != null and openEnddate != ''">
+            OPEN_ENDDATE,
+            </if>
+            IS_USE,
+            VIEW_COUNT,
+            REG_DT,
+            REG_ID,
+            UPD_DT,
+            UPD_ID
+        ) VALUES (
+            #{seq},
+            #{onoffDiv},
+            #{screenGubun},
+            #{categoryCd},
+            #{bannerNo},
+            #{bannerTitle},
+            #{bannerTyp},
+            <if test="openStartdate != null and openStartdate != ''">
+            STR_TO_DATE(#{openStartdate}, '%Y-%m-%d'),
+            </if>
+            <if test="openEnddate != null and openEnddate != ''">
+            STR_TO_DATE(#{openEnddate}, '%Y-%m-%d'),
+            </if>
+            #{isUse},
+            0,
+            now(),
+            #{regId},
+            now(),
+            #{regId}
+        )
+    </insert>
+
+    <!-- 배너 수정 -->
+    <update id="updateBanner" parameterType="com.academy.banner.service.BannerVO">
+        UPDATE TB_BANNER
+        SET
+            SCREEN_GUBUN = #{screenGubun},
+            CATEGORY_CD = #{categoryCd},
+            BANNER_NO = #{bannerNo},
+            BANNER_TITLE = #{bannerTitle},
+            BANNER_TYP = #{bannerTyp},
+            <if test="openStartdate != null and openStartdate != ''">
+            OPEN_STARTDATE = STR_TO_DATE(#{openStartdate}, '%Y-%m-%d'),
+            </if>
+            <if test="openEnddate != null and openEnddate != ''">
+            OPEN_ENDDATE = STR_TO_DATE(#{openEnddate}, '%Y-%m-%d'),
+            </if>
+            IS_USE = #{isUse},
+            UPD_DT = now(),
+            UPD_ID = #{updId}
+        WHERE SEQ = #{seq}
+    </update>
+
+    <!-- 배너 타입 일괄 변경 -->
+    <update id="updateBannerType" parameterType="com.academy.banner.service.BannerVO">
+        UPDATE TB_BANNER
+        SET
+            BANNER_TYP = #{bannerTyp},
+            UPD_DT = now(),
+            UPD_ID = #{updId}
+        WHERE SEQ = #{seq}
+    </update>
+
+    <!-- 배너 삭제 -->
+    <delete id="deleteBanner" parameterType="com.academy.banner.service.BannerVO">
+        DELETE FROM TB_BANNER WHERE SEQ = #{seq}
+    </delete>
+
+
+    <!-- =====================================================
+         배너 아이템 (TB_BANNER_ITEM) 관련
+         ===================================================== -->
+
+    <!-- 배너 아이템 목록 조회 -->
+    <select id="selectBannerItemList" parameterType="com.academy.banner.service.BannerItemVO" resultType="org.json.simple.JSONObject">
+        SELECT
+            A.SEQ,
+            A.P_SEQ,
+            A.ROL_IDX,
+            A.BANNER_SUBTITLE,
+            A.BANNER_NOTE,
+            A.BANNER_IMAGE,
+            A.BANNER_THUMBNAIL_IMAGE,
+            DATE_FORMAT(A.BANNER_SDT, '%Y-%m-%d') AS BANNER_SDT,
+            DATE_FORMAT(A.BANNER_EDT, '%Y-%m-%d') AS BANNER_EDT,
+            A.CLICK_CNT,
+            A.IS_USE,
+            DATE_FORMAT(A.REG_DT, '%Y-%m-%d') AS REG_DT,
+            A.REG_ID,
+            DATE_FORMAT(A.UPD_DT, '%Y-%m-%d') AS UPD_DT,
+            A.UPD_ID,
+            A.G_SEQ
+        FROM TB_BANNER_ITEM A
+        WHERE A.P_SEQ = #{pSeq}
+        <if test="searchText != null and searchText != ''">
+            AND A.BANNER_SUBTITLE LIKE CONCAT('%', #{searchText}, '%')
+        </if>
+        <if test="searchRolIdx != null and searchRolIdx != ''">
+            AND A.ROL_IDX = #{searchRolIdx}
+        </if>
+        <if test="searchIsUse != null and searchIsUse != ''">
+            AND A.IS_USE = #{searchIsUse}
+        </if>
+        <if test="searchSubCategory != null and searchSubCategory != ''">
+            <choose>
+                <when test='searchSubCategory == "H"'>
+                    AND A.SCREEN_GUBUN = #{searchSubCategory}
+                </when>
+                <when test='searchSubCategory != "000"'>
+                    AND A.CATEGORY_CD = #{searchSubCategory}
+                </when>
+            </choose>
+        </if>
+        ORDER BY A.ROL_IDX ASC, A.SEQ DESC
+        LIMIT #{recordCountPerPage} OFFSET #{firstIndex}
+    </select>
+
+    <!-- 배너 아이템 목록 건수 조회 -->
+    <select id="selectBannerItemListCount" parameterType="com.academy.banner.service.BannerItemVO" resultType="int">
+        SELECT COUNT(*) AS CNT
+        FROM TB_BANNER_ITEM A
+        WHERE A.P_SEQ = #{pSeq}
+        <if test="searchText != null and searchText != ''">
+            AND A.BANNER_SUBTITLE LIKE CONCAT('%', #{searchText}, '%')
+        </if>
+        <if test="searchRolIdx != null and searchRolIdx != ''">
+            AND A.ROL_IDX = #{searchRolIdx}
+        </if>
+        <if test="searchIsUse != null and searchIsUse != ''">
+            AND A.IS_USE = #{searchIsUse}
+        </if>
+        <if test="searchSubCategory != null and searchSubCategory != ''">
+            <choose>
+                <when test='searchSubCategory == "H"'>
+                    AND A.SCREEN_GUBUN = #{searchSubCategory}
+                </when>
+                <when test='searchSubCategory != "000"'>
+                    AND A.CATEGORY_CD = #{searchSubCategory}
+                </when>
+            </choose>
+        </if>
+    </select>
+
+    <!-- 배너 아이템 상세 조회 -->
+    <select id="selectBannerItemDetail" parameterType="com.academy.banner.service.BannerItemVO" resultType="org.json.simple.JSONObject">
+        SELECT
+            B.SEQ,
+            B.P_SEQ,
+            B.ROL_IDX,
+            B.BANNER_SUBTITLE,
+            B.BANNER_NOTE,
+            B.BANNER_IMAGE,
+            B.BANNER_THUMBNAIL_IMAGE,
+            B.BANNER_LINK,
+            B.BANNER_LINK_TARGET,
+            DATE_FORMAT(B.BANNER_SDT, '%Y%m%d') AS BANNER_SDT,
+            DATE_FORMAT(B.BANNER_EDT, '%Y%m%d') AS BANNER_EDT,
+            B.CLICK_CNT,
+            B.IS_USE,
+            B.REG_DT,
+            B.REG_ID,
+            B.UPD_DT,
+            B.UPD_ID,
+            B.G_SEQ,
+            A.BANNER_TYP,
+            CASE
+                WHEN A.BANNER_TYP = 'I' THEN B.BANNER_IMAGE
+                ELSE B.BANNER_LINK
+            END AS BANNER_LINK_TXT
+        FROM TB_BANNER A
+        INNER JOIN TB_BANNER_ITEM B ON A.SEQ = B.P_SEQ
+        WHERE B.SEQ = #{seq}
+    </select>
+
+    <!-- 배너 아이템 등록 -->
+    <insert id="insertBannerItem" parameterType="com.academy.banner.service.BannerItemVO">
+        <selectKey keyProperty="seq" resultType="String" order="BEFORE">
+            SELECT REPLACE(UUID(),'-','')
+        </selectKey>
+        INSERT INTO TB_BANNER_ITEM (
+            SEQ,
+            P_SEQ,
+            ROL_IDX,
+            BANNER_SUBTITLE,
+            BANNER_NOTE,
+            <if test="bannerImage != null and bannerImage != ''">
+            BANNER_IMAGE,
+            </if>
+            <if test="bannerThumbnailImage != null and bannerThumbnailImage != ''">
+            BANNER_THUMBNAIL_IMAGE,
+            </if>
+            BANNER_LINK,
+            BANNER_LINK_TARGET,
+            BANNER_SDT,
+            BANNER_EDT,
+            CLICK_CNT,
+            IS_USE,
+            REG_DT,
+            REG_ID,
+            UPD_DT,
+            UPD_ID,
+            G_SEQ
+        ) VALUES (
+            #{seq},
+            #{pSeq},
+            #{rolIdx},
+            #{bannerSubtitle},
+            #{bannerNote},
+            <if test="bannerImage != null and bannerImage != ''">
+            #{bannerImage},
+            </if>
+            <if test="bannerThumbnailImage != null and bannerThumbnailImage != ''">
+            #{bannerThumbnailImage},
+            </if>
+            #{bannerLink},
+            #{bannerLinkTarget},
+            STR_TO_DATE(#{bannerSdt}, '%Y-%m-%d'),
+            STR_TO_DATE(#{bannerEdt}, '%Y-%m-%d'),
+            0,
+            #{isUse},
+            now(),
+            #{regId},
+            now(),
+            #{regId},
+            #{gSeq}
+        )
+    </insert>
+
+    <!-- 배너 아이템 수정 -->
+    <update id="updateBannerItem" parameterType="com.academy.banner.service.BannerItemVO">
+        UPDATE TB_BANNER_ITEM
+        SET
+            ROL_IDX = #{rolIdx},
+            BANNER_SUBTITLE = #{bannerSubtitle},
+            BANNER_NOTE = #{bannerNote},
+            <if test="bannerImage != null and bannerImage != ''">
+            BANNER_IMAGE = #{bannerImage},
+            </if>
+            <if test="bannerThumbnailImage != null and bannerThumbnailImage != ''">
+            BANNER_THUMBNAIL_IMAGE = #{bannerThumbnailImage},
+            </if>
+            BANNER_LINK = #{bannerLink},
+            BANNER_LINK_TARGET = #{bannerLinkTarget},
+            BANNER_SDT = STR_TO_DATE(#{bannerSdt}, '%Y-%m-%d'),
+            BANNER_EDT = STR_TO_DATE(#{bannerEdt}, '%Y-%m-%d'),
+            IS_USE = #{isUse},
+            UPD_DT = now(),
+            UPD_ID = #{updId}
+        WHERE SEQ = #{seq}
+    </update>
+
+    <!-- 배너 아이템 순서/사용여부 수정 -->
+    <update id="updateBannerItemOrder" parameterType="com.academy.banner.service.BannerItemVO">
+        UPDATE TB_BANNER_ITEM
+        SET
+            ROL_IDX = #{rolIdx},
+            <if test="isUse != null and isUse != ''">
+            IS_USE = #{isUse},
+            </if>
+            UPD_DT = now(),
+            UPD_ID = #{updId}
+        WHERE SEQ = #{seq}
+    </update>
+
+    <!-- 배너 아이템 삭제 -->
+    <delete id="deleteBannerItem" parameterType="com.academy.banner.service.BannerItemVO">
+        DELETE FROM TB_BANNER_ITEM WHERE SEQ = #{seq}
+    </delete>
+
+    <!-- 배너 아이템 일괄 삭제 (부모 배너 기준) -->
+    <delete id="deleteBannerItemByParent" parameterType="com.academy.banner.service.BannerVO">
+        DELETE FROM TB_BANNER_ITEM WHERE P_SEQ = #{seq}
+    </delete>
+
+    <!-- 카테고리별 배너 존재 여부 확인 -->
+    <select id="selectBannerCountByCategory" parameterType="com.academy.banner.service.BannerItemVO" resultType="int">
+        SELECT COUNT(*) AS CNT
+        FROM TB_BANNER
+        WHERE 1=1
+        <if test="onoffDiv != null and onoffDiv != ''">
+            AND ONOFF_DIV = #{onoffDiv}
+        </if>
+        <if test="screenGubun != null and screenGubun != ''">
+            AND SCREEN_GUBUN = #{screenGubun}
+        </if>
+        <if test="categoryCd != null and categoryCd != ''">
+            AND CATEGORY_CD = #{categoryCd}
+        </if>
+        <if test="bannerNo != null and bannerNo != ''">
+            AND BANNER_NO = #{bannerNo}
+        </if>
+    </select>
+
+    <!-- 배너번호 기준 아이템 일괄 등록 (카테고리 복사용) -->
+    <insert id="insertBannerItemByBannerNo" parameterType="com.academy.banner.service.BannerItemVO">
+        INSERT INTO TB_BANNER_ITEM (
+            SEQ,
+            P_SEQ,
+            ROL_IDX,
+            BANNER_SUBTITLE,
+            BANNER_NOTE,
+            <if test="bannerImage != null and bannerImage != ''">
+            BANNER_IMAGE,
+            </if>
+            <if test="bannerThumbnailImage != null and bannerThumbnailImage != ''">
+            BANNER_THUMBNAIL_IMAGE,
+            </if>
+            BANNER_LINK,
+            BANNER_LINK_TARGET,
+            BANNER_SDT,
+            BANNER_EDT,
+            CLICK_CNT,
+            IS_USE,
+            REG_DT,
+            REG_ID,
+            UPD_DT,
+            UPD_ID,
+            G_SEQ
+        )
+        SELECT
+            REPLACE(UUID(),'-','') AS SEQ,
+            A.SEQ AS P_SEQ,
+            #{rolIdx},
+            #{bannerSubtitle},
+            #{bannerNote},
+            <if test="bannerImage != null and bannerImage != ''">
+            #{bannerImage},
+            </if>
+            <if test="bannerThumbnailImage != null and bannerThumbnailImage != ''">
+            #{bannerThumbnailImage},
+            </if>
+            #{bannerLink},
+            #{bannerLinkTarget},
+            STR_TO_DATE(#{bannerSdt}, '%Y-%m-%d'),
+            STR_TO_DATE(#{bannerEdt}, '%Y-%m-%d'),
+            0,
+            #{isUse},
+            now(),
+            #{regId},
+            now(),
+            #{regId},
+            #{gSeq}
+        FROM TB_BANNER A
+        WHERE A.ONOFF_DIV = #{onoffDiv}
+        AND A.SCREEN_GUBUN = #{screenGubun}
+        AND A.CATEGORY_CD = #{categoryCd}
+        AND A.BANNER_NO = #{bannerNo}
+    </insert>
+
+    <!-- 최대 G_SEQ 조회 -->
+    <select id="selectMaxGSeq" resultType="int">
+        SELECT IFNULL(MAX(G_SEQ), 0) + 1 FROM TB_BANNER_ITEM
+    </select>
+
+</mapper>


### PR DESCRIPTION
Added APIs for CRUD operations on banners and banner items, including list, detail view, creation, update, and deletion. Created MyBatis mappers (`banner.xml`) and VO classes (`BannerVO`, `BannerItemVO`) to handle database interactions. Documented endpoints with Swagger annotations (`@Operation`, `@Tag`) for improved API usability.