### PR TITLE
feat: add Board Management module with VO, Mapper, and SQL files

### DIFF
--- a/src/main/java/com/academy/board/BoardApi.java
+++ b/src/main/java/com/academy/board/BoardApi.java
@@ -1,6 +1,7 @@
 package com.academy.board;
 
 import java.util.HashMap;
+import java.util.List;
 
 import org.json.simple.JSONObject;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -9,121 +10,821 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.academy.board.service.BoardCommentVO;
+import com.academy.board.service.BoardFileVO;
+import com.academy.board.service.BoardMngVO;
 import com.academy.board.service.BoardService;
 import com.academy.board.service.BoardVO;
 import com.academy.common.CORSFilter;
 import com.academy.common.PaginationInfo;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
+/**
+ * 게시판 관리 API 컨트롤러
+ * @author rainend
+ * @version 1.0
+ * @see
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *    수정일           수정자                수정내용
+ *  ---------------    --------------    ---------------------------
+ *  2025.11            rainend           게시판 등록
+ *  2025.12.10         system            게시판 관리 기능 확장 (게시판 관리, FAQ, 강사용, 미응답, 첨부파일, 코멘트)
+ * </pre>
+ */
 @Tag(name = "Board", description = "게시판 관리 API")
 @RestController
 @RequestMapping("/api/board")
 public class BoardApi extends CORSFilter {
 
-	private final BoardService boardService;
+    private final BoardService boardService;
 
     public BoardApi(BoardService boardService) {
         this.boardService = boardService;
     }
 
-	@Operation(summary = "게시판 목록 조회", description = "페이징 처리된 게시판 목록을 조회합니다.")
-	@GetMapping(value = "/getBoardList")
-	public JSONObject getBoardList(@ModelAttribute("BoardVO") BoardVO boardVO) throws Exception { 
-		
-		HashMap<String,Object> jsonObject = new HashMap<String,Object>();
-		
-		/** paging */
-		PaginationInfo paginationInfo = new PaginationInfo();
-		paginationInfo.setCurrentPageNo(boardVO.getPageIndex());
-		paginationInfo.setRecordCountPerPage(boardVO.getPageUnit());
-		paginationInfo.setPageSize(boardVO.getPageSize());
+    // =====================================================
+    // 게시판 관리 (TB_BOARD_MNG) 관련 API
+    // =====================================================
 
-		boardVO.setFirstIndex(paginationInfo.getFirstRecordIndex());
-		boardVO.setLastIndex(paginationInfo.getLastRecordIndex());
-		boardVO.setRecordCountPerPage(paginationInfo.getRecordCountPerPage());
-		
-		jsonObject.put("boardList", boardService.selectBoardList(boardVO));
+    @Operation(summary = "게시판 관리 목록 조회", description = "페이징 처리된 게시판 관리 목록을 조회합니다.")
+    @GetMapping(value = "/getBoardMngList")
+    public JSONObject getBoardMngList(@ModelAttribute("BoardMngVO") BoardMngVO boardMngVO) throws Exception {
 
-		int totCnt = boardService.selectBoardListTotCnt(boardVO);
-		paginationInfo.setTotalRecordCount(totCnt);
-		jsonObject.put("paginationInfo", paginationInfo);
-		
-		JSONObject jObject = new JSONObject(jsonObject);
-		
-		return jObject;
-	}
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
 
-	@Operation(summary = "게시판 상세 조회", description = "게시판 상세 정보를 조회합니다.")
-	@GetMapping(value = "/getBoardDetail")
-	public JSONObject getBoardDetail(@ModelAttribute("BoardVO") BoardVO boardVO) throws Exception { 
+        /** paging */
+        PaginationInfo paginationInfo = new PaginationInfo();
+        paginationInfo.setCurrentPageNo(boardMngVO.getPageIndex());
+        paginationInfo.setRecordCountPerPage(boardMngVO.getPageUnit());
+        paginationInfo.setPageSize(boardMngVO.getPageSize());
 
-		HashMap<String,Object> jsonObject = new HashMap<String,Object>();
-		
-		jsonObject.put("boardDetail", boardService.getBoardDetail(boardVO));
+        boardMngVO.setFirstIndex(paginationInfo.getFirstRecordIndex());
+        boardMngVO.setLastIndex(paginationInfo.getLastRecordIndex());
+        boardMngVO.setRecordCountPerPage(paginationInfo.getRecordCountPerPage());
 
-		JSONObject jObject = new JSONObject(jsonObject);
-		
-		return jObject;
-	}
+        jsonObject.put("boardMngList", boardService.selectBoardMngList(boardMngVO));
 
-	@Operation(summary = "게시물 등록", description = "새로운 게시물을 등록합니다.")
-	@PostMapping(value = "/insertBoard")
-	public JSONObject insertBoard(@ModelAttribute("BoardVO") BoardVO boardVO) throws Exception { 
+        int totCnt = boardService.selectBoardMngListCount(boardMngVO);
+        paginationInfo.setTotalRecordCount(totCnt);
+        jsonObject.put("paginationInfo", paginationInfo);
 
-		HashMap<String,Object> jsonObject = new HashMap<String,Object>();
+        JSONObject jObject = new JSONObject(jsonObject);
 
-		try {
-			boardService.insertBoard(boardVO);
-			jsonObject.put("retMsg", "OK");
-		} catch (Exception e){
-			jsonObject.put("retMsg", "FAIL");
-			e.printStackTrace();
-		}
-		
-		JSONObject jObject = new JSONObject(jsonObject);
+        return jObject;
+    }
 
-		return jObject;
-	}
+    @Operation(summary = "게시판 타입 목록 조회", description = "게시판 타입(공지, 일반 등) 목록을 조회합니다.")
+    @GetMapping(value = "/getBoardTypeList")
+    public JSONObject getBoardTypeList() throws Exception {
 
-	@Operation(summary = "게시물 수정", description = "게시물 정보를 수정합니다.")
-	@PostMapping(value="/updateBoard")
-	public JSONObject updateBoard(@ModelAttribute("BoardVO") BoardVO boardVO) throws Exception {
-		
-		HashMap<String,Object> jsonObject = new HashMap<String,Object>();
-		
-		try {
-			boardService.updateBoard(boardVO);
-			jsonObject.put("retMsg", "OK");
-		} catch (Exception e){
-			jsonObject.put("retMsg", "FAIL");
-			e.printStackTrace();
-		}
-	
-		JSONObject jObject = new JSONObject(jsonObject);
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
 
-		return jObject;
-	}
+        jsonObject.put("boardTypeList", boardService.selectBoardTypeList());
 
-	@Operation(summary = "게시물 삭제", description = "게시물을 삭제합니다.")
-	@PostMapping(value="/deleteBoard")
-	public JSONObject deleteBoard(@ModelAttribute("BoardVO") BoardVO boardVO) throws Exception {
+        JSONObject jObject = new JSONObject(jsonObject);
 
-		HashMap<String,Object> jsonObject = new HashMap<String,Object>();
-		
-		try {
-			boardService.deleteBoard(boardVO);
-			jsonObject.put("retMsg", "OK");
-		} catch (Exception e){
-			jsonObject.put("retMsg", "FAIL");
-			e.printStackTrace();
-		}
-		
-		JSONObject jObject = new JSONObject(jsonObject);
+        return jObject;
+    }
 
-		return jObject;
-	}
+    @Operation(summary = "게시판 관리 상세 조회", description = "게시판 관리 상세 정보를 조회합니다.")
+    @GetMapping(value = "/getBoardMngDetail")
+    public JSONObject getBoardMngDetail(@ModelAttribute("BoardMngVO") BoardMngVO boardMngVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        jsonObject.put("boardMngDetail", boardService.selectBoardMngDetail(boardMngVO));
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    @Operation(summary = "게시판 관리 등록", description = "새로운 게시판을 등록합니다.")
+    @PostMapping(value = "/insertBoardMng")
+    public JSONObject insertBoardMng(@ModelAttribute("BoardMngVO") BoardMngVO boardMngVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        try {
+            boardService.insertBoardMng(boardMngVO);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            e.printStackTrace();
+        }
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    @Operation(summary = "게시판 관리 수정", description = "게시판 관리 정보를 수정합니다.")
+    @PostMapping(value = "/updateBoardMng")
+    public JSONObject updateBoardMng(@ModelAttribute("BoardMngVO") BoardMngVO boardMngVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        try {
+            boardService.updateBoardMng(boardMngVO);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            e.printStackTrace();
+        }
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    @Operation(summary = "게시판 관리 삭제", description = "게시판을 삭제합니다.")
+    @PostMapping(value = "/deleteBoardMng")
+    public JSONObject deleteBoardMng(@ModelAttribute("BoardMngVO") BoardMngVO boardMngVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        try {
+            boardService.deleteBoardMng(boardMngVO);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            e.printStackTrace();
+        }
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    @Operation(summary = "게시판 관리 일괄 삭제", description = "선택된 게시판들을 일괄 삭제합니다.")
+    @PostMapping(value = "/deleteBoardMngBatch")
+    public JSONObject deleteBoardMngBatch(@ModelAttribute("BoardMngVO") BoardMngVO boardMngVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        try {
+            boardService.deleteBoardMngBatch(boardMngVO);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            e.printStackTrace();
+        }
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    @Operation(summary = "게시판 종류 정보 조회", description = "게시물 등록 시 필요한 게시판 종류 정보를 조회합니다.")
+    @GetMapping(value = "/getBoardKind")
+    public JSONObject getBoardKind(@ModelAttribute("BoardVO") BoardVO boardVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        jsonObject.put("boardKind", boardService.selectBoardKind(boardVO));
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    // =====================================================
+    // 게시판 (TB_BOARD) 관련 API
+    // =====================================================
+
+    @Operation(summary = "게시판 목록 조회", description = "페이징 처리된 게시판 목록을 조회합니다.")
+    @GetMapping(value = "/getBoardList")
+    public JSONObject getBoardList(@ModelAttribute("BoardVO") BoardVO boardVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        /** paging */
+        PaginationInfo paginationInfo = new PaginationInfo();
+        paginationInfo.setCurrentPageNo(boardVO.getPageIndex());
+        paginationInfo.setRecordCountPerPage(boardVO.getPageUnit());
+        paginationInfo.setPageSize(boardVO.getPageSize());
+
+        boardVO.setFirstIndex(paginationInfo.getFirstRecordIndex());
+        boardVO.setLastIndex(paginationInfo.getLastRecordIndex());
+        boardVO.setRecordCountPerPage(paginationInfo.getRecordCountPerPage());
+
+        jsonObject.put("boardList", boardService.selectBoardList(boardVO));
+
+        int totCnt = boardService.selectBoardListTotCnt(boardVO);
+        paginationInfo.setTotalRecordCount(totCnt);
+        jsonObject.put("paginationInfo", paginationInfo);
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    @Operation(summary = "미응답 게시판 목록 조회", description = "페이징 처리된 미응답 게시판 목록을 조회합니다.")
+    @GetMapping(value = "/getBoardNotAnswerList")
+    public JSONObject getBoardNotAnswerList(@ModelAttribute("BoardVO") BoardVO boardVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        /** paging */
+        PaginationInfo paginationInfo = new PaginationInfo();
+        paginationInfo.setCurrentPageNo(boardVO.getPageIndex());
+        paginationInfo.setRecordCountPerPage(boardVO.getPageUnit());
+        paginationInfo.setPageSize(boardVO.getPageSize());
+
+        boardVO.setFirstIndex(paginationInfo.getFirstRecordIndex());
+        boardVO.setLastIndex(paginationInfo.getLastRecordIndex());
+        boardVO.setRecordCountPerPage(paginationInfo.getRecordCountPerPage());
+
+        jsonObject.put("boardNotAnswerList", boardService.selectBoardNotAnswerList(boardVO));
+
+        int totCnt = boardService.selectBoardNotAnswerListCount(boardVO);
+        paginationInfo.setTotalRecordCount(totCnt);
+        jsonObject.put("paginationInfo", paginationInfo);
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    @Operation(summary = "FAQ 게시판 목록 조회", description = "페이징 처리된 FAQ 게시판 목록을 조회합니다.")
+    @GetMapping(value = "/getBoardFAQList")
+    public JSONObject getBoardFAQList(@ModelAttribute("BoardVO") BoardVO boardVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        /** paging */
+        PaginationInfo paginationInfo = new PaginationInfo();
+        paginationInfo.setCurrentPageNo(boardVO.getPageIndex());
+        paginationInfo.setRecordCountPerPage(boardVO.getPageUnit());
+        paginationInfo.setPageSize(boardVO.getPageSize());
+
+        boardVO.setFirstIndex(paginationInfo.getFirstRecordIndex());
+        boardVO.setLastIndex(paginationInfo.getLastRecordIndex());
+        boardVO.setRecordCountPerPage(paginationInfo.getRecordCountPerPage());
+
+        jsonObject.put("boardFAQList", boardService.selectBoardFAQList(boardVO));
+
+        int totCnt = boardService.selectBoardFAQListCount(boardVO);
+        paginationInfo.setTotalRecordCount(totCnt);
+        jsonObject.put("paginationInfo", paginationInfo);
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    @Operation(summary = "강사용 게시판 목록 조회", description = "페이징 처리된 강사용 게시판 목록을 조회합니다.")
+    @GetMapping(value = "/getBoardTeacherList")
+    public JSONObject getBoardTeacherList(@ModelAttribute("BoardVO") BoardVO boardVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        /** paging */
+        PaginationInfo paginationInfo = new PaginationInfo();
+        paginationInfo.setCurrentPageNo(boardVO.getPageIndex());
+        paginationInfo.setRecordCountPerPage(boardVO.getPageUnit());
+        paginationInfo.setPageSize(boardVO.getPageSize());
+
+        boardVO.setFirstIndex(paginationInfo.getFirstRecordIndex());
+        boardVO.setLastIndex(paginationInfo.getLastRecordIndex());
+        boardVO.setRecordCountPerPage(paginationInfo.getRecordCountPerPage());
+
+        jsonObject.put("boardTeacherList", boardService.selectBoardTeacherList(boardVO));
+
+        int totCnt = boardService.selectBoardTeacherListCount(boardVO);
+        paginationInfo.setTotalRecordCount(totCnt);
+        jsonObject.put("paginationInfo", paginationInfo);
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    @Operation(summary = "게시판 상세 조회", description = "게시판 상세 정보를 조회합니다.")
+    @GetMapping(value = "/getBoardDetail")
+    public JSONObject getBoardDetail(@ModelAttribute("BoardVO") BoardVO boardVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        jsonObject.put("boardDetail", boardService.getBoardDetail(boardVO));
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    @Operation(summary = "원본글 상세 조회", description = "답변글에서 참조하는 원본글 상세 정보를 조회합니다.")
+    @GetMapping(value = "/getBoardDetailOrigin")
+    public JSONObject getBoardDetailOrigin(@ModelAttribute("BoardVO") BoardVO boardVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        jsonObject.put("boardDetailOrigin", boardService.getBoardDetailOrigin(boardVO));
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    @Operation(summary = "게시물 등록", description = "새로운 게시물을 등록합니다.")
+    @PostMapping(value = "/insertBoard")
+    public JSONObject insertBoard(@ModelAttribute("BoardVO") BoardVO boardVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        try {
+            boardService.insertBoard(boardVO);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            e.printStackTrace();
+        }
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    @Operation(summary = "FAQ 게시물 등록", description = "새로운 FAQ 게시물을 등록합니다.")
+    @PostMapping(value = "/insertBoardFAQ")
+    public JSONObject insertBoardFAQ(@ModelAttribute("BoardVO") BoardVO boardVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        try {
+            boardService.insertBoardFAQ(boardVO);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            e.printStackTrace();
+        }
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    @Operation(summary = "답변 게시물 등록", description = "원본글에 대한 답변 게시물을 등록합니다.")
+    @PostMapping(value = "/insertBoardReply")
+    public JSONObject insertBoardReply(@ModelAttribute("BoardVO") BoardVO boardVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        try {
+            boardService.insertBoardReply(boardVO);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            e.printStackTrace();
+        }
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    @Operation(summary = "게시물 수정", description = "게시물 정보를 수정합니다.")
+    @PostMapping(value = "/updateBoard")
+    public JSONObject updateBoard(@ModelAttribute("BoardVO") BoardVO boardVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        try {
+            boardService.updateBoard(boardVO);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            e.printStackTrace();
+        }
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    @Operation(summary = "FAQ 게시물 수정", description = "FAQ 게시물 정보를 수정합니다.")
+    @PostMapping(value = "/updateBoardFAQ")
+    public JSONObject updateBoardFAQ(@ModelAttribute("BoardVO") BoardVO boardVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        try {
+            boardService.updateBoardFAQ(boardVO);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            e.printStackTrace();
+        }
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    @Operation(summary = "게시물 삭제", description = "게시물을 삭제합니다.")
+    @PostMapping(value = "/deleteBoard")
+    public JSONObject deleteBoard(@ModelAttribute("BoardVO") BoardVO boardVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        try {
+            boardService.deleteBoard(boardVO);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            e.printStackTrace();
+        }
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    @Operation(summary = "조회수 증가", description = "게시물 조회수를 1 증가시킵니다.")
+    @PostMapping(value = "/updateBoardHits")
+    public JSONObject updateBoardHits(@ModelAttribute("BoardVO") BoardVO boardVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        try {
+            boardService.updateBoardHits(boardVO);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            e.printStackTrace();
+        }
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    @Operation(summary = "이슈 여부 수정", description = "게시물의 이슈 여부를 수정합니다.")
+    @PostMapping(value = "/updateBoardIssue")
+    public JSONObject updateBoardIssue(@ModelAttribute("BoardVO") BoardVO boardVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        try {
+            boardService.updateBoardIssue(boardVO);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            e.printStackTrace();
+        }
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    @Operation(summary = "추천 여부 수정", description = "게시물의 추천 여부를 수정합니다.")
+    @PostMapping(value = "/updateBoardRecommend")
+    public JSONObject updateBoardRecommend(@ModelAttribute("BoardVO") BoardVO boardVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        try {
+            boardService.updateBoardRecommend(boardVO);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            e.printStackTrace();
+        }
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    @Operation(summary = "공개 여부 수정", description = "게시물의 공개 여부를 수정합니다.")
+    @PostMapping(value = "/updateBoardOpenYn")
+    public JSONObject updateBoardOpenYn(@ModelAttribute("BoardVO") BoardVO boardVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        try {
+            boardService.updateBoardOpenYn(boardVO);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            e.printStackTrace();
+        }
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    @Operation(summary = "메인 노출 여부 수정", description = "게시물의 메인 노출 여부를 수정합니다.")
+    @PostMapping(value = "/updateBoardMainYn")
+    public JSONObject updateBoardMainYn(@ModelAttribute("BoardVO") BoardVO boardVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        try {
+            boardService.updateBoardMainYn(boardVO);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            e.printStackTrace();
+        }
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    @Operation(summary = "답변 상태 수정", description = "게시물의 답변 상태를 수정합니다.")
+    @PostMapping(value = "/updateBoardReply")
+    public JSONObject updateBoardReply(@ModelAttribute("BoardVO") BoardVO boardVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        try {
+            boardService.updateBoardReply(boardVO);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            e.printStackTrace();
+        }
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    @Operation(summary = "답변 존재 여부 확인", description = "게시물에 대한 답변 존재 여부를 확인합니다.")
+    @GetMapping(value = "/getReplyCount")
+    public JSONObject getReplyCount(@ModelAttribute("BoardVO") BoardVO boardVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        jsonObject.put("replyCount", boardService.selectReplyCount(boardVO));
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    @Operation(summary = "답변 데이터 조회", description = "게시물에 대한 답변 데이터 목록을 조회합니다.")
+    @GetMapping(value = "/getReplyData")
+    public JSONObject getReplyData(@ModelAttribute("BoardVO") BoardVO boardVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        jsonObject.put("replyData", boardService.selectReplyData(boardVO));
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    // =====================================================
+    // 게시판 카테고리 (TB_BOARD_CATEGORY_INFO) 관련 API
+    // =====================================================
+
+    @Operation(summary = "직급 코드 목록 조회", description = "직급 코드 목록을 조회합니다.")
+    @GetMapping(value = "/getRankCodeList")
+    public JSONObject getRankCodeList(@ModelAttribute("BoardVO") BoardVO boardVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        jsonObject.put("rankCodeList", boardService.selectRankCodeList(boardVO));
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    @Operation(summary = "게시판 카테고리 정보 등록", description = "게시판 카테고리 정보를 등록합니다.")
+    @PostMapping(value = "/insertBoardCatInfo")
+    public JSONObject insertBoardCatInfo(@ModelAttribute("BoardVO") BoardVO boardVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        try {
+            boardService.insertBoardCatInfo(boardVO);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            e.printStackTrace();
+        }
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    @Operation(summary = "게시판 카테고리 정보 조회", description = "게시판 카테고리 정보 목록을 조회합니다.")
+    @GetMapping(value = "/getBoardCodeList")
+    public JSONObject getBoardCodeList(@ModelAttribute("BoardVO") BoardVO boardVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        jsonObject.put("boardCodeList", boardService.selectBoardCodeList(boardVO));
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    @Operation(summary = "게시판 카테고리 정보 삭제", description = "게시판 카테고리 정보를 삭제합니다.")
+    @PostMapping(value = "/deleteBoardCatInfo")
+    public JSONObject deleteBoardCatInfo(@ModelAttribute("BoardVO") BoardVO boardVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        try {
+            boardService.deleteBoardCatInfo(boardVO);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            e.printStackTrace();
+        }
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    // =====================================================
+    // 게시판 첨부파일 (TB_BOARD_FILE) 관련 API
+    // =====================================================
+
+    @Operation(summary = "게시판 첨부파일 목록 조회", description = "게시물의 첨부파일 목록을 조회합니다.")
+    @GetMapping(value = "/getBoardFileList")
+    public JSONObject getBoardFileList(@ModelAttribute("BoardFileVO") BoardFileVO boardFileVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        jsonObject.put("boardFileList", boardService.selectBoardFileList(boardFileVO));
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    @Operation(summary = "게시판 이미지 첨부파일 목록 조회", description = "게시물의 이미지 첨부파일 목록을 조회합니다.")
+    @GetMapping(value = "/getBoardFileImgList")
+    public JSONObject getBoardFileImgList(@ModelAttribute("BoardFileVO") BoardFileVO boardFileVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        jsonObject.put("boardFileImgList", boardService.selectBoardFileImgList(boardFileVO));
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    @Operation(summary = "게시판 첨부파일 등록", description = "게시물에 첨부파일을 등록합니다.")
+    @PostMapping(value = "/insertBoardFile")
+    public JSONObject insertBoardFile(@ModelAttribute("BoardFileVO") BoardFileVO boardFileVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        try {
+            boardService.insertBoardFile(boardFileVO);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            e.printStackTrace();
+        }
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    @Operation(summary = "답변 게시판 첨부파일 등록", description = "답변 게시물에 첨부파일을 등록합니다.")
+    @PostMapping(value = "/insertBoardReplyFile")
+    public JSONObject insertBoardReplyFile(@ModelAttribute("BoardFileVO") BoardFileVO boardFileVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        try {
+            boardService.insertBoardReplyFile(boardFileVO);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            e.printStackTrace();
+        }
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    @Operation(summary = "게시판 첨부파일 삭제 (경로 기준)", description = "파일 경로를 기준으로 첨부파일을 삭제합니다.")
+    @PostMapping(value = "/deleteBoardFileByPath")
+    public JSONObject deleteBoardFileByPath(@ModelAttribute("BoardFileVO") BoardFileVO boardFileVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        try {
+            boardService.deleteBoardFileByPath(boardFileVO);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            e.printStackTrace();
+        }
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    @Operation(summary = "게시판 첨부파일 삭제 (게시글 기준)", description = "게시글을 기준으로 모든 첨부파일을 삭제합니다.")
+    @PostMapping(value = "/deleteBoardFileByBoard")
+    public JSONObject deleteBoardFileByBoard(@ModelAttribute("BoardFileVO") BoardFileVO boardFileVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        try {
+            boardService.deleteBoardFileByBoard(boardFileVO);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            e.printStackTrace();
+        }
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    // =====================================================
+    // 게시판 코멘트 (TB_BOARD_COMMENT) 관련 API
+    // =====================================================
+
+    @Operation(summary = "게시판 코멘트 목록 조회", description = "페이징 처리된 게시판 코멘트 목록을 조회합니다.")
+    @GetMapping(value = "/getBoardCommentList")
+    public JSONObject getBoardCommentList(@ModelAttribute("BoardCommentVO") BoardCommentVO boardCommentVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        /** paging */
+        PaginationInfo paginationInfo = new PaginationInfo();
+        paginationInfo.setCurrentPageNo(boardCommentVO.getPageIndex());
+        paginationInfo.setRecordCountPerPage(boardCommentVO.getPageUnit());
+        paginationInfo.setPageSize(boardCommentVO.getPageSize());
+
+        boardCommentVO.setFirstIndex(paginationInfo.getFirstRecordIndex());
+        boardCommentVO.setLastIndex(paginationInfo.getLastRecordIndex());
+        boardCommentVO.setRecordCountPerPage(paginationInfo.getRecordCountPerPage());
+
+        jsonObject.put("boardCommentList", boardService.selectBoardCommentList(boardCommentVO));
+
+        int totCnt = boardService.selectBoardCommentListCount(boardCommentVO);
+        paginationInfo.setTotalRecordCount(totCnt);
+        jsonObject.put("paginationInfo", paginationInfo);
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    @Operation(summary = "게시판 코멘트 등록", description = "게시물에 코멘트를 등록합니다.")
+    @PostMapping(value = "/insertBoardComment")
+    public JSONObject insertBoardComment(@ModelAttribute("BoardCommentVO") BoardCommentVO boardCommentVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        try {
+            boardService.insertBoardComment(boardCommentVO);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            e.printStackTrace();
+        }
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
+
+    @Operation(summary = "게시판 코멘트 삭제", description = "게시물의 코멘트를 삭제합니다.")
+    @PostMapping(value = "/deleteBoardComment")
+    public JSONObject deleteBoardComment(@ModelAttribute("BoardCommentVO") BoardCommentVO boardCommentVO) throws Exception {
+
+        HashMap<String, Object> jsonObject = new HashMap<String, Object>();
+
+        try {
+            boardService.deleteBoardComment(boardCommentVO);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            e.printStackTrace();
+        }
+
+        JSONObject jObject = new JSONObject(jsonObject);
+
+        return jObject;
+    }
 
 }

--- a/src/main/java/com/academy/board/service/BoardCommentVO.java
+++ b/src/main/java/com/academy/board/service/BoardCommentVO.java
@@ -1,0 +1,90 @@
+package com.academy.board.service;
+
+import java.io.Serializable;
+
+import com.academy.common.CommonVO;
+
+/**
+ * 게시판 코멘트 VO 클래스 (TB_BOARD_COMMENT 테이블 매핑)
+ * @author system
+ * @version 1.0
+ * @see
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *    수정일           수정자                수정내용
+ *  ---------------    --------------    ---------------------------
+ *  2025.12.10         system            게시판 코멘트 등록
+ * </pre>
+ */
+public class BoardCommentVO extends CommonVO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** 코멘트 SEQ (Primary Key) */
+    private String seq;
+
+    /** 게시판관리 SEQ */
+    private String cmmtBoardMngSeq;
+
+    /** 게시판 SEQ */
+    private String cmmtBoardSeq;
+
+    /** 제목 */
+    private String title;
+
+    /** 내용 */
+    private String content;
+
+    /** 삭제용 SEQ */
+    private String deleteSeq;
+
+    // Getters and Setters
+    public String getSeq() {
+        return seq;
+    }
+
+    public void setSeq(String seq) {
+        this.seq = seq;
+    }
+
+    public String getCmmtBoardMngSeq() {
+        return cmmtBoardMngSeq;
+    }
+
+    public void setCmmtBoardMngSeq(String cmmtBoardMngSeq) {
+        this.cmmtBoardMngSeq = cmmtBoardMngSeq;
+    }
+
+    public String getCmmtBoardSeq() {
+        return cmmtBoardSeq;
+    }
+
+    public void setCmmtBoardSeq(String cmmtBoardSeq) {
+        this.cmmtBoardSeq = cmmtBoardSeq;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public String getDeleteSeq() {
+        return deleteSeq;
+    }
+
+    public void setDeleteSeq(String deleteSeq) {
+        this.deleteSeq = deleteSeq;
+    }
+}

--- a/src/main/java/com/academy/board/service/BoardFileVO.java
+++ b/src/main/java/com/academy/board/service/BoardFileVO.java
@@ -1,0 +1,90 @@
+package com.academy.board.service;
+
+import java.io.Serializable;
+
+import com.academy.common.CommonVO;
+
+/**
+ * 게시판 첨부파일 VO 클래스 (TB_BOARD_FILE 테이블 매핑)
+ * @author system
+ * @version 1.0
+ * @see
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *    수정일           수정자                수정내용
+ *  ---------------    --------------    ---------------------------
+ *  2025.12.10         system            게시판 첨부파일 등록
+ * </pre>
+ */
+public class BoardFileVO extends CommonVO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** 게시판관리 SEQ */
+    private String boardMngSeq;
+
+    /** 게시판 SEQ */
+    private String boardSeq;
+
+    /** 파일 번호 */
+    private int fileNo;
+
+    /** 파일명 (원본) */
+    private String fileName;
+
+    /** 파일 경로 */
+    private String filePath;
+
+    /** 부모 게시글 SEQ (답변 첨부파일용) */
+    private String parentBoardSeq;
+
+    // Getters and Setters
+    public String getBoardMngSeq() {
+        return boardMngSeq;
+    }
+
+    public void setBoardMngSeq(String boardMngSeq) {
+        this.boardMngSeq = boardMngSeq;
+    }
+
+    public String getBoardSeq() {
+        return boardSeq;
+    }
+
+    public void setBoardSeq(String boardSeq) {
+        this.boardSeq = boardSeq;
+    }
+
+    public int getFileNo() {
+        return fileNo;
+    }
+
+    public void setFileNo(int fileNo) {
+        this.fileNo = fileNo;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public String getFilePath() {
+        return filePath;
+    }
+
+    public void setFilePath(String filePath) {
+        this.filePath = filePath;
+    }
+
+    public String getParentBoardSeq() {
+        return parentBoardSeq;
+    }
+
+    public void setParentBoardSeq(String parentBoardSeq) {
+        this.parentBoardSeq = parentBoardSeq;
+    }
+}

--- a/src/main/java/com/academy/board/service/BoardMngVO.java
+++ b/src/main/java/com/academy/board/service/BoardMngVO.java
@@ -1,0 +1,223 @@
+package com.academy.board.service;
+
+import java.io.Serializable;
+
+import com.academy.common.CommonVO;
+
+/**
+ * 게시판 관리 VO 클래스 (TB_BOARD_MNG 테이블 매핑)
+ * @author system
+ * @version 1.0
+ * @see
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *    수정일           수정자                수정내용
+ *  ---------------    --------------    ---------------------------
+ *  2025.12.10         system            게시판 관리 등록
+ * </pre>
+ */
+public class BoardMngVO extends CommonVO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** 게시판관리 SEQ (Primary Key) */
+    private String boardMngSeq;
+
+    /** 게시판명 */
+    private String boardMngName;
+
+    /** 온/오프라인 구분 (O: 온라인, F: 오프라인, T: 강사용) */
+    private String onoffDiv;
+
+    /** 온/오프라인 구분명 (조회용) */
+    private String onoffDivNm;
+
+    /** 게시판 타입 (BOARD: 일반게시판, NOTICE: 공지사항, FAQ: FAQ, TCC: 강사상담) */
+    private String boardMngType;
+
+    /** 게시판 타입명 (조회용) */
+    private String boardMngTypeNm;
+
+    /** 첨부파일 사용 여부 */
+    private String attachFileYn;
+
+    /** 공개 여부 (Y: 로그인, N: 비로그인) */
+    private String openYn;
+
+    /** 공개 여부명 (조회용) */
+    private String openYnNm;
+
+    /** 답변 사용 여부 */
+    private String replyYn;
+
+    /** 사용여부명 (조회용) */
+    private String isUseNm;
+
+    /** 게시물 수 (조회용) */
+    private int cnt;
+
+    /** 오늘 등록 게시물 수 (조회용) */
+    private int today;
+
+    /* 검색 조건 */
+    /** 검색 타입 (BOARD_MNG_SEQ, BOARD_MNG_NAME) */
+    private String searchType;
+
+    /** 검색 키워드 */
+    private String searchKeyword;
+
+    /** 검색 온/오프라인 구분 */
+    private String searchOnoffDiv;
+
+    /** 상세 조회용 SEQ */
+    private String detailBoardMngSeq;
+
+    /** 일괄 삭제용 ID 목록 */
+    private String deleteIds;
+
+    // Getters and Setters
+    public String getBoardMngSeq() {
+        return boardMngSeq;
+    }
+
+    public void setBoardMngSeq(String boardMngSeq) {
+        this.boardMngSeq = boardMngSeq;
+    }
+
+    public String getBoardMngName() {
+        return boardMngName;
+    }
+
+    public void setBoardMngName(String boardMngName) {
+        this.boardMngName = boardMngName;
+    }
+
+    public String getOnoffDiv() {
+        return onoffDiv;
+    }
+
+    public void setOnoffDiv(String onoffDiv) {
+        this.onoffDiv = onoffDiv;
+    }
+
+    public String getOnoffDivNm() {
+        return onoffDivNm;
+    }
+
+    public void setOnoffDivNm(String onoffDivNm) {
+        this.onoffDivNm = onoffDivNm;
+    }
+
+    public String getBoardMngType() {
+        return boardMngType;
+    }
+
+    public void setBoardMngType(String boardMngType) {
+        this.boardMngType = boardMngType;
+    }
+
+    public String getBoardMngTypeNm() {
+        return boardMngTypeNm;
+    }
+
+    public void setBoardMngTypeNm(String boardMngTypeNm) {
+        this.boardMngTypeNm = boardMngTypeNm;
+    }
+
+    public String getAttachFileYn() {
+        return attachFileYn;
+    }
+
+    public void setAttachFileYn(String attachFileYn) {
+        this.attachFileYn = attachFileYn;
+    }
+
+    public String getOpenYn() {
+        return openYn;
+    }
+
+    public void setOpenYn(String openYn) {
+        this.openYn = openYn;
+    }
+
+    public String getOpenYnNm() {
+        return openYnNm;
+    }
+
+    public void setOpenYnNm(String openYnNm) {
+        this.openYnNm = openYnNm;
+    }
+
+    public String getReplyYn() {
+        return replyYn;
+    }
+
+    public void setReplyYn(String replyYn) {
+        this.replyYn = replyYn;
+    }
+
+    public String getIsUseNm() {
+        return isUseNm;
+    }
+
+    public void setIsUseNm(String isUseNm) {
+        this.isUseNm = isUseNm;
+    }
+
+    public int getCnt() {
+        return cnt;
+    }
+
+    public void setCnt(int cnt) {
+        this.cnt = cnt;
+    }
+
+    public int getToday() {
+        return today;
+    }
+
+    public void setToday(int today) {
+        this.today = today;
+    }
+
+    public String getSearchType() {
+        return searchType;
+    }
+
+    public void setSearchType(String searchType) {
+        this.searchType = searchType;
+    }
+
+    public String getSearchKeyword() {
+        return searchKeyword;
+    }
+
+    public void setSearchKeyword(String searchKeyword) {
+        this.searchKeyword = searchKeyword;
+    }
+
+    public String getSearchOnoffDiv() {
+        return searchOnoffDiv;
+    }
+
+    public void setSearchOnoffDiv(String searchOnoffDiv) {
+        this.searchOnoffDiv = searchOnoffDiv;
+    }
+
+    public String getDetailBoardMngSeq() {
+        return detailBoardMngSeq;
+    }
+
+    public void setDetailBoardMngSeq(String detailBoardMngSeq) {
+        this.detailBoardMngSeq = detailBoardMngSeq;
+    }
+
+    public String getDeleteIds() {
+        return deleteIds;
+    }
+
+    public void setDeleteIds(String deleteIds) {
+        this.deleteIds = deleteIds;
+    }
+}

--- a/src/main/java/com/academy/board/service/BoardService.java
+++ b/src/main/java/com/academy/board/service/BoardService.java
@@ -1,42 +1,396 @@
 package com.academy.board.service;
 
+import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.List;
 
 import org.json.simple.JSONObject;
 import org.springframework.stereotype.Service;
 
 import com.academy.mapper.BoardMapper;
 
+/**
+ * 게시판 관리 Service 클래스
+ * @author rainend
+ * @version 1.0
+ * @see
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *    수정일           수정자                수정내용
+ *  ---------------    --------------    ---------------------------
+ *  2025.11            rainend           게시판 등록
+ *  2025.12.10         system            게시판 관리 기능 확장
+ * </pre>
+ */
 @Service
-public class BoardService {
+public class BoardService implements Serializable {
 
-	private final BoardMapper boardMapper;
-	
-	public BoardService(BoardMapper boardMapper) {
-		this.boardMapper = boardMapper;
-	}
-	
-	public ArrayList<JSONObject> selectBoardList(BoardVO boardVO) {
-		return boardMapper.selectBoardList(boardVO);
-	}
+    private static final long serialVersionUID = 1L;
+
+    private final BoardMapper boardMapper;
+
+    public BoardService(BoardMapper boardMapper) {
+        this.boardMapper = boardMapper;
+    }
+
+    // =====================================================
+    // 게시판 관리 (TB_BOARD_MNG) 관련
+    // =====================================================
+
+    /**
+     * 게시판 관리 목록 조회
+     */
+    public List<JSONObject> selectBoardMngList(BoardMngVO boardMngVO) {
+        return boardMapper.selectBoardMngList(boardMngVO);
+    }
+
+    /**
+     * 게시판 관리 목록 건수 조회
+     */
+    public int selectBoardMngListCount(BoardMngVO boardMngVO) {
+        return boardMapper.selectBoardMngListCount(boardMngVO);
+    }
+
+    /**
+     * 게시판 타입 목록 조회
+     */
+    public List<JSONObject> selectBoardTypeList() {
+        return boardMapper.selectBoardTypeList();
+    }
+
+    /**
+     * 게시판 관리 상세 조회
+     */
+    public JSONObject selectBoardMngDetail(BoardMngVO boardMngVO) {
+        return boardMapper.selectBoardMngDetail(boardMngVO);
+    }
+
+    /**
+     * 게시판 관리 등록
+     */
+    public void insertBoardMng(BoardMngVO boardMngVO) {
+        boardMapper.insertBoardMng(boardMngVO);
+    }
+
+    /**
+     * 게시판 관리 수정
+     */
+    public void updateBoardMng(BoardMngVO boardMngVO) {
+        boardMapper.updateBoardMng(boardMngVO);
+    }
+
+    /**
+     * 게시판 관리 삭제
+     */
+    public void deleteBoardMng(BoardMngVO boardMngVO) {
+        boardMapper.deleteBoardMng(boardMngVO);
+    }
+
+    /**
+     * 게시판 관리 일괄 삭제
+     */
+    public void deleteBoardMngBatch(BoardMngVO boardMngVO) {
+        boardMapper.deleteBoardMngBatch(boardMngVO);
+    }
+
+    /**
+     * 게시판 종류 정보 조회
+     */
+    public JSONObject selectBoardKind(BoardVO boardVO) {
+        return boardMapper.selectBoardKind(boardVO);
+    }
+
+    // =====================================================
+    // 게시판 (TB_BOARD) 관련
+    // =====================================================
+
+    /**
+     * 게시판 목록 조회
+     */
+    public ArrayList<JSONObject> selectBoardList(BoardVO boardVO) {
+        return boardMapper.selectBoardList(boardVO);
+    }
+
+    /**
+     * 게시판 목록 건수 조회
+     */
     public int selectBoardListTotCnt(BoardVO boardVO) {
         return boardMapper.selectBoardListTotCnt(boardVO);
     }
-	
-	public JSONObject getBoardDetail(BoardVO boardVO) {
-		return boardMapper.getBoardDetail(boardVO);
-	}
 
+    /**
+     * 미응답 게시판 목록 조회
+     */
+    public List<JSONObject> selectBoardNotAnswerList(BoardVO boardVO) {
+        return boardMapper.selectBoardNotAnswerList(boardVO);
+    }
+
+    /**
+     * 미응답 게시판 목록 건수 조회
+     */
+    public int selectBoardNotAnswerListCount(BoardVO boardVO) {
+        return boardMapper.selectBoardNotAnswerListCount(boardVO);
+    }
+
+    /**
+     * FAQ 게시판 목록 조회
+     */
+    public List<JSONObject> selectBoardFAQList(BoardVO boardVO) {
+        return boardMapper.selectBoardFAQList(boardVO);
+    }
+
+    /**
+     * FAQ 게시판 목록 건수 조회
+     */
+    public int selectBoardFAQListCount(BoardVO boardVO) {
+        return boardMapper.selectBoardFAQListCount(boardVO);
+    }
+
+    /**
+     * 강사용 게시판 목록 조회
+     */
+    public List<JSONObject> selectBoardTeacherList(BoardVO boardVO) {
+        return boardMapper.selectBoardTeacherList(boardVO);
+    }
+
+    /**
+     * 강사용 게시판 목록 건수 조회
+     */
+    public int selectBoardTeacherListCount(BoardVO boardVO) {
+        return boardMapper.selectBoardTeacherListCount(boardVO);
+    }
+
+    /**
+     * 게시판 상세 조회
+     */
+    public JSONObject getBoardDetail(BoardVO boardVO) {
+        return boardMapper.getBoardDetail(boardVO);
+    }
+
+    /**
+     * 원본글 상세 조회
+     */
+    public JSONObject getBoardDetailOrigin(BoardVO boardVO) {
+        return boardMapper.getBoardDetailOrigin(boardVO);
+    }
+
+    /**
+     * 게시판 등록
+     */
     public void insertBoard(BoardVO boardVO) {
-    	boardMapper.insertBoard(boardVO);
+        boardMapper.insertBoard(boardVO);
     }
 
+    /**
+     * FAQ 게시판 등록
+     */
+    public void insertBoardFAQ(BoardVO boardVO) {
+        boardMapper.insertBoardFAQ(boardVO);
+    }
+
+    /**
+     * 답변 게시판 등록
+     */
+    public void insertBoardReply(BoardVO boardVO) {
+        boardMapper.insertBoardReply(boardVO);
+    }
+
+    /**
+     * 게시판 수정
+     */
     public void updateBoard(BoardVO boardVO) {
-    	boardMapper.updateBoard(boardVO);
+        boardMapper.updateBoard(boardVO);
     }
 
+    /**
+     * FAQ 게시판 수정
+     */
+    public void updateBoardFAQ(BoardVO boardVO) {
+        boardMapper.updateBoardFAQ(boardVO);
+    }
+
+    /**
+     * 게시판 삭제
+     */
     public void deleteBoard(BoardVO boardVO) {
-    	boardMapper.deleteBoard(boardVO);
+        // 첨부파일 삭제
+        BoardFileVO boardFileVO = new BoardFileVO();
+        boardFileVO.setBoardMngSeq(boardVO.getBoardMngSeq());
+        boardFileVO.setBoardSeq(boardVO.getBoardSeq());
+        boardMapper.deleteBoardFileByBoard(boardFileVO);
+
+        // 카테고리 정보 삭제
+        boardMapper.deleteBoardCatInfo(boardVO);
+
+        // 게시글 삭제
+        boardMapper.deleteBoard(boardVO);
+    }
+
+    /**
+     * 조회수 증가
+     */
+    public void updateBoardHits(BoardVO boardVO) {
+        boardMapper.updateBoardHits(boardVO);
+    }
+
+    /**
+     * 이슈 여부 수정
+     */
+    public void updateBoardIssue(BoardVO boardVO) {
+        boardMapper.updateBoardIssue(boardVO);
+    }
+
+    /**
+     * 추천 여부 수정
+     */
+    public void updateBoardRecommend(BoardVO boardVO) {
+        boardMapper.updateBoardRecommend(boardVO);
+    }
+
+    /**
+     * 공개 여부 수정
+     */
+    public void updateBoardOpenYn(BoardVO boardVO) {
+        boardMapper.updateBoardOpenYn(boardVO);
+    }
+
+    /**
+     * 메인 노출 여부 수정
+     */
+    public void updateBoardMainYn(BoardVO boardVO) {
+        boardMapper.updateBoardMainYn(boardVO);
+    }
+
+    /**
+     * 답변 상태 수정
+     */
+    public void updateBoardReply(BoardVO boardVO) {
+        boardMapper.updateBoardReply(boardVO);
+    }
+
+    /**
+     * 답변 존재 여부 확인
+     */
+    public int selectReplyCount(BoardVO boardVO) {
+        return boardMapper.selectReplyCount(boardVO);
+    }
+
+    /**
+     * 답변 데이터 조회
+     */
+    public List<JSONObject> selectReplyData(BoardVO boardVO) {
+        return boardMapper.selectReplyData(boardVO);
+    }
+
+    // =====================================================
+    // 게시판 카테고리 (TB_BOARD_CATEGORY_INFO) 관련
+    // =====================================================
+
+    /**
+     * 직급 코드 목록 조회
+     */
+    public List<JSONObject> selectRankCodeList(BoardVO boardVO) {
+        return boardMapper.selectRankCodeList(boardVO);
+    }
+
+    /**
+     * 게시판 카테고리 정보 등록
+     */
+    public void insertBoardCatInfo(BoardVO boardVO) {
+        boardMapper.insertBoardCatInfo(boardVO);
+    }
+
+    /**
+     * 게시판 카테고리 정보 조회
+     */
+    public List<JSONObject> selectBoardCodeList(BoardVO boardVO) {
+        return boardMapper.selectBoardCodeList(boardVO);
+    }
+
+    /**
+     * 게시판 카테고리 정보 삭제
+     */
+    public void deleteBoardCatInfo(BoardVO boardVO) {
+        boardMapper.deleteBoardCatInfo(boardVO);
+    }
+
+    // =====================================================
+    // 게시판 첨부파일 (TB_BOARD_FILE) 관련
+    // =====================================================
+
+    /**
+     * 게시판 첨부파일 목록 조회
+     */
+    public List<JSONObject> selectBoardFileList(BoardFileVO boardFileVO) {
+        return boardMapper.selectBoardFileList(boardFileVO);
+    }
+
+    /**
+     * 게시판 이미지 첨부파일 목록 조회
+     */
+    public List<JSONObject> selectBoardFileImgList(BoardFileVO boardFileVO) {
+        return boardMapper.selectBoardFileImgList(boardFileVO);
+    }
+
+    /**
+     * 게시판 첨부파일 등록
+     */
+    public void insertBoardFile(BoardFileVO boardFileVO) {
+        boardMapper.insertBoardFile(boardFileVO);
+    }
+
+    /**
+     * 답변 게시판 첨부파일 등록
+     */
+    public void insertBoardReplyFile(BoardFileVO boardFileVO) {
+        boardMapper.insertBoardReplyFile(boardFileVO);
+    }
+
+    /**
+     * 게시판 첨부파일 삭제 (경로 기준)
+     */
+    public void deleteBoardFileByPath(BoardFileVO boardFileVO) {
+        boardMapper.deleteBoardFileByPath(boardFileVO);
+    }
+
+    /**
+     * 게시판 첨부파일 삭제 (게시글 기준)
+     */
+    public void deleteBoardFileByBoard(BoardFileVO boardFileVO) {
+        boardMapper.deleteBoardFileByBoard(boardFileVO);
+    }
+
+    // =====================================================
+    // 게시판 코멘트 (TB_BOARD_COMMENT) 관련
+    // =====================================================
+
+    /**
+     * 게시판 코멘트 목록 조회
+     */
+    public List<JSONObject> selectBoardCommentList(BoardCommentVO boardCommentVO) {
+        return boardMapper.selectBoardCommentList(boardCommentVO);
+    }
+
+    /**
+     * 게시판 코멘트 목록 건수 조회
+     */
+    public int selectBoardCommentListCount(BoardCommentVO boardCommentVO) {
+        return boardMapper.selectBoardCommentListCount(boardCommentVO);
+    }
+
+    /**
+     * 게시판 코멘트 등록
+     */
+    public void insertBoardComment(BoardCommentVO boardCommentVO) {
+        boardMapper.insertBoardComment(boardCommentVO);
+    }
+
+    /**
+     * 게시판 코멘트 삭제
+     */
+    public void deleteBoardComment(BoardCommentVO boardCommentVO) {
+        boardMapper.deleteBoardComment(boardCommentVO);
     }
 
 }

--- a/src/main/java/com/academy/board/service/BoardVO.java
+++ b/src/main/java/com/academy/board/service/BoardVO.java
@@ -68,6 +68,28 @@ public class BoardVO extends CommonVO implements Serializable {
 	private String mockcode;
 	private String diviceType;
 
+	/* Search / Filter */
+	/** 검색 타입 (SEARCHKIND: SEARCHSUBJECT, SEARCHNAME, SEARCHCONTENT) */
+	private String searchKind;
+	/** 검색어 (SEARCHTEXT) */
+	private String searchText;
+	/** 검색 카테고리 (SEARCHCATEGORY) */
+	private String searchCategory;
+	/** 검색 온/오프라인 구분 (SEARCHONOFFDIV: O, F, T) */
+	private String searchOnoffDiv;
+	/** 검색 교수 ID (SEARCHPRFID) */
+	private String searchPrfId;
+	/** 온/오프라인 구분 (ONOFF_DIV: O=온라인, F=오프라인, T=강사용) */
+	private String onoffDiv;
+
+	/* Reply status */
+	/** 답변 상태 (BOARD_REPLY: N=답변대기, Y=답변완료, C=처리중(CS), A=처리중(운영)) */
+	private String boardReply;
+	/** 이슈 여부 (ISSUE) */
+	private String issue;
+	/** 메인 노출 여부 (MAIN_YN) */
+	private String mainYn;
+
 	/* ---------------------------------- */
 	/* Aliases / compatibility methods */
 	/** boardId alias (used by mapper as parameter) */
@@ -164,5 +186,32 @@ public class BoardVO extends CommonVO implements Serializable {
 
 	public String getDiviceType() { return diviceType; }
 	public void setDiviceType(String diviceType) { this.diviceType = diviceType; }
+
+	public String getSearchKind() { return searchKind; }
+	public void setSearchKind(String searchKind) { this.searchKind = searchKind; }
+
+	public String getSearchText() { return searchText; }
+	public void setSearchText(String searchText) { this.searchText = searchText; }
+
+	public String getSearchCategory() { return searchCategory; }
+	public void setSearchCategory(String searchCategory) { this.searchCategory = searchCategory; }
+
+	public String getSearchOnoffDiv() { return searchOnoffDiv; }
+	public void setSearchOnoffDiv(String searchOnoffDiv) { this.searchOnoffDiv = searchOnoffDiv; }
+
+	public String getSearchPrfId() { return searchPrfId; }
+	public void setSearchPrfId(String searchPrfId) { this.searchPrfId = searchPrfId; }
+
+	public String getOnoffDiv() { return onoffDiv; }
+	public void setOnoffDiv(String onoffDiv) { this.onoffDiv = onoffDiv; }
+
+	public String getBoardReply() { return boardReply; }
+	public void setBoardReply(String boardReply) { this.boardReply = boardReply; }
+
+	public String getIssue() { return issue; }
+	public void setIssue(String issue) { this.issue = issue; }
+
+	public String getMainYn() { return mainYn; }
+	public void setMainYn(String mainYn) { this.mainYn = mainYn; }
 
 }

--- a/src/main/java/com/academy/mapper/BoardManagementMapper.java
+++ b/src/main/java/com/academy/mapper/BoardManagementMapper.java
@@ -1,0 +1,87 @@
+package com.academy.mapper;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.json.simple.JSONObject;
+
+import com.academy.board.service.BoardMngVO;
+import com.academy.board.service.BoardVO;
+
+/**
+ * 게시판 관리에 관한 데이터 접근 클래스를 정의한다.
+ * @author system
+ * @since 2025.12.10
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일         수정자           수정내용
+ *  ----------------    --------    ---------------------------
+ *   2025.12.10         system          최초 생성
+ * </pre>
+ */
+@Mapper
+public interface BoardManagementMapper {
+
+    /**
+     * 게시판 관리 목록 조회
+     * @param boardMngVO 검색조건
+     * @return List 게시판 관리 목록정보
+     */
+    List<JSONObject> selectBoardMngList(BoardMngVO boardMngVO);
+
+    /**
+     * 게시판 관리 목록 건수 조회
+     * @param boardMngVO 검색조건
+     * @return int 게시판 관리 목록 건수
+     */
+    int selectBoardMngListCount(BoardMngVO boardMngVO);
+
+    /**
+     * 게시판 타입 목록 조회
+     * @return List 게시판 타입 목록
+     */
+    List<JSONObject> selectBoardTypeList();
+
+    /**
+     * 게시판 관리 상세 조회
+     * @param boardMngVO 검색조건
+     * @return JSONObject 게시판 관리 상세정보
+     */
+    JSONObject selectBoardMngDetail(BoardMngVO boardMngVO);
+
+    /**
+     * 게시판 관리 등록
+     * @param boardMngVO 게시판 관리 정보
+     */
+    void insertBoardMng(BoardMngVO boardMngVO);
+
+    /**
+     * 게시판 관리 수정
+     * @param boardMngVO 게시판 관리 정보
+     */
+    void updateBoardMng(BoardMngVO boardMngVO);
+
+    /**
+     * 게시판 관리 삭제
+     * @param boardMngVO 게시판 관리 정보
+     */
+    void deleteBoardMng(BoardMngVO boardMngVO);
+
+    /**
+     * 게시판 관리 일괄 삭제
+     * @param boardMngVO 게시판 관리 정보
+     */
+    void deleteBoardMngBatch(BoardMngVO boardMngVO);
+
+    /**
+     * 게시판 종류 정보 조회 (게시물 등록 시)
+     * @param boardVO 검색조건
+     * @return JSONObject 게시판 종류 정보
+     */
+    JSONObject selectBoardKind(BoardVO boardVO);
+
+}

--- a/src/main/java/com/academy/mapper/BoardMapper.java
+++ b/src/main/java/com/academy/mapper/BoardMapper.java
@@ -1,10 +1,14 @@
 package com.academy.mapper;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.ibatis.annotations.Mapper;
 import org.json.simple.JSONObject;
 
+import com.academy.board.service.BoardCommentVO;
+import com.academy.board.service.BoardFileVO;
+import com.academy.board.service.BoardMngVO;
 import com.academy.board.service.BoardVO;
 
 /**
@@ -20,28 +24,334 @@ import com.academy.board.service.BoardVO;
  *   수정일      		수정자           수정내용
  *  ----------------    --------    ---------------------------
  *   2025.02.10  		rainend          최초 생성
+ *   2025.12.10         system           게시판 관리 기능 확장
  * </pre>
  */
 @Mapper
 public interface BoardMapper {
 
+    // =====================================================
+    // 게시판 관리 (TB_BOARD_MNG) 관련
+    // =====================================================
+
     /**
+     * 게시판 관리 목록 조회
+     * @param boardMngVO 검색조건
+     * @return List 게시판 관리 목록정보
+     */
+    List<JSONObject> selectBoardMngList(BoardMngVO boardMngVO);
+
+    /**
+     * 게시판 관리 목록 건수 조회
+     * @param boardMngVO 검색조건
+     * @return int 게시판 관리 목록 건수
+     */
+    int selectBoardMngListCount(BoardMngVO boardMngVO);
+
+    /**
+     * 게시판 타입 목록 조회
+     * @return List 게시판 타입 목록
+     */
+    List<JSONObject> selectBoardTypeList();
+
+    /**
+     * 게시판 관리 상세 조회
+     * @param boardMngVO 검색조건
+     * @return JSONObject 게시판 관리 상세정보
+     */
+    JSONObject selectBoardMngDetail(BoardMngVO boardMngVO);
+
+    /**
+     * 게시판 관리 등록
+     * @param boardMngVO 게시판 관리 정보
+     */
+    void insertBoardMng(BoardMngVO boardMngVO);
+
+    /**
+     * 게시판 관리 수정
+     * @param boardMngVO 게시판 관리 정보
+     */
+    void updateBoardMng(BoardMngVO boardMngVO);
+
+    /**
+     * 게시판 관리 삭제
+     * @param boardMngVO 게시판 관리 정보
+     */
+    void deleteBoardMng(BoardMngVO boardMngVO);
+
+    /**
+     * 게시판 관리 일괄 삭제
+     * @param boardMngVO 게시판 관리 정보
+     */
+    void deleteBoardMngBatch(BoardMngVO boardMngVO);
+
+    /**
+     * 게시판 종류 정보 조회 (게시물 등록 시)
+     * @param boardVO 검색조건
+     * @return JSONObject 게시판 종류 정보
+     */
+    JSONObject selectBoardKind(BoardVO boardVO);
+
+    // =====================================================
+    // 게시판 (TB_BOARD) 관련
+    // =====================================================
+
+    /**
+     * 게시판 목록 조회
      * @param boardVO 검색조건
      * @return List 게시판 목록정보
      */
-	public ArrayList<JSONObject> selectBoardList(BoardVO boardVO);
-	public int selectBoardListTotCnt(BoardVO boardVO);
+    ArrayList<JSONObject> selectBoardList(BoardVO boardVO);
 
     /**
+     * 게시판 목록 건수 조회
      * @param boardVO 검색조건
-     * @return Object 게시판 개별정보
+     * @return int 게시판 목록 건수
      */
-	public JSONObject getBoardDetail(BoardVO boardVO);
+    int selectBoardListTotCnt(BoardVO boardVO);
 
-    public void insertBoard(BoardVO boardVO);
+    /**
+     * 미응답 게시판 목록 조회
+     * @param boardVO 검색조건
+     * @return List 미응답 게시판 목록정보
+     */
+    List<JSONObject> selectBoardNotAnswerList(BoardVO boardVO);
 
-    public void updateBoard(BoardVO boardVO);
+    /**
+     * 미응답 게시판 목록 건수 조회
+     * @param boardVO 검색조건
+     * @return int 미응답 게시판 목록 건수
+     */
+    int selectBoardNotAnswerListCount(BoardVO boardVO);
 
-    public void deleteBoard(BoardVO boardVO);
+    /**
+     * FAQ 게시판 목록 조회
+     * @param boardVO 검색조건
+     * @return List FAQ 게시판 목록정보
+     */
+    List<JSONObject> selectBoardFAQList(BoardVO boardVO);
+
+    /**
+     * FAQ 게시판 목록 건수 조회
+     * @param boardVO 검색조건
+     * @return int FAQ 게시판 목록 건수
+     */
+    int selectBoardFAQListCount(BoardVO boardVO);
+
+    /**
+     * 강사용 게시판 목록 조회
+     * @param boardVO 검색조건
+     * @return List 강사용 게시판 목록정보
+     */
+    List<JSONObject> selectBoardTeacherList(BoardVO boardVO);
+
+    /**
+     * 강사용 게시판 목록 건수 조회
+     * @param boardVO 검색조건
+     * @return int 강사용 게시판 목록 건수
+     */
+    int selectBoardTeacherListCount(BoardVO boardVO);
+
+    /**
+     * 게시판 상세 조회
+     * @param boardVO 검색조건
+     * @return JSONObject 게시판 상세정보
+     */
+    JSONObject getBoardDetail(BoardVO boardVO);
+
+    /**
+     * 원본글 상세 조회 (답변글에서 참조)
+     * @param boardVO 검색조건
+     * @return JSONObject 원본글 상세정보
+     */
+    JSONObject getBoardDetailOrigin(BoardVO boardVO);
+
+    /**
+     * 게시판 등록
+     * @param boardVO 게시판 정보
+     */
+    void insertBoard(BoardVO boardVO);
+
+    /**
+     * FAQ 게시판 등록
+     * @param boardVO 게시판 정보
+     */
+    void insertBoardFAQ(BoardVO boardVO);
+
+    /**
+     * 답변 게시판 등록
+     * @param boardVO 게시판 정보
+     */
+    void insertBoardReply(BoardVO boardVO);
+
+    /**
+     * 게시판 수정
+     * @param boardVO 게시판 정보
+     */
+    void updateBoard(BoardVO boardVO);
+
+    /**
+     * FAQ 게시판 수정
+     * @param boardVO 게시판 정보
+     */
+    void updateBoardFAQ(BoardVO boardVO);
+
+    /**
+     * 게시판 삭제
+     * @param boardVO 게시판 정보
+     */
+    void deleteBoard(BoardVO boardVO);
+
+    /**
+     * 조회수 증가
+     * @param boardVO 게시판 정보
+     */
+    void updateBoardHits(BoardVO boardVO);
+
+    /**
+     * 이슈 여부 수정
+     * @param boardVO 게시판 정보
+     */
+    void updateBoardIssue(BoardVO boardVO);
+
+    /**
+     * 추천 여부 수정
+     * @param boardVO 게시판 정보
+     */
+    void updateBoardRecommend(BoardVO boardVO);
+
+    /**
+     * 공개 여부 수정
+     * @param boardVO 게시판 정보
+     */
+    void updateBoardOpenYn(BoardVO boardVO);
+
+    /**
+     * 메인 노출 여부 수정
+     * @param boardVO 게시판 정보
+     */
+    void updateBoardMainYn(BoardVO boardVO);
+
+    /**
+     * 답변 상태 수정
+     * @param boardVO 게시판 정보
+     */
+    void updateBoardReply(BoardVO boardVO);
+
+    /**
+     * 답변 존재 여부 확인
+     * @param boardVO 검색조건
+     * @return int 답변 수
+     */
+    int selectReplyCount(BoardVO boardVO);
+
+    /**
+     * 답변 데이터 조회
+     * @param boardVO 검색조건
+     * @return List 답변 데이터 목록
+     */
+    List<JSONObject> selectReplyData(BoardVO boardVO);
+
+    // =====================================================
+    // 게시판 카테고리 (TB_BOARD_CATEGORY_INFO) 관련
+    // =====================================================
+
+    /**
+     * 직급 코드 목록 조회
+     * @param boardVO 검색조건
+     * @return List 직급 코드 목록
+     */
+    List<JSONObject> selectRankCodeList(BoardVO boardVO);
+
+    /**
+     * 게시판 카테고리 정보 등록
+     * @param boardVO 게시판 정보
+     */
+    void insertBoardCatInfo(BoardVO boardVO);
+
+    /**
+     * 게시판 카테고리 정보 조회
+     * @param boardVO 검색조건
+     * @return List 게시판 카테고리 정보 목록
+     */
+    List<JSONObject> selectBoardCodeList(BoardVO boardVO);
+
+    /**
+     * 게시판 카테고리 정보 삭제
+     * @param boardVO 게시판 정보
+     */
+    void deleteBoardCatInfo(BoardVO boardVO);
+
+    // =====================================================
+    // 게시판 첨부파일 (TB_BOARD_FILE) 관련
+    // =====================================================
+
+    /**
+     * 게시판 첨부파일 목록 조회
+     * @param boardFileVO 검색조건
+     * @return List 게시판 첨부파일 목록
+     */
+    List<JSONObject> selectBoardFileList(BoardFileVO boardFileVO);
+
+    /**
+     * 게시판 이미지 첨부파일 목록 조회
+     * @param boardFileVO 검색조건
+     * @return List 게시판 이미지 첨부파일 목록
+     */
+    List<JSONObject> selectBoardFileImgList(BoardFileVO boardFileVO);
+
+    /**
+     * 게시판 첨부파일 등록
+     * @param boardFileVO 첨부파일 정보
+     */
+    void insertBoardFile(BoardFileVO boardFileVO);
+
+    /**
+     * 답변 게시판 첨부파일 등록
+     * @param boardFileVO 첨부파일 정보
+     */
+    void insertBoardReplyFile(BoardFileVO boardFileVO);
+
+    /**
+     * 게시판 첨부파일 삭제 (경로 기준)
+     * @param boardFileVO 첨부파일 정보
+     */
+    void deleteBoardFileByPath(BoardFileVO boardFileVO);
+
+    /**
+     * 게시판 첨부파일 삭제 (게시글 기준)
+     * @param boardFileVO 첨부파일 정보
+     */
+    void deleteBoardFileByBoard(BoardFileVO boardFileVO);
+
+    // =====================================================
+    // 게시판 코멘트 (TB_BOARD_COMMENT) 관련
+    // =====================================================
+
+    /**
+     * 게시판 코멘트 목록 조회
+     * @param boardCommentVO 검색조건
+     * @return List 게시판 코멘트 목록
+     */
+    List<JSONObject> selectBoardCommentList(BoardCommentVO boardCommentVO);
+
+    /**
+     * 게시판 코멘트 목록 건수 조회
+     * @param boardCommentVO 검색조건
+     * @return int 게시판 코멘트 목록 건수
+     */
+    int selectBoardCommentListCount(BoardCommentVO boardCommentVO);
+
+    /**
+     * 게시판 코멘트 등록
+     * @param boardCommentVO 코멘트 정보
+     */
+    void insertBoardComment(BoardCommentVO boardCommentVO);
+
+    /**
+     * 게시판 코멘트 삭제
+     * @param boardCommentVO 코멘트 정보
+     */
+    void deleteBoardComment(BoardCommentVO boardCommentVO);
 
 }

--- a/src/main/java/com/academy/mapper/BoardNotAnswerMapper.java
+++ b/src/main/java/com/academy/mapper/BoardNotAnswerMapper.java
@@ -1,0 +1,181 @@
+package com.academy.mapper;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.json.simple.JSONObject;
+
+import com.academy.board.service.BoardFileVO;
+import com.academy.board.service.BoardVO;
+
+/**
+ * 미응답 게시판에 관한 데이터 접근 클래스를 정의한다.
+ * @author system
+ * @since 2025.12.10
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일         수정자           수정내용
+ *  ----------------    --------    ---------------------------
+ *   2025.12.10         system          최초 생성
+ * </pre>
+ */
+@Mapper
+public interface BoardNotAnswerMapper {
+
+    // =====================================================
+    // 미응답 게시판 목록 관련
+    // =====================================================
+
+    /**
+     * 미응답 게시판 목록 조회
+     * @param boardVO 검색조건
+     * @return List 미응답 게시판 목록정보
+     */
+    List<JSONObject> selectBoardNotAnswerList(BoardVO boardVO);
+
+    /**
+     * 미응답 게시판 목록 건수 조회
+     * @param boardVO 검색조건
+     * @return int 미응답 게시판 목록 건수
+     */
+    int selectBoardNotAnswerListCount(BoardVO boardVO);
+
+    // =====================================================
+    // 게시판 카테고리 관련
+    // =====================================================
+
+    /**
+     * 직급 코드 목록 조회
+     * @param boardVO 검색조건
+     * @return List 직급 코드 목록
+     */
+    List<JSONObject> selectRankCodeList(BoardVO boardVO);
+
+    /**
+     * 게시판 카테고리 정보 등록
+     * @param boardVO 게시판 정보
+     */
+    void insertBoardCatInfo(BoardVO boardVO);
+
+    /**
+     * 게시판 카테고리 정보 조회
+     * @param boardVO 검색조건
+     * @return List 게시판 카테고리 정보 목록
+     */
+    List<JSONObject> selectBoardCodeList(BoardVO boardVO);
+
+    /**
+     * 게시판 카테고리 정보 삭제
+     * @param boardVO 게시판 정보
+     */
+    void deleteBoardCatInfo(BoardVO boardVO);
+
+    // =====================================================
+    // 게시판 상세/CRUD 관련
+    // =====================================================
+
+    /**
+     * 게시판 상세 조회 (미응답용)
+     * @param boardVO 검색조건
+     * @return JSONObject 게시판 상세정보
+     */
+    JSONObject getBoardDetail(BoardVO boardVO);
+
+    /**
+     * 원본글 상세 조회 (답변글에서 참조)
+     * @param boardVO 검색조건
+     * @return JSONObject 원본글 상세정보
+     */
+    JSONObject getBoardDetailOrigin(BoardVO boardVO);
+
+    /**
+     * 답변 게시물 등록
+     * @param boardVO 게시판 정보
+     */
+    void insertBoardReply(BoardVO boardVO);
+
+    /**
+     * 게시판 수정
+     * @param boardVO 게시판 정보
+     */
+    void updateBoard(BoardVO boardVO);
+
+    /**
+     * 조회수 증가
+     * @param boardVO 게시판 정보
+     */
+    void updateBoardHits(BoardVO boardVO);
+
+    /**
+     * 답변 상태 수정
+     * @param boardVO 게시판 정보
+     */
+    void updateBoardReply(BoardVO boardVO);
+
+    /**
+     * 답변 존재 여부 확인
+     * @param boardVO 검색조건
+     * @return int 답변 수
+     */
+    int selectReplyCount(BoardVO boardVO);
+
+    /**
+     * 답변 데이터 조회
+     * @param boardVO 검색조건
+     * @return List 답변 데이터 목록
+     */
+    List<JSONObject> selectReplyData(BoardVO boardVO);
+
+    /**
+     * 게시판 삭제
+     * @param boardVO 게시판 정보
+     */
+    void deleteBoard(BoardVO boardVO);
+
+    // =====================================================
+    // 첨부파일 관련
+    // =====================================================
+
+    /**
+     * 게시판 첨부파일 목록 조회
+     * @param boardFileVO 검색조건
+     * @return List 게시판 첨부파일 목록
+     */
+    List<JSONObject> selectBoardFileList(BoardFileVO boardFileVO);
+
+    /**
+     * 게시판 이미지 첨부파일 목록 조회
+     * @param boardFileVO 검색조건
+     * @return List 게시판 이미지 첨부파일 목록
+     */
+    List<JSONObject> selectBoardFileImgList(BoardFileVO boardFileVO);
+
+    /**
+     * 게시판 첨부파일 등록
+     * @param boardFileVO 첨부파일 정보
+     */
+    void insertBoardFile(BoardFileVO boardFileVO);
+
+    /**
+     * 답변 게시판 첨부파일 등록
+     * @param boardFileVO 첨부파일 정보
+     */
+    void insertBoardReplyFile(BoardFileVO boardFileVO);
+
+    /**
+     * 게시판 첨부파일 삭제 (경로 기준)
+     * @param boardFileVO 첨부파일 정보
+     */
+    void deleteBoardFileByPath(BoardFileVO boardFileVO);
+
+    /**
+     * 게시판 첨부파일 삭제 (게시글 기준)
+     * @param boardFileVO 첨부파일 정보
+     */
+    void deleteBoardFileByBoard(BoardFileVO boardFileVO);
+
+}

--- a/src/main/java/com/academy/mapper/BoardTeacherMapper.java
+++ b/src/main/java/com/academy/mapper/BoardTeacherMapper.java
@@ -1,0 +1,85 @@
+package com.academy.mapper;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.json.simple.JSONObject;
+
+import com.academy.board.service.BoardVO;
+
+/**
+ * 강사용 게시판에 관한 데이터 접근 클래스를 정의한다.
+ * @author system
+ * @since 2025.12.10
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일         수정자           수정내용
+ *  ----------------    --------    ---------------------------
+ *   2025.12.10         system          최초 생성
+ * </pre>
+ */
+@Mapper
+public interface BoardTeacherMapper {
+
+    /**
+     * 강사용 게시판 목록 조회
+     * @param boardVO 검색조건
+     * @return List 강사용 게시판 목록정보
+     */
+    List<JSONObject> selectBoardTeacherList(BoardVO boardVO);
+
+    /**
+     * 강사용 게시판 목록 건수 조회
+     * @param boardVO 검색조건
+     * @return int 강사용 게시판 목록 건수
+     */
+    int selectBoardTeacherListCount(BoardVO boardVO);
+
+    /**
+     * 강사용 게시판 상세 조회
+     * @param boardVO 검색조건
+     * @return JSONObject 강사용 게시판 상세정보
+     */
+    JSONObject getBoardTeacherDetail(BoardVO boardVO);
+
+    /**
+     * 강사용 게시판 등록
+     * @param boardVO 게시판 정보
+     */
+    void insertBoardTeacher(BoardVO boardVO);
+
+    /**
+     * 강사용 게시판 수정
+     * @param boardVO 게시판 정보
+     */
+    void updateBoardTeacher(BoardVO boardVO);
+
+    /**
+     * 이슈 여부 수정
+     * @param boardVO 게시판 정보
+     */
+    void updateBoardIssue(BoardVO boardVO);
+
+    /**
+     * 추천 여부 수정
+     * @param boardVO 게시판 정보
+     */
+    void updateBoardRecommend(BoardVO boardVO);
+
+    /**
+     * 공개 여부 수정
+     * @param boardVO 게시판 정보
+     */
+    void updateBoardOpenYn(BoardVO boardVO);
+
+    /**
+     * 메인 노출 여부 수정
+     * @param boardVO 게시판 정보
+     */
+    void updateBoardMainYn(BoardVO boardVO);
+
+}

--- a/src/main/resources/mapper/board.xml
+++ b/src/main/resources/mapper/board.xml
@@ -3,146 +3,1058 @@
 	수정일           	수정자           수정내용
   ===========      =========    =================
  *2025.02.00		rainend		 공지사항 -> 게시판(acm_board) 매퍼로 수정
+ *2025.12.10        system       게시판 관리 기능 확장 (MySQL 버전)
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.academy.mapper.BoardMapper">
 
-	<!-- 게시판 리스트 -->
-	<select id="selectBoardList" resultType="org.json.simple.JSONObject">
-		SELECT 
-			BOARD_MNG_SEQ, BOARD_SEQ, PARENT_BOARD_SEQ, SUBJECT, CONTENT, FILE_PATH, FILE_NAME, REAL_FILE_NAME, 
-			NOTICE_TOP_YN, OPEN_YN, IS_USE, HITS, 
-			REG_DT, REG_ID, UPD_DT, UPD_ID, 
-			CREATENAME, ANSWER, THUMBNAIL_FILE_PATH, THUMBNAIL_FILE_NAME, THUMBNAIL_FILE_REAL_NAME, RECOMMEND, 
-			BOARD_SEQ3, EXAM_TYPE, EXAM_AREA, EXAM_CATE, EXAM_SUB, CATEGORY_CODE, PROF_ID, BOARD_TYPE, MOCKCODE, DIVICE_TYPE
-		FROM acm_board
-		ORDER BY BOARD_SEQ DESC
+	<!-- =====================================================
+	     게시판 관리 (TB_BOARD_MNG) 관련
+	     ===================================================== -->
+
+	<!-- 게시판 관리 목록 조회 -->
+	<select id="selectBoardMngList" parameterType="com.academy.board.service.BoardMngVO" resultType="org.json.simple.JSONObject">
+		SELECT
+			A.BOARD_MNG_SEQ,
+			A.BOARD_MNG_NAME,
+			CASE A.ONOFF_DIV
+				WHEN 'O' THEN '온라인'
+				WHEN 'F' THEN '오프라인'
+				WHEN 'T' THEN '강사용'
+				ELSE A.ONOFF_DIV
+			END AS ONOFF_DIV_NM,
+			A.ONOFF_DIV,
+			A.BOARD_MNG_TYPE,
+			(SELECT CODE_NM FROM TB_BA_CONFIG_CD WHERE SYS_CD = 'BOARD_MNG_TYPE' AND CODE_VAL = A.BOARD_MNG_TYPE) AS BOARD_MNG_TYPE_NM,
+			CASE A.OPEN_YN WHEN 'Y' THEN '로그인' WHEN 'N' THEN '비로그인' ELSE A.OPEN_YN END AS OPEN_YN_NM,
+			CASE A.IS_USE WHEN 'Y' THEN '활성' WHEN 'N' THEN '비활성' ELSE A.IS_USE END AS IS_USE_NM,
+			DATE_FORMAT(A.REG_DT, '%Y-%m-%d %H:%i:%s') AS REG_DT,
+			A.REG_ID,
+			DATE_FORMAT(A.UPD_DT, '%Y-%m-%d %H:%i:%s') AS UPD_DT,
+			A.UPD_ID,
+			(SELECT COUNT(BOARD_SEQ) FROM TB_BOARD WHERE BOARD_MNG_SEQ = A.BOARD_MNG_SEQ) AS CNT,
+			(SELECT COUNT(BOARD_SEQ) FROM TB_BOARD WHERE BOARD_MNG_SEQ = A.BOARD_MNG_SEQ AND DATE_FORMAT(REG_DT, '%Y-%m-%d') = CURDATE()) AS TODAY
+		FROM TB_BOARD_MNG A
+		WHERE 1=1
+		<if test="searchOnoffDiv != null and searchOnoffDiv != ''">
+			AND A.ONOFF_DIV = #{searchOnoffDiv}
+		</if>
+		<if test="onoffDiv != null and onoffDiv != ''">
+			AND A.ONOFF_DIV = #{onoffDiv}
+		</if>
+		<if test="searchKeyword != null and searchKeyword != ''">
+			<choose>
+				<when test='searchType == "BOARD_MNG_SEQ"'>
+					AND A.BOARD_MNG_SEQ LIKE CONCAT('%', #{searchKeyword}, '%')
+				</when>
+				<when test='searchType == "BOARD_MNG_NAME"'>
+					AND A.BOARD_MNG_NAME LIKE CONCAT('%', #{searchKeyword}, '%')
+				</when>
+				<otherwise>
+					AND (A.BOARD_MNG_SEQ LIKE CONCAT('%', #{searchKeyword}, '%')
+						OR A.BOARD_MNG_NAME LIKE CONCAT('%', #{searchKeyword}, '%'))
+				</otherwise>
+			</choose>
+		</if>
+		ORDER BY A.REG_DT DESC
 		LIMIT #{recordCountPerPage} OFFSET #{firstIndex}
 	</select>
 
-	<!-- 게시판 게시물 수 -->
-	<select id="selectBoardListTotCnt" resultType="int">
-		SELECT COUNT(*) TOTAL_CNT
-		FROM acm_board
+	<!-- 게시판 관리 목록 건수 조회 -->
+	<select id="selectBoardMngListCount" parameterType="com.academy.board.service.BoardMngVO" resultType="int">
+		SELECT COUNT(*) AS CNT
+		FROM TB_BOARD_MNG A
+		WHERE 1=1
+		<if test="searchOnoffDiv != null and searchOnoffDiv != ''">
+			AND A.ONOFF_DIV = #{searchOnoffDiv}
+		</if>
+		<if test="onoffDiv != null and onoffDiv != ''">
+			AND A.ONOFF_DIV = #{onoffDiv}
+		</if>
+		<if test="searchKeyword != null and searchKeyword != ''">
+			<choose>
+				<when test='searchType == "BOARD_MNG_SEQ"'>
+					AND A.BOARD_MNG_SEQ LIKE CONCAT('%', #{searchKeyword}, '%')
+				</when>
+				<when test='searchType == "BOARD_MNG_NAME"'>
+					AND A.BOARD_MNG_NAME LIKE CONCAT('%', #{searchKeyword}, '%')
+				</when>
+				<otherwise>
+					AND (A.BOARD_MNG_SEQ LIKE CONCAT('%', #{searchKeyword}, '%')
+						OR A.BOARD_MNG_NAME LIKE CONCAT('%', #{searchKeyword}, '%'))
+				</otherwise>
+			</choose>
+		</if>
 	</select>
 
-	<!-- 게시판 하나 가져오기 -->
-	<select id="getBoardDetail" resultType="org.json.simple.JSONObject">
+	<!-- 게시판 타입 목록 조회 -->
+	<select id="selectBoardTypeList" resultType="org.json.simple.JSONObject">
+		SELECT CODE_CD, CODE_NM FROM TB_BA_CONFIG_CD WHERE SYS_CD = 'BOARD_MNG_TYPE'
+	</select>
+
+	<!-- 게시판 관리 상세 조회 -->
+	<select id="selectBoardMngDetail" parameterType="com.academy.board.service.BoardMngVO" resultType="org.json.simple.JSONObject">
 		SELECT
-			BOARD_MNG_SEQ, BOARD_SEQ, PARENT_BOARD_SEQ, SUBJECT, CONTENT, FILE_PATH, FILE_NAME, REAL_FILE_NAME, 
-			NOTICE_TOP_YN, OPEN_YN, IS_USE, HITS, 
-			REG_DT, REG_ID, UPD_DT, UPD_ID, 
-			CREATENAME, ANSWER, THUMBNAIL_FILE_PATH, THUMBNAIL_FILE_NAME, THUMBNAIL_FILE_REAL_NAME, RECOMMEND, 
-			BOARD_SEQ3, EXAM_TYPE, EXAM_AREA, EXAM_CATE, EXAM_SUB, CATEGORY_CODE, PROF_ID, BOARD_TYPE, MOCKCODE, DIVICE_TYPE
-		FROM acm_board ab
-		WHERE ab.BOARD_SEQ = #{boardId}
+			A.BOARD_MNG_SEQ,
+			A.BOARD_MNG_NAME,
+			A.ONOFF_DIV,
+			CASE A.ONOFF_DIV WHEN 'O' THEN '온라인' WHEN 'F' THEN '오프라인' WHEN 'T' THEN '강사용' ELSE A.ONOFF_DIV END AS ONOFF_DIV_NM,
+			A.BOARD_MNG_TYPE,
+			(SELECT CODE_NM FROM TB_BA_CONFIG_CD WHERE SYS_CD = 'BOARD_MNG_TYPE' AND CODE_CD = A.BOARD_MNG_TYPE) AS BOARD_MNG_TYPE_NM,
+			A.ATTACH_FILE_YN,
+			A.OPEN_YN,
+			A.REPLY_YN,
+			A.IS_USE,
+			DATE_FORMAT(A.REG_DT, '%Y-%m-%d %H:%i:%s') AS REG_DT,
+			A.REG_ID,
+			DATE_FORMAT(A.UPD_DT, '%Y-%m-%d %H:%i:%s') AS UPD_DT,
+			A.UPD_ID
+		FROM TB_BOARD_MNG A
+		WHERE A.BOARD_MNG_SEQ = #{detailBoardMngSeq}
 	</select>
 
-	<!-- 게시판 등록 -->
-	<insert id="insertBoard">
-		<!-- generate BOARD_SEQ (boardId) only when boardId is null/empty -->
-		<selectKey keyProperty="boardId" resultType="String" order="BEFORE">
-			SELECT CASE WHEN #{boardId} IS NULL OR #{boardId} = '' THEN REPLACE(UUID(),'-','') ELSE #{boardId} END
+	<!-- 게시판 관리 등록 -->
+	<insert id="insertBoardMng" parameterType="com.academy.board.service.BoardMngVO">
+		<selectKey keyProperty="boardMngSeq" resultType="String" order="BEFORE">
+			SELECT CONCAT(#{boardMngType}, '_', LPAD(IFNULL(CAST(SUBSTRING(MAX(BOARD_MNG_SEQ), -3) AS UNSIGNED) + 1, 1), 3, '0'))
+			FROM TB_BOARD_MNG
+			WHERE BOARD_MNG_TYPE = #{boardMngType}
 		</selectKey>
-
-		INSERT INTO acm_board
-		<trim prefix="(" suffix=")" suffixOverrides="," >
+		INSERT INTO TB_BOARD_MNG (
 			BOARD_MNG_SEQ,
-			BOARD_SEQ,
-			<if test="parentBoardSeq != null">PARENT_BOARD_SEQ,</if>
-			<if test="openYn != null">OPEN_YN,</if>
-			<if test="boardTitle != null">SUBJECT,</if>
-			<if test="boardMemo != null">CONTENT,</if>
-			<if test="filePath != null">FILE_PATH,</if>
-			<if test="fileName != null">FILE_NAME,</if>
-			<if test="realFileName != null">REAL_FILE_NAME,</if>
-			<if test="noticeTopYn != null">NOTICE_TOP_YN,</if>
-			<if test="isUse != null">IS_USE,</if>
-			<if test="hits != null">HITS,</if>
-			<if test="createName != null">CREATENAME,</if>
-			<if test="answer != null">ANSWER,</if>
-			<if test="thumbnailFilePath != null">THUMBNAIL_FILE_PATH,</if>
-			<if test="thumbnailFileName != null">THUMBNAIL_FILE_NAME,</if>
-			<if test="thumbnailFileRealName != null">THUMBNAIL_FILE_REAL_NAME,</if>
-			<if test="recommend != null">RECOMMEND,</if>
-			<if test="boardSeq3 != null">BOARD_SEQ3,</if>
-			<if test="examType != null">EXAM_TYPE,</if>
-			<if test="examArea != null">EXAM_AREA,</if>
-			<if test="examCate != null">EXAM_CATE,</if>
-			<if test="examSub != null">EXAM_SUB,</if>
-			<if test="categoryCode != null">CATEGORY_CODE,</if>
-			<if test="profId != null">PROF_ID,</if>
-			<if test="boardType != null">BOARD_TYPE,</if>
-			<if test="mockcode != null">MOCKCODE,</if>
-			<if test="diviceType != null">DIVICE_TYPE,</if>
+			BOARD_MNG_NAME,
+			ONOFF_DIV,
+			BOARD_MNG_TYPE,
+			ATTACH_FILE_YN,
+			OPEN_YN,
+			REPLY_YN,
+			IS_USE,
 			REG_DT,
 			REG_ID,
 			UPD_DT,
 			UPD_ID
-		</trim>
-
-		VALUES
-		<trim prefix="(" suffix=")" suffixOverrides="," >
-			IFNULL(#{boardMngSeq}, #{boardId}),
-			#{boardId},
-			<if test="parentBoardSeq != null">#{parentBoardSeq},</if>
-			<if test="openYn != null">#{openYn},</if>
-			<if test="boardTitle != null">#{boardTitle},</if>
-			<if test="boardMemo != null">#{boardMemo, jdbcType=BLOB},</if>
-			<if test="filePath != null">#{filePath},</if>
-			<if test="fileName != null">#{fileName},</if>
-			<if test="realFileName != null">#{realFileName},</if>
-			<if test="noticeTopYn != null">#{noticeTopYn},</if>
-			<if test="isUse != null">#{isUse},</if>
-			<if test="hits != null">#{hits, jdbcType=BIGINT},</if>
-			<if test="createName != null">#{createName},</if>
-			<if test="answer != null">#{answer, jdbcType=BLOB},</if>
-			<if test="thumbnailFilePath != null">#{thumbnailFilePath},</if>
-			<if test="thumbnailFileName != null">#{thumbnailFileName},</if>
-			<if test="thumbnailFileRealName != null">#{thumbnailFileRealName},</if>
-			<if test="recommend != null">#{recommend},</if>
-			<if test="boardSeq3 != null">#{boardSeq3},</if>
-			<if test="examType != null">#{examType},</if>
-			<if test="examArea != null">#{examArea},</if>
-			<if test="examCate != null">#{examCate},</if>
-			<if test="examSub != null">#{examSub},</if>
-			<if test="categoryCode != null">#{categoryCode},</if>
-			<if test="profId != null">#{profId},</if>
-			<if test="boardType != null">#{boardType},</if>
-			<if test="mockcode != null">#{mockcode},</if>
-			<if test="diviceType != null">#{diviceType},</if>
+		) VALUES (
+			#{boardMngSeq},
+			#{boardMngName},
+			#{onoffDiv},
+			#{boardMngType},
+			'Y',
+			#{openYn},
+			<choose>
+				<when test="boardMngType == 'BOARD' or boardMngType == 'TCC'">#{replyYn},</when>
+				<otherwise>'N',</otherwise>
+			</choose>
+			#{isUse},
 			now(),
 			#{regId},
 			now(),
 			#{regId}
-		</trim>
+		)
 	</insert>
 
-	<!-- 게시판 수정 -->
-	<update id="updateBoard">
-		UPDATE acm_board
-		SET 
-			SUBJECT = #{boardTitle},
-			CONTENT = #{boardMemo},
-			FILE_PATH = #{filePath},
-			FILE_NAME = #{fileName},
-			REAL_FILE_NAME = #{realFileName},
-			THUMBNAIL_FILE_PATH = #{thumbnailFilePath},
-			THUMBNAIL_FILE_NAME = #{thumbnailFileName},
-			THUMBNAIL_FILE_REAL_NAME = #{thumbnailFileRealName},
-			NOTICE_TOP_YN = #{noticeTopYn},
+	<!-- 게시판 관리 수정 -->
+	<update id="updateBoardMng" parameterType="com.academy.board.service.BoardMngVO">
+		UPDATE TB_BOARD_MNG
+		SET
+			BOARD_MNG_NAME = #{boardMngName},
+			<if test="boardMngType == 'BOARD' or boardMngType == 'TCC'">
+			REPLY_YN = #{replyYn},
+			</if>
+			OPEN_YN = #{openYn},
 			IS_USE = #{isUse},
 			UPD_DT = now(),
 			UPD_ID = #{updId}
-		WHERE BOARD_MNG_SEQ = #{boardMngSeq}
-		AND BOARD_SEQ = #{boardSeq}
+		WHERE BOARD_MNG_SEQ = #{detailBoardMngSeq}
 	</update>
 
-	<!-- 게시판 비활성화 -->
-	<update id="deleteBoard">
-		DELETE FROM acm_board
+	<!-- 게시판 관리 삭제 -->
+	<delete id="deleteBoardMng" parameterType="com.academy.board.service.BoardMngVO">
+		DELETE FROM TB_BOARD_MNG WHERE BOARD_MNG_SEQ = #{detailBoardMngSeq}
+	</delete>
+
+	<!-- 게시판 관리 일괄 삭제 -->
+	<delete id="deleteBoardMngBatch" parameterType="com.academy.board.service.BoardMngVO">
+		DELETE FROM TB_BOARD_MNG WHERE BOARD_MNG_SEQ IN (${deleteIds})
+	</delete>
+
+	<!-- 게시판 종류 정보 조회 -->
+	<select id="selectBoardKind" parameterType="com.academy.board.service.BoardVO" resultType="org.json.simple.JSONObject">
+		SELECT
+			BOARD_MNG_SEQ,
+			BOARD_MNG_NAME,
+			ONOFF_DIV,
+			BOARD_MNG_TYPE,
+			ATTACH_FILE_YN,
+			OPEN_YN,
+			REPLY_YN
+		FROM TB_BOARD_MNG
+		WHERE BOARD_MNG_SEQ = #{boardMngSeq}
+	</select>
+
+	<!-- =====================================================
+	     게시판 (TB_BOARD) 관련
+	     ===================================================== -->
+
+	<!-- 게시판 리스트 -->
+	<select id="selectBoardList" parameterType="com.academy.board.service.BoardVO" resultType="org.json.simple.JSONObject">
+		SELECT
+			A.BOARD_MNG_SEQ,
+			A.BOARD_SEQ,
+			A.PARENT_BOARD_SEQ,
+			A.SUBJECT,
+			A.CONTENT,
+			A.FILE_PATH,
+			A.FILE_NAME,
+			A.REAL_FILE_NAME,
+			A.NOTICE_TOP_YN,
+			A.OPEN_YN,
+			A.IS_USE,
+			A.HITS,
+			DATE_FORMAT(A.REG_DT, '%Y-%m-%d %H:%i:%s') AS REG_DT,
+			A.REG_ID,
+			DATE_FORMAT(A.UPD_DT, '%Y-%m-%d %H:%i:%s') AS UPD_DT,
+			A.UPD_ID,
+			A.CREATENAME,
+			A.THUMBNAIL_FILE_PATH,
+			A.THUMBNAIL_FILE_NAME,
+			A.THUMBNAIL_FILE_REAL_NAME,
+			A.RECOMMEND,
+			A.ISSUE,
+			A.MAIN_YN,
+			A.PROF_ID,
+			A.BOARD_REPLY,
+			(SELECT FILE_NAME FROM TB_BOARD_FILE WHERE BOARD_SEQ = A.BOARD_SEQ LIMIT 1) AS ATTACH_FILE_NAME,
+			CASE
+				WHEN EXISTS (SELECT 1 FROM TB_BOARD B WHERE B.BOARD_MNG_SEQ = A.BOARD_MNG_SEQ AND B.PARENT_BOARD_SEQ = A.BOARD_SEQ) THEN '답변완료'
+				WHEN A.PARENT_BOARD_SEQ > 0 THEN '답변완료'
+				ELSE CASE A.BOARD_REPLY
+					WHEN 'C' THEN '처리중(CS)'
+					WHEN 'A' THEN '처리중(운영)'
+					WHEN 'Y' THEN '답변완료'
+					ELSE '답변대기'
+				END
+			END AS BOARD_REPLY_NM
+		FROM TB_BOARD A
+		LEFT JOIN TB_BOARD_MNG B ON A.BOARD_MNG_SEQ = B.BOARD_MNG_SEQ
+		WHERE 1=1
+		<if test="boardMngSeq != null and boardMngSeq != ''">
+			AND A.BOARD_MNG_SEQ = #{boardMngSeq}
+		</if>
+		<if test="searchOnoffDiv != null and searchOnoffDiv != ''">
+			AND B.ONOFF_DIV = #{searchOnoffDiv}
+		</if>
+		<if test="searchCategory != null and searchCategory != ''">
+			AND EXISTS (SELECT 1 FROM TB_BOARD_CATEGORY_INFO C WHERE C.BOARD_SEQ = A.BOARD_SEQ AND C.CATEGORY_CODE = #{searchCategory})
+		</if>
+		<if test="searchText != null and searchText != ''">
+			<choose>
+				<when test='searchKind == "SEARCHSUBJECT"'>
+					AND A.SUBJECT LIKE CONCAT('%', #{searchText}, '%')
+				</when>
+				<when test='searchKind == "SEARCHNAME"'>
+					AND A.CREATENAME LIKE CONCAT('%', #{searchText}, '%')
+				</when>
+				<when test='searchKind == "SEARCHCONTENT"'>
+					AND A.CONTENT LIKE CONCAT('%', #{searchText}, '%')
+				</when>
+				<otherwise>
+					AND (A.SUBJECT LIKE CONCAT('%', #{searchText}, '%')
+						OR A.CREATENAME LIKE CONCAT('%', #{searchText}, '%')
+						OR A.CONTENT LIKE CONCAT('%', #{searchText}, '%'))
+				</otherwise>
+			</choose>
+		</if>
+		<if test="searchPrfId != null and searchPrfId != ''">
+			AND A.PROF_ID = #{searchPrfId}
+		</if>
+		ORDER BY A.NOTICE_TOP_YN DESC, A.BOARD_SEQ DESC
+		LIMIT #{recordCountPerPage} OFFSET #{firstIndex}
+	</select>
+
+	<!-- 게시판 게시물 수 -->
+	<select id="selectBoardListTotCnt" parameterType="com.academy.board.service.BoardVO" resultType="int">
+		SELECT COUNT(*) AS TOTAL_CNT
+		FROM TB_BOARD A
+		LEFT JOIN TB_BOARD_MNG B ON A.BOARD_MNG_SEQ = B.BOARD_MNG_SEQ
+		WHERE 1=1
+		<if test="boardMngSeq != null and boardMngSeq != ''">
+			AND A.BOARD_MNG_SEQ = #{boardMngSeq}
+		</if>
+		<if test="searchOnoffDiv != null and searchOnoffDiv != ''">
+			AND B.ONOFF_DIV = #{searchOnoffDiv}
+		</if>
+		<if test="searchCategory != null and searchCategory != ''">
+			AND EXISTS (SELECT 1 FROM TB_BOARD_CATEGORY_INFO C WHERE C.BOARD_SEQ = A.BOARD_SEQ AND C.CATEGORY_CODE = #{searchCategory})
+		</if>
+		<if test="searchText != null and searchText != ''">
+			<choose>
+				<when test='searchKind == "SEARCHSUBJECT"'>
+					AND A.SUBJECT LIKE CONCAT('%', #{searchText}, '%')
+				</when>
+				<when test='searchKind == "SEARCHNAME"'>
+					AND A.CREATENAME LIKE CONCAT('%', #{searchText}, '%')
+				</when>
+				<when test='searchKind == "SEARCHCONTENT"'>
+					AND A.CONTENT LIKE CONCAT('%', #{searchText}, '%')
+				</when>
+				<otherwise>
+					AND (A.SUBJECT LIKE CONCAT('%', #{searchText}, '%')
+						OR A.CREATENAME LIKE CONCAT('%', #{searchText}, '%')
+						OR A.CONTENT LIKE CONCAT('%', #{searchText}, '%'))
+				</otherwise>
+			</choose>
+		</if>
+		<if test="searchPrfId != null and searchPrfId != ''">
+			AND A.PROF_ID = #{searchPrfId}
+		</if>
+	</select>
+
+	<!-- 미응답 게시판 목록 조회 -->
+	<select id="selectBoardNotAnswerList" parameterType="com.academy.board.service.BoardVO" resultType="org.json.simple.JSONObject">
+		SELECT
+			(SELECT BOARD_MNG_NAME FROM TB_BOARD_MNG WHERE BOARD_MNG_SEQ = A.BOARD_MNG_SEQ) AS BOARD_NAME,
+			B.ONOFF_DIV,
+			A.BOARD_MNG_SEQ,
+			CAST(A.BOARD_SEQ AS UNSIGNED) AS BOARD_SEQ,
+			A.SUBJECT,
+			A.CONTENT,
+			(SELECT FILE_NAME FROM TB_BOARD_FILE WHERE BOARD_SEQ = A.BOARD_SEQ LIMIT 1) AS FILE_NAME,
+			A.PARENT_BOARD_SEQ,
+			A.NOTICE_TOP_YN,
+			A.HITS,
+			DATE_FORMAT(A.REG_DT, '%Y-%m-%d %H:%i:%s') AS REG_DT,
+			DATE_FORMAT(A.UPD_DT, '%Y-%m-%d %H:%i:%s') AS UPD_DT,
+			A.UPD_ID,
+			A.CREATENAME,
+			A.PROF_ID,
+			(SELECT USER_NM FROM TB_MA_MEMBER WHERE USER_ID = A.PROF_ID) AS PROF_NM,
+			A.BOARD_REPLY,
+			CASE
+				WHEN EXISTS (SELECT 1 FROM TB_BOARD X WHERE X.BOARD_MNG_SEQ = A.BOARD_MNG_SEQ AND X.PARENT_BOARD_SEQ = A.BOARD_SEQ) THEN '답변완료'
+				WHEN A.PARENT_BOARD_SEQ > 0 THEN '답변완료'
+				ELSE CASE A.BOARD_REPLY
+					WHEN 'C' THEN '처리중(CS)'
+					WHEN 'A' THEN '처리중(운영)'
+					WHEN 'Y' THEN '답변완료'
+					ELSE '답변대기'
+				END
+			END AS BOARD_REPLY_NM
+		FROM TB_BOARD A
+		INNER JOIN TB_BOARD_MNG B ON A.BOARD_MNG_SEQ = B.BOARD_MNG_SEQ
+		WHERE B.REPLY_YN = 'Y'
+		AND A.PARENT_BOARD_SEQ = 0
+		AND A.BOARD_MNG_SEQ LIKE 'BOARD_%'
+		AND B.BOARD_MNG_NAME LIKE '%상담실%'
+		AND A.NOTICE_TOP_YN = 'N'
+		AND NOT EXISTS (SELECT 1 FROM TB_BOARD X WHERE X.PARENT_BOARD_SEQ = A.BOARD_SEQ)
+		<if test="onoffDiv != null and onoffDiv == 'O'">
+			AND B.ONOFF_DIV = 'O'
+		</if>
+		<if test="onoffDiv != null and onoffDiv == 'F'">
+			AND B.ONOFF_DIV = 'F'
+		</if>
+		<choose>
+			<when test="profId != null and profId != ''">
+				AND A.PROF_ID IS NOT NULL
+			</when>
+			<otherwise>
+				AND A.PROF_ID IS NULL
+			</otherwise>
+		</choose>
+		ORDER BY A.BOARD_SEQ DESC
+		LIMIT #{recordCountPerPage} OFFSET #{firstIndex}
+	</select>
+
+	<!-- 미응답 게시판 목록 건수 조회 -->
+	<select id="selectBoardNotAnswerListCount" parameterType="com.academy.board.service.BoardVO" resultType="int">
+		SELECT COUNT(*) AS CNT
+		FROM TB_BOARD A
+		INNER JOIN TB_BOARD_MNG B ON A.BOARD_MNG_SEQ = B.BOARD_MNG_SEQ
+		WHERE B.REPLY_YN = 'Y'
+		AND A.PARENT_BOARD_SEQ = 0
+		AND A.BOARD_MNG_SEQ LIKE 'BOARD_%'
+		AND B.BOARD_MNG_NAME LIKE '%상담실%'
+		AND A.NOTICE_TOP_YN = 'N'
+		AND NOT EXISTS (SELECT 1 FROM TB_BOARD X WHERE X.PARENT_BOARD_SEQ = A.BOARD_SEQ)
+		<if test="onoffDiv != null and onoffDiv == 'O'">
+			AND B.ONOFF_DIV = 'O'
+		</if>
+		<if test="onoffDiv != null and onoffDiv == 'F'">
+			AND B.ONOFF_DIV = 'F'
+		</if>
+		<choose>
+			<when test="profId != null and profId != ''">
+				AND A.PROF_ID IS NOT NULL
+			</when>
+			<otherwise>
+				AND A.PROF_ID IS NULL
+			</otherwise>
+		</choose>
+	</select>
+
+	<!-- FAQ 게시판 목록 조회 -->
+	<select id="selectBoardFAQList" parameterType="com.academy.board.service.BoardVO" resultType="org.json.simple.JSONObject">
+		SELECT
+			A.BOARD_MNG_SEQ,
+			A.BOARD_SEQ,
+			A.SUBJECT,
+			A.ANSWER,
+			A.NOTICE_TOP_YN,
+			A.OPEN_YN,
+			A.IS_USE,
+			A.HITS,
+			DATE_FORMAT(A.REG_DT, '%Y-%m-%d %H:%i:%s') AS REG_DT,
+			A.REG_ID,
+			A.CREATENAME,
+			A.PROF_ID
+		FROM TB_BOARD A
+		LEFT JOIN TB_BOARD_MNG B ON A.BOARD_MNG_SEQ = B.BOARD_MNG_SEQ
+		WHERE 1=1
+		<if test="boardMngSeq != null and boardMngSeq != ''">
+			AND A.BOARD_MNG_SEQ = #{boardMngSeq}
+		</if>
+		<if test="searchOnoffDiv != null and searchOnoffDiv != ''">
+			AND B.ONOFF_DIV = #{searchOnoffDiv}
+		</if>
+		<if test="searchCategory != null and searchCategory != ''">
+			AND EXISTS (SELECT 1 FROM TB_BOARD_CATEGORY_INFO C WHERE C.BOARD_SEQ = A.BOARD_SEQ AND C.CATEGORY_CODE = #{searchCategory})
+		</if>
+		<if test="searchText != null and searchText != ''">
+			<choose>
+				<when test='searchKind == "SEARCHSUBJECT"'>
+					AND A.SUBJECT LIKE CONCAT('%', #{searchText}, '%')
+				</when>
+				<when test='searchKind == "SEARCHNAME"'>
+					AND A.CREATENAME LIKE CONCAT('%', #{searchText}, '%')
+				</when>
+				<otherwise>
+					AND (A.SUBJECT LIKE CONCAT('%', #{searchText}, '%')
+						OR A.CREATENAME LIKE CONCAT('%', #{searchText}, '%'))
+				</otherwise>
+			</choose>
+		</if>
+		ORDER BY A.NOTICE_TOP_YN DESC, A.BOARD_SEQ DESC
+		LIMIT #{recordCountPerPage} OFFSET #{firstIndex}
+	</select>
+
+	<!-- FAQ 게시판 목록 건수 조회 -->
+	<select id="selectBoardFAQListCount" parameterType="com.academy.board.service.BoardVO" resultType="int">
+		SELECT COUNT(*) AS CNT
+		FROM TB_BOARD A
+		LEFT JOIN TB_BOARD_MNG B ON A.BOARD_MNG_SEQ = B.BOARD_MNG_SEQ
+		WHERE 1=1
+		<if test="boardMngSeq != null and boardMngSeq != ''">
+			AND A.BOARD_MNG_SEQ = #{boardMngSeq}
+		</if>
+		<if test="searchOnoffDiv != null and searchOnoffDiv != ''">
+			AND B.ONOFF_DIV = #{searchOnoffDiv}
+		</if>
+		<if test="searchCategory != null and searchCategory != ''">
+			AND EXISTS (SELECT 1 FROM TB_BOARD_CATEGORY_INFO C WHERE C.BOARD_SEQ = A.BOARD_SEQ AND C.CATEGORY_CODE = #{searchCategory})
+		</if>
+		<if test="searchText != null and searchText != ''">
+			<choose>
+				<when test='searchKind == "SEARCHSUBJECT"'>
+					AND A.SUBJECT LIKE CONCAT('%', #{searchText}, '%')
+				</when>
+				<when test='searchKind == "SEARCHNAME"'>
+					AND A.CREATENAME LIKE CONCAT('%', #{searchText}, '%')
+				</when>
+				<otherwise>
+					AND (A.SUBJECT LIKE CONCAT('%', #{searchText}, '%')
+						OR A.CREATENAME LIKE CONCAT('%', #{searchText}, '%'))
+				</otherwise>
+			</choose>
+		</if>
+	</select>
+
+	<!-- 강사용 게시판 목록 조회 -->
+	<select id="selectBoardTeacherList" parameterType="com.academy.board.service.BoardVO" resultType="org.json.simple.JSONObject">
+		SELECT
+			(SELECT NAME FROM TB_CATEGORY_INFO WHERE CODE = #{searchCategory}) AS CODENAME,
+			CAST(A.BOARD_SEQ AS UNSIGNED) AS BOARD_SEQ,
+			A.SUBJECT,
+			A.CONTENT,
+			(SELECT FILE_NAME FROM TB_BOARD_FILE WHERE BOARD_SEQ = A.BOARD_SEQ LIMIT 1) AS FILE_NAME,
+			A.THUMBNAIL_FILE_NAME,
+			A.PARENT_BOARD_SEQ,
+			A.NOTICE_TOP_YN,
+			A.HITS,
+			DATE_FORMAT(A.REG_DT, '%Y-%m-%d %H:%i:%s') AS REG_DT,
+			(SELECT USER_NM FROM TB_MA_MEMBER WHERE USER_ID = A.REG_ID) AS USER_NM,
+			DATE_FORMAT(A.UPD_DT, '%Y-%m-%d %H:%i:%s') AS UPD_DT,
+			A.UPD_ID,
+			A.CREATENAME,
+			A.RECOMMEND,
+			A.ISSUE,
+			A.OPEN_YN,
+			A.PROF_ID,
+			(SELECT USER_NM FROM TB_MA_MEMBER WHERE USER_ID = A.PROF_ID) AS PROF_NM
+		FROM TB_BOARD A
+		INNER JOIN TB_BOARD_MNG B ON A.BOARD_MNG_SEQ = B.BOARD_MNG_SEQ
+		WHERE A.BOARD_MNG_SEQ = #{boardMngSeq}
+		AND B.BOARD_MNG_SEQ = #{boardMngSeq}
+		<choose>
+			<when test="searchOnoffDiv != null and searchOnoffDiv != ''">
+				AND B.ONOFF_DIV = #{searchOnoffDiv}
+			</when>
+			<otherwise>
+				<if test="onoffDiv != null and onoffDiv == 'T'">
+					AND B.ONOFF_DIV = 'T'
+				</if>
+			</otherwise>
+		</choose>
+		<if test="searchText != null and searchText != ''">
+			<choose>
+				<when test='searchKind == "SEARCHSUBJECT"'>
+					AND A.SUBJECT LIKE CONCAT('%', #{searchText}, '%')
+				</when>
+				<when test='searchKind == "SEARCHNAME"'>
+					AND A.CREATENAME LIKE CONCAT('%', #{searchText}, '%')
+				</when>
+				<when test='searchKind == "SEARCHCONTENT"'>
+					AND A.CONTENT LIKE CONCAT('%', #{searchText}, '%')
+				</when>
+				<otherwise>
+					AND (A.SUBJECT LIKE CONCAT('%', #{searchText}, '%')
+						OR A.CREATENAME LIKE CONCAT('%', #{searchText}, '%')
+						OR A.CONTENT LIKE CONCAT('%', #{searchText}, '%'))
+				</otherwise>
+			</choose>
+		</if>
+		<if test="searchPrfId != null and searchPrfId != ''">
+			AND A.PROF_ID = #{searchPrfId}
+		</if>
+		ORDER BY A.NOTICE_TOP_YN DESC, A.BOARD_SEQ DESC
+		LIMIT #{recordCountPerPage} OFFSET #{firstIndex}
+	</select>
+
+	<!-- 강사용 게시판 목록 건수 조회 -->
+	<select id="selectBoardTeacherListCount" parameterType="com.academy.board.service.BoardVO" resultType="int">
+		SELECT COUNT(*) AS CNT
+		FROM TB_BOARD A
+		INNER JOIN TB_BOARD_MNG B ON A.BOARD_MNG_SEQ = B.BOARD_MNG_SEQ
+		WHERE A.BOARD_MNG_SEQ = #{boardMngSeq}
+		AND B.BOARD_MNG_SEQ = #{boardMngSeq}
+		<choose>
+			<when test="searchOnoffDiv != null and searchOnoffDiv != ''">
+				AND B.ONOFF_DIV = #{searchOnoffDiv}
+			</when>
+			<otherwise>
+				<if test="onoffDiv != null and onoffDiv == 'T'">
+					AND B.ONOFF_DIV = 'T'
+				</if>
+			</otherwise>
+		</choose>
+		<if test="searchText != null and searchText != ''">
+			<choose>
+				<when test='searchKind == "SEARCHSUBJECT"'>
+					AND A.SUBJECT LIKE CONCAT('%', #{searchText}, '%')
+				</when>
+				<when test='searchKind == "SEARCHNAME"'>
+					AND A.CREATENAME LIKE CONCAT('%', #{searchText}, '%')
+				</when>
+				<when test='searchKind == "SEARCHCONTENT"'>
+					AND A.CONTENT LIKE CONCAT('%', #{searchText}, '%')
+				</when>
+				<otherwise>
+					AND (A.SUBJECT LIKE CONCAT('%', #{searchText}, '%')
+						OR A.CREATENAME LIKE CONCAT('%', #{searchText}, '%')
+						OR A.CONTENT LIKE CONCAT('%', #{searchText}, '%'))
+				</otherwise>
+			</choose>
+		</if>
+		<if test="searchPrfId != null and searchPrfId != ''">
+			AND A.PROF_ID = #{searchPrfId}
+		</if>
+	</select>
+
+	<!-- 게시판 상세 조회 -->
+	<select id="getBoardDetail" parameterType="com.academy.board.service.BoardVO" resultType="org.json.simple.JSONObject">
+		SELECT
+			A.BOARD_MNG_SEQ,
+			A.BOARD_SEQ,
+			A.PARENT_BOARD_SEQ,
+			A.SUBJECT,
+			A.CONTENT,
+			A.ANSWER,
+			A.FILE_PATH,
+			A.FILE_NAME,
+			A.REAL_FILE_NAME,
+			A.NOTICE_TOP_YN,
+			A.OPEN_YN,
+			A.IS_USE,
+			A.HITS,
+			DATE_FORMAT(A.REG_DT, '%Y-%m-%d %H:%i:%s') AS REG_DT,
+			A.REG_ID,
+			A.UPD_DT,
+			A.UPD_ID,
+			A.CREATENAME,
+			A.BOARD_REPLY,
+			A.THUMBNAIL_FILE_PATH,
+			A.THUMBNAIL_FILE_NAME,
+			A.THUMBNAIL_FILE_REAL_NAME,
+			A.RECOMMEND,
+			A.ISSUE,
+			A.MAIN_YN,
+			A.PROF_ID,
+			CASE
+				WHEN EXISTS (SELECT 1 FROM TB_BOARD X WHERE X.BOARD_MNG_SEQ = A.BOARD_MNG_SEQ AND X.PARENT_BOARD_SEQ = A.BOARD_SEQ) THEN '답변완료'
+				WHEN A.PARENT_BOARD_SEQ > 0 THEN '답변완료'
+				ELSE CASE A.BOARD_REPLY
+					WHEN 'C' THEN '처리중(CS)'
+					WHEN 'A' THEN '처리중(운영)'
+					WHEN 'Y' THEN '답변완료'
+					ELSE '답변대기'
+				END
+			END AS BOARD_REPLY_NM
+		FROM TB_BOARD A
+		WHERE A.BOARD_SEQ = #{boardSeq}
+	</select>
+
+	<!-- 원본글 상세 조회 -->
+	<select id="getBoardDetailOrigin" parameterType="com.academy.board.service.BoardVO" resultType="org.json.simple.JSONObject">
+		SELECT
+			A.BOARD_MNG_SEQ,
+			A.BOARD_SEQ,
+			A.SUBJECT,
+			A.CONTENT,
+			DATE_FORMAT(A.REG_DT, '%Y-%m-%d %H:%i:%s') AS REG_DT,
+			A.REG_ID,
+			A.CREATENAME
+		FROM TB_BOARD A
+		WHERE A.BOARD_SEQ = #{parentBoardSeq}
+	</select>
+
+	<!-- 게시판 등록 -->
+	<insert id="insertBoard" parameterType="com.academy.board.service.BoardVO">
+		<selectKey keyProperty="boardSeq" resultType="String" order="BEFORE">
+			SELECT IFNULL(MAX(CAST(BOARD_SEQ AS UNSIGNED)), 0) + 1 FROM TB_BOARD
+		</selectKey>
+		INSERT INTO TB_BOARD (
+			BOARD_MNG_SEQ,
+			BOARD_SEQ,
+			PARENT_BOARD_SEQ,
+			OPEN_YN,
+			SUBJECT,
+			CONTENT,
+			<if test="filePath != null and filePath != ''">FILE_PATH,</if>
+			<if test="fileName != null and fileName != ''">FILE_NAME,</if>
+			<if test="realFileName != null and realFileName != ''">REAL_FILE_NAME,</if>
+			NOTICE_TOP_YN,
+			IS_USE,
+			HITS,
+			CREATENAME,
+			<if test="thumbnailFilePath != null and thumbnailFilePath != ''">THUMBNAIL_FILE_PATH,</if>
+			<if test="thumbnailFileName != null and thumbnailFileName != ''">THUMBNAIL_FILE_NAME,</if>
+			<if test="thumbnailFileRealName != null and thumbnailFileRealName != ''">THUMBNAIL_FILE_REAL_NAME,</if>
+			<if test="recommend != null and recommend != ''">RECOMMEND,</if>
+			<if test="issue != null and issue != ''">ISSUE,</if>
+			<if test="profId != null and profId != ''">PROF_ID,</if>
+			<if test="mockcode != null and mockcode != ''">MOCKCODE,</if>
+			<if test="boardReply != null and boardReply != ''">BOARD_REPLY,</if>
+			REG_DT,
+			REG_ID,
+			UPD_DT,
+			UPD_ID
+		) VALUES (
+			#{boardMngSeq},
+			#{boardSeq},
+			IFNULL(#{parentBoardSeq}, '0'),
+			#{openYn},
+			#{subject},
+			#{boardMemo},
+			<if test="filePath != null and filePath != ''">#{filePath},</if>
+			<if test="fileName != null and fileName != ''">#{fileName},</if>
+			<if test="realFileName != null and realFileName != ''">#{realFileName},</if>
+			IFNULL(#{noticeTopYn}, 'N'),
+			IFNULL(#{isUse}, 'Y'),
+			0,
+			#{createName},
+			<if test="thumbnailFilePath != null and thumbnailFilePath != ''">#{thumbnailFilePath},</if>
+			<if test="thumbnailFileName != null and thumbnailFileName != ''">#{thumbnailFileName},</if>
+			<if test="thumbnailFileRealName != null and thumbnailFileRealName != ''">#{thumbnailFileRealName},</if>
+			<if test="recommend != null and recommend != ''">#{recommend},</if>
+			<if test="issue != null and issue != ''">#{issue},</if>
+			<if test="profId != null and profId != ''">#{profId},</if>
+			<if test="mockcode != null and mockcode != ''">#{mockcode},</if>
+			<if test="boardReply != null and boardReply != ''">#{boardReply},</if>
+			now(),
+			#{regId},
+			now(),
+			#{regId}
+		)
+	</insert>
+
+	<!-- FAQ 게시판 등록 -->
+	<insert id="insertBoardFAQ" parameterType="com.academy.board.service.BoardVO">
+		<selectKey keyProperty="boardSeq" resultType="String" order="BEFORE">
+			SELECT IFNULL(MAX(CAST(BOARD_SEQ AS UNSIGNED)), 0) + 1 FROM TB_BOARD
+		</selectKey>
+		INSERT INTO TB_BOARD (
+			BOARD_MNG_SEQ,
+			BOARD_SEQ,
+			PARENT_BOARD_SEQ,
+			OPEN_YN,
+			SUBJECT,
+			ANSWER,
+			<if test="filePath != null and filePath != ''">FILE_PATH,</if>
+			<if test="fileName != null and fileName != ''">FILE_NAME,</if>
+			<if test="realFileName != null and realFileName != ''">REAL_FILE_NAME,</if>
+			NOTICE_TOP_YN,
+			IS_USE,
+			HITS,
+			CREATENAME,
+			<if test="profId != null and profId != ''">PROF_ID,</if>
+			REG_DT,
+			REG_ID,
+			UPD_DT,
+			UPD_ID
+		) VALUES (
+			#{boardMngSeq},
+			#{boardSeq},
+			'0',
+			#{openYn},
+			#{subject},
+			#{answer},
+			<if test="filePath != null and filePath != ''">#{filePath},</if>
+			<if test="fileName != null and fileName != ''">#{fileName},</if>
+			<if test="realFileName != null and realFileName != ''">#{realFileName},</if>
+			IFNULL(#{noticeTopYn}, 'N'),
+			IFNULL(#{isUse}, 'Y'),
+			0,
+			#{createName},
+			<if test="profId != null and profId != ''">#{profId},</if>
+			now(),
+			#{regId},
+			now(),
+			#{regId}
+		)
+	</insert>
+
+	<!-- 답변 게시판 등록 -->
+	<insert id="insertBoardReply" parameterType="com.academy.board.service.BoardVO">
+		<selectKey keyProperty="boardSeq" resultType="String" order="BEFORE">
+			SELECT IFNULL(MAX(CAST(BOARD_SEQ AS UNSIGNED)), 0) + 1 FROM TB_BOARD
+		</selectKey>
+		INSERT INTO TB_BOARD (
+			BOARD_MNG_SEQ,
+			BOARD_SEQ,
+			PARENT_BOARD_SEQ,
+			OPEN_YN,
+			SUBJECT,
+			CONTENT,
+			NOTICE_TOP_YN,
+			IS_USE,
+			HITS,
+			BOARD_TYPE,
+			CREATENAME,
+			<if test="profId != null and profId != ''">PROF_ID,</if>
+			<if test="mockcode != null and mockcode != ''">MOCKCODE,</if>
+			REG_DT,
+			REG_ID,
+			UPD_DT,
+			UPD_ID
+		) VALUES (
+			#{boardMngSeq},
+			#{boardSeq},
+			#{parentBoardSeq},
+			#{openYn},
+			#{subject},
+			#{boardMemo},
+			IFNULL(#{noticeTopYn}, 'N'),
+			IFNULL(#{isUse}, 'Y'),
+			0,
+			#{boardType},
+			#{createName},
+			<if test="profId != null and profId != ''">#{profId},</if>
+			<if test="mockcode != null and mockcode != ''">#{mockcode},</if>
+			now(),
+			#{regId},
+			now(),
+			#{regId}
+		)
+	</insert>
+
+	<!-- 게시판 수정 -->
+	<update id="updateBoard" parameterType="com.academy.board.service.BoardVO">
+		UPDATE TB_BOARD
+		SET
+			NOTICE_TOP_YN = #{noticeTopYn},
+			OPEN_YN = #{openYn},
+			SUBJECT = #{subject},
+			CONTENT = #{boardMemo},
+			<if test="filePath != null and filePath != ''">FILE_PATH = #{filePath},</if>
+			<if test="fileName != null and fileName != ''">FILE_NAME = #{fileName},</if>
+			<if test="realFileName != null and realFileName != ''">REAL_FILE_NAME = #{realFileName},</if>
+			<if test="thumbnailFilePath != null and thumbnailFilePath != ''">THUMBNAIL_FILE_PATH = #{thumbnailFilePath},</if>
+			<if test="thumbnailFileName != null and thumbnailFileName != ''">THUMBNAIL_FILE_NAME = #{thumbnailFileName},</if>
+			<if test="thumbnailFileRealName != null and thumbnailFileRealName != ''">THUMBNAIL_FILE_REAL_NAME = #{thumbnailFileRealName},</if>
+			<if test="recommend != null">RECOMMEND = #{recommend},</if>
+			<if test="issue != null">ISSUE = #{issue},</if>
+			<if test="profId != null">PROF_ID = #{profId},</if>
+			<if test="mockcode != null">MOCKCODE = #{mockcode},</if>
+			UPD_DT = now(),
+			UPD_ID = #{updId}
+		WHERE BOARD_SEQ = #{boardSeq}
+	</update>
+
+	<!-- FAQ 게시판 수정 -->
+	<update id="updateBoardFAQ" parameterType="com.academy.board.service.BoardVO">
+		UPDATE TB_BOARD
+		SET
+			NOTICE_TOP_YN = #{noticeTopYn},
+			OPEN_YN = #{openYn},
+			SUBJECT = #{subject},
+			ANSWER = #{answer},
+			<if test="filePath != null and filePath != ''">FILE_PATH = #{filePath},</if>
+			<if test="fileName != null and fileName != ''">FILE_NAME = #{fileName},</if>
+			<if test="realFileName != null and realFileName != ''">REAL_FILE_NAME = #{realFileName},</if>
+			UPD_DT = now(),
+			UPD_ID = #{updId}
+		WHERE BOARD_SEQ = #{boardSeq}
+	</update>
+
+	<!-- 게시판 삭제 -->
+	<delete id="deleteBoard" parameterType="com.academy.board.service.BoardVO">
+		DELETE FROM TB_BOARD
 		WHERE BOARD_MNG_SEQ = #{boardMngSeq}
 		AND BOARD_SEQ = #{boardSeq}
+	</delete>
+
+	<!-- 조회수 증가 -->
+	<update id="updateBoardHits" parameterType="com.academy.board.service.BoardVO">
+		UPDATE TB_BOARD SET HITS = HITS + 1 WHERE BOARD_SEQ = #{boardSeq}
 	</update>
+
+	<!-- 이슈 여부 수정 -->
+	<update id="updateBoardIssue" parameterType="com.academy.board.service.BoardVO">
+		UPDATE TB_BOARD SET ISSUE = #{issue}, UPD_DT = now(), UPD_ID = #{updId} WHERE BOARD_SEQ = #{boardSeq}
+	</update>
+
+	<!-- 추천 여부 수정 -->
+	<update id="updateBoardRecommend" parameterType="com.academy.board.service.BoardVO">
+		UPDATE TB_BOARD SET RECOMMEND = #{recommend}, UPD_DT = now(), UPD_ID = #{updId} WHERE BOARD_SEQ = #{boardSeq}
+	</update>
+
+	<!-- 공개 여부 수정 -->
+	<update id="updateBoardOpenYn" parameterType="com.academy.board.service.BoardVO">
+		UPDATE TB_BOARD SET OPEN_YN = #{openYn}, UPD_DT = now(), UPD_ID = #{updId} WHERE BOARD_SEQ = #{boardSeq}
+	</update>
+
+	<!-- 메인 노출 여부 수정 -->
+	<update id="updateBoardMainYn" parameterType="com.academy.board.service.BoardVO">
+		UPDATE TB_BOARD SET MAIN_YN = #{mainYn}, UPD_DT = now(), UPD_ID = #{updId} WHERE BOARD_SEQ = #{boardSeq}
+	</update>
+
+	<!-- 답변 상태 수정 -->
+	<update id="updateBoardReply" parameterType="com.academy.board.service.BoardVO">
+		UPDATE TB_BOARD SET BOARD_REPLY = #{boardReply}, UPD_DT = now(), UPD_ID = #{updId}
+		WHERE BOARD_SEQ = #{boardSeq} AND BOARD_MNG_SEQ = #{boardMngSeq}
+	</update>
+
+	<!-- 답변 존재 여부 확인 -->
+	<select id="selectReplyCount" parameterType="com.academy.board.service.BoardVO" resultType="int">
+		SELECT COUNT(*) AS CNT FROM TB_BOARD WHERE PARENT_BOARD_SEQ = #{boardSeq}
+	</select>
+
+	<!-- 답변 데이터 조회 -->
+	<select id="selectReplyData" parameterType="com.academy.board.service.BoardVO" resultType="org.json.simple.JSONObject">
+		SELECT BOARD_SEQ, FILE_PATH
+		FROM TB_BOARD
+		WHERE BOARD_MNG_SEQ = #{boardMngSeq}
+		AND PARENT_BOARD_SEQ = #{boardSeq}
+	</select>
+
+	<!-- =====================================================
+	     게시판 카테고리 (TB_BOARD_CATEGORY_INFO) 관련
+	     ===================================================== -->
+
+	<!-- 직급 코드 목록 조회 -->
+	<select id="selectRankCodeList" parameterType="com.academy.board.service.BoardVO" resultType="org.json.simple.JSONObject">
+		SELECT
+			ID, CODE, NAME, IS_USE,
+			CASE IS_USE WHEN 'Y' THEN '활성' WHEN 'N' THEN '비활성' ELSE IS_USE END AS IS_USE_NM,
+			REG_DT, REG_ID, UPD_DT, UPD_ID
+		FROM TB_CATEGORY_INFO
+		WHERE IS_USE = 'Y'
+		AND P_CODE = 'CLASSCODE'
+		<if test="onoffDiv != null and onoffDiv == 'O'">
+			AND USE_ON = 'Y'
+		</if>
+		<if test="onoffDiv != null and onoffDiv == 'F'">
+			AND USE_OFF = 'Y'
+		</if>
+		ORDER BY CODE ASC
+	</select>
+
+	<!-- 게시판 카테고리 정보 등록 -->
+	<insert id="insertBoardCatInfo" parameterType="com.academy.board.service.BoardVO">
+		INSERT INTO TB_BOARD_CATEGORY_INFO (
+			BOARD_MNG_SEQ,
+			BOARD_SEQ,
+			CATEGORY_CODE
+		) VALUES (
+			#{boardMngSeq},
+			#{boardSeq},
+			#{categoryCode}
+		)
+	</insert>
+
+	<!-- 게시판 카테고리 정보 조회 -->
+	<select id="selectBoardCodeList" parameterType="com.academy.board.service.BoardVO" resultType="org.json.simple.JSONObject">
+		SELECT CATEGORY_CODE FROM TB_BOARD_CATEGORY_INFO
+		WHERE BOARD_MNG_SEQ = #{boardMngSeq} AND BOARD_SEQ = #{boardSeq}
+	</select>
+
+	<!-- 게시판 카테고리 정보 삭제 -->
+	<delete id="deleteBoardCatInfo" parameterType="com.academy.board.service.BoardVO">
+		DELETE FROM TB_BOARD_CATEGORY_INFO
+		WHERE BOARD_SEQ = #{boardSeq} AND BOARD_MNG_SEQ = #{boardMngSeq}
+	</delete>
+
+	<!-- =====================================================
+	     게시판 첨부파일 (TB_BOARD_FILE) 관련
+	     ===================================================== -->
+
+	<!-- 게시판 첨부파일 목록 조회 -->
+	<select id="selectBoardFileList" parameterType="com.academy.board.service.BoardFileVO" resultType="org.json.simple.JSONObject">
+		SELECT BOARD_SEQ, FILE_NO, FILE_NAME, FILE_PATH
+		FROM TB_BOARD_FILE
+		WHERE BOARD_SEQ = #{boardSeq}
+	</select>
+
+	<!-- 게시판 이미지 첨부파일 목록 조회 -->
+	<select id="selectBoardFileImgList" parameterType="com.academy.board.service.BoardFileVO" resultType="org.json.simple.JSONObject">
+		SELECT BOARD_SEQ, FILE_NO, FILE_NAME, FILE_PATH
+		FROM TB_BOARD_FILE
+		WHERE BOARD_SEQ = #{boardSeq}
+		AND (
+			LOWER(RIGHT(FILE_NAME, 3)) IN ('jpg', 'png', 'gif', 'bmp')
+			OR LOWER(RIGHT(FILE_NAME, 4)) IN ('jpeg')
+		)
+	</select>
+
+	<!-- 게시판 첨부파일 등록 -->
+	<insert id="insertBoardFile" parameterType="com.academy.board.service.BoardFileVO">
+		INSERT INTO TB_BOARD_FILE (
+			BOARD_MNG_SEQ,
+			BOARD_SEQ,
+			FILE_NO,
+			FILE_NAME,
+			FILE_PATH,
+			REG_ID,
+			REG_DT,
+			UPD_ID,
+			UPD_DT
+		) VALUES (
+			#{boardMngSeq},
+			#{boardSeq},
+			(SELECT IFNULL(MAX(FILE_NO), 0) + 1 FROM TB_BOARD_FILE A WHERE A.BOARD_SEQ = #{boardSeq}),
+			#{fileName},
+			#{filePath},
+			#{regId},
+			now(),
+			#{regId},
+			now()
+		)
+	</insert>
+
+	<!-- 답변 게시판 첨부파일 등록 -->
+	<insert id="insertBoardReplyFile" parameterType="com.academy.board.service.BoardFileVO">
+		INSERT INTO TB_BOARD_FILE (
+			BOARD_MNG_SEQ,
+			BOARD_SEQ,
+			FILE_NO,
+			FILE_NAME,
+			FILE_PATH,
+			REG_ID,
+			REG_DT,
+			UPD_ID,
+			UPD_DT,
+			PARENT_BOARD_SEQ
+		) VALUES (
+			#{boardMngSeq},
+			#{boardSeq},
+			(SELECT IFNULL(MAX(FILE_NO), 0) + 1 FROM TB_BOARD_FILE A WHERE A.BOARD_SEQ = #{boardSeq}),
+			#{fileName},
+			#{filePath},
+			#{regId},
+			now(),
+			#{regId},
+			now(),
+			#{parentBoardSeq}
+		)
+	</insert>
+
+	<!-- 게시판 첨부파일 삭제 (경로 기준) -->
+	<delete id="deleteBoardFileByPath" parameterType="com.academy.board.service.BoardFileVO">
+		DELETE FROM TB_BOARD_FILE WHERE FILE_PATH = #{filePath} AND BOARD_SEQ = #{boardSeq}
+	</delete>
+
+	<!-- 게시판 첨부파일 삭제 (게시글 기준) -->
+	<delete id="deleteBoardFileByBoard" parameterType="com.academy.board.service.BoardFileVO">
+		DELETE FROM TB_BOARD_FILE WHERE BOARD_MNG_SEQ = #{boardMngSeq} AND BOARD_SEQ = #{boardSeq}
+	</delete>
+
+	<!-- =====================================================
+	     게시판 코멘트 (TB_BOARD_COMMENT) 관련
+	     ===================================================== -->
+
+	<!-- 게시판 코멘트 목록 조회 -->
+	<select id="selectBoardCommentList" parameterType="com.academy.board.service.BoardCommentVO" resultType="org.json.simple.JSONObject">
+		SELECT
+			SEQ,
+			CMMT_BOARD_MNG_SEQ,
+			CMMT_BOARD_SEQ,
+			TITLE,
+			CONTENT,
+			DATE_FORMAT(REG_DT, '%Y-%m-%d %H:%i:%s') AS REG_DT,
+			REG_ID,
+			(SELECT USER_NM FROM TB_MA_MEMBER WHERE USER_ID = A.REG_ID) AS REG_NM
+		FROM TB_BOARD_COMMENT A
+		WHERE CMMT_BOARD_MNG_SEQ = #{cmmtBoardMngSeq}
+		AND CMMT_BOARD_SEQ = #{cmmtBoardSeq}
+		ORDER BY REG_DT DESC
+		LIMIT #{recordCountPerPage} OFFSET #{firstIndex}
+	</select>
+
+	<!-- 게시판 코멘트 목록 건수 조회 -->
+	<select id="selectBoardCommentListCount" parameterType="com.academy.board.service.BoardCommentVO" resultType="int">
+		SELECT COUNT(*) AS CNT
+		FROM TB_BOARD_COMMENT
+		WHERE CMMT_BOARD_MNG_SEQ = #{cmmtBoardMngSeq}
+		AND CMMT_BOARD_SEQ = #{cmmtBoardSeq}
+	</select>
+
+	<!-- 게시판 코멘트 등록 -->
+	<insert id="insertBoardComment" parameterType="com.academy.board.service.BoardCommentVO">
+		INSERT INTO TB_BOARD_COMMENT (
+			SEQ,
+			CMMT_BOARD_MNG_SEQ,
+			CMMT_BOARD_SEQ,
+			TITLE,
+			CONTENT,
+			REG_DT,
+			REG_ID,
+			UPD_DT,
+			UPD_ID
+		) VALUES (
+			REPLACE(UUID(), '-', ''),
+			#{cmmtBoardMngSeq},
+			#{cmmtBoardSeq},
+			#{title},
+			#{content},
+			now(),
+			#{regId},
+			now(),
+			#{regId}
+		)
+	</insert>
+
+	<!-- 게시판 코멘트 삭제 -->
+	<delete id="deleteBoardComment" parameterType="com.academy.board.service.BoardCommentVO">
+		DELETE FROM TB_BOARD_COMMENT WHERE SEQ = #{deleteSeq}
+	</delete>
 
 </mapper>

--- a/src/main/resources/mapper/boardManagementSQL.xml
+++ b/src/main/resources/mapper/boardManagementSQL.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.academy.mapper.BoardManagementMapper">
+
+    <!-- 게시판 관리 목록 조회 -->
+    <select id="selectBoardMngList" parameterType="com.academy.board.service.BoardMngVO" resultType="org.json.simple.JSONObject">
+        SELECT
+            BOARD_MNG_SEQ,
+            BOARD_MNG_NAME,
+            CASE ONOFF_DIV WHEN 'O' THEN '온라인' WHEN 'F' THEN '오프라인' WHEN 'T' THEN '강사용' ELSE ONOFF_DIV END AS ONOFF_DIV_NM,
+            (SELECT CODE_NM FROM TB_BA_CONFIG_CD
+             WHERE SYS_CD = 'BOARD_MNG_TYPE'
+             AND CODE_VAL = A.BOARD_MNG_TYPE) AS BOARD_MNG_TYPE_NM,
+            BOARD_MNG_TYPE,
+            CASE OPEN_YN WHEN 'Y' THEN '로그인' WHEN 'N' THEN '비로그인' ELSE OPEN_YN END AS OPEN_YN_NM,
+            CASE ISUSE WHEN 'Y' THEN '활성' WHEN 'N' THEN '비활성' ELSE ISUSE END AS ISUSE_NM,
+            DATE_FORMAT(REG_DT, '%Y-%m-%d %H:%i:%s') AS REG_DT,
+            REG_ID,
+            DATE_FORMAT(UPD_DT, '%Y-%m-%d %H:%i:%s') AS UPD_DT,
+            UPD_ID
+        FROM TB_BOARD_MNG A
+        WHERE 1=1
+        <if test="searchKeyword != null and searchKeyword != ''">
+            <choose>
+                <when test='searchType == "BOARD_MNG_SEQ"'>
+                    AND BOARD_MNG_SEQ LIKE CONCAT('%', #{searchKeyword}, '%')
+                </when>
+                <when test='searchType == "BOARD_MNG_NAME"'>
+                    AND BOARD_MNG_NAME LIKE CONCAT('%', #{searchKeyword}, '%')
+                </when>
+                <otherwise>
+                    AND (BOARD_MNG_SEQ LIKE CONCAT('%', #{searchKeyword}, '%')
+                         OR BOARD_MNG_NAME LIKE CONCAT('%', #{searchKeyword}, '%'))
+                </otherwise>
+            </choose>
+        </if>
+        ORDER BY REG_DT DESC
+        LIMIT #{recordCountPerPage} OFFSET #{firstIndex}
+    </select>
+
+    <!-- 게시판 관리 목록 건수 조회 -->
+    <select id="selectBoardMngListCount" parameterType="com.academy.board.service.BoardMngVO" resultType="int">
+        SELECT COUNT(*) AS CNT
+        FROM TB_BOARD_MNG
+        WHERE 1=1
+        <if test="searchKeyword != null and searchKeyword != ''">
+            <choose>
+                <when test='searchType == "BOARD_MNG_SEQ"'>
+                    AND BOARD_MNG_SEQ LIKE CONCAT('%', #{searchKeyword}, '%')
+                </when>
+                <when test='searchType == "BOARD_MNG_NAME"'>
+                    AND BOARD_MNG_NAME LIKE CONCAT('%', #{searchKeyword}, '%')
+                </when>
+                <otherwise>
+                    AND (BOARD_MNG_SEQ LIKE CONCAT('%', #{searchKeyword}, '%')
+                         OR BOARD_MNG_NAME LIKE CONCAT('%', #{searchKeyword}, '%'))
+                </otherwise>
+            </choose>
+        </if>
+    </select>
+
+    <!-- 게시판 타입 목록 조회 -->
+    <select id="selectBoardTypeList" resultType="org.json.simple.JSONObject">
+        SELECT CODE_CD, CODE_NM FROM TB_BA_CONFIG_CD WHERE SYS_CD = 'BOARD_MNG_TYPE'
+    </select>
+
+    <!-- 게시판 관리 상세 조회 -->
+    <select id="selectBoardMngDetail" parameterType="com.academy.board.service.BoardMngVO" resultType="org.json.simple.JSONObject">
+        SELECT
+            BOARD_MNG_SEQ,
+            (SELECT CODE_NM FROM TB_BA_CONFIG_CD
+             WHERE SYS_CD = 'BOARD_MNG_TYPE'
+             AND CODE_CD = A.BOARD_MNG_TYPE) AS BOARD_MNG_TYPE_NM,
+            CASE ONOFF_DIV WHEN 'O' THEN '온라인' WHEN 'F' THEN '오프라인' WHEN 'T' THEN '강사용' ELSE ONOFF_DIV END AS ONOFF_DIV_NM,
+            BOARD_MNG_NAME,
+            BOARD_MNG_TYPE,
+            ATTACH_FILE_YN,
+            OPEN_YN,
+            REPLY_YN,
+            ISUSE,
+            DATE_FORMAT(REG_DT, '%Y-%m-%d %H:%i:%s') AS REG_DT,
+            REG_ID,
+            DATE_FORMAT(UPD_DT, '%Y-%m-%d %H:%i:%s') AS UPD_DT,
+            UPD_ID
+        FROM TB_BOARD_MNG A
+        WHERE BOARD_MNG_SEQ = #{boardMngSeq}
+    </select>
+
+    <!-- 게시판 관리 등록 -->
+    <insert id="insertBoardMng" parameterType="com.academy.board.service.BoardMngVO">
+        INSERT INTO TB_BOARD_MNG (
+            BOARD_MNG_SEQ,
+            BOARD_MNG_NAME,
+            ONOFF_DIV,
+            BOARD_MNG_TYPE,
+            ATTACH_FILE_YN,
+            OPEN_YN,
+            REPLY_YN,
+            ISUSE,
+            REG_DT,
+            REG_ID,
+            UPD_DT,
+            UPD_ID
+        ) VALUES (
+            (SELECT CONCAT(#{boardMngType}, '_', LPAD(IFNULL(CAST(SUBSTRING(MAX(BOARD_MNG_SEQ), -3) AS UNSIGNED) + 1, 1), 3, '0'))
+             FROM TB_BOARD_MNG B
+             WHERE BOARD_MNG_TYPE = #{boardMngType}),
+            #{boardMngName},
+            #{onoffDiv},
+            #{boardMngType},
+            'Y',
+            #{openYn},
+            <if test="boardMngType == 'BOARD' or boardMngType == 'TCC'">
+                #{replyYn},
+            </if>
+            <if test="boardMngType != 'BOARD' and boardMngType != 'TCC'">
+                'N',
+            </if>
+            #{isuse},
+            now(),
+            #{regId},
+            now(),
+            #{updId}
+        )
+    </insert>
+
+    <!-- 게시판 관리 수정 -->
+    <update id="updateBoardMng" parameterType="com.academy.board.service.BoardMngVO">
+        UPDATE TB_BOARD_MNG
+        SET
+            BOARD_MNG_NAME = #{boardMngName},
+            <if test="boardMngType == 'BOARD' or boardMngType == 'TCC'">
+                REPLY_YN = #{replyYn},
+            </if>
+            OPEN_YN = #{openYn},
+            ISUSE = #{isuse},
+            UPD_DT = now(),
+            UPD_ID = #{updId}
+        WHERE BOARD_MNG_SEQ = #{boardMngSeq}
+    </update>
+
+    <!-- 게시판 관리 삭제 -->
+    <delete id="deleteBoardMng" parameterType="com.academy.board.service.BoardMngVO">
+        DELETE FROM TB_BOARD_MNG WHERE BOARD_MNG_SEQ = #{boardMngSeq}
+    </delete>
+
+    <!-- 게시판 관리 일괄 삭제 -->
+    <delete id="deleteBoardMngBatch" parameterType="com.academy.board.service.BoardMngVO">
+        DELETE FROM TB_BOARD_MNG WHERE BOARD_MNG_SEQ IN (${deleteIds})
+    </delete>
+
+    <!-- 게시판 종류 정보 조회 (게시물 등록 시) -->
+    <select id="selectBoardKind" parameterType="com.academy.board.service.BoardVO" resultType="org.json.simple.JSONObject">
+        SELECT
+            BOARD_MNG_SEQ,
+            BOARD_MNG_NAME,
+            ONOFF_DIV,
+            BOARD_MNG_TYPE,
+            ATTACH_FILE_YN,
+            OPEN_YN,
+            REPLY_YN
+        FROM TB_BOARD_MNG
+        WHERE BOARD_MNG_SEQ = #{boardMngSeq}
+    </select>
+
+</mapper>

--- a/src/main/resources/mapper/boardNotAnswerSQL.xml
+++ b/src/main/resources/mapper/boardNotAnswerSQL.xml
@@ -1,0 +1,376 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.academy.mapper.BoardNotAnswerMapper">
+
+    <!-- 미응답 게시판 목록 조회 -->
+    <select id="selectBoardNotAnswerList" parameterType="com.academy.board.service.BoardVO" resultType="org.json.simple.JSONObject">
+        SELECT
+            (SELECT BOARD_MNG_NAME FROM TB_BOARD_MNG WHERE BOARD_MNG_SEQ = C.BOARD_MNG_SEQ) AS BOARD_NAME,
+            D.ONOFF_DIV,
+            C.BOARD_MNG_SEQ,
+            CAST(C.BOARD_SEQ AS UNSIGNED) AS BOARD_SEQ,
+            C.SUBJECT,
+            C.CONTENT,
+            (SELECT FILE_NAME FROM TB_BOARD_FILE WHERE BOARD_SEQ = C.BOARD_SEQ LIMIT 1) AS FILE_NAME,
+            C.PARENT_BOARD_SEQ,
+            C.NOTICE_TOP_YN,
+            C.HITS,
+            DATE_FORMAT(C.REG_DT, '%Y-%m-%d %H:%i:%s') AS REG_DT,
+            DATE_FORMAT(C.UPD_DT, '%Y-%m-%d %H:%i:%s') AS UPD_DT,
+            C.UPD_ID,
+            C.CREATENAME,
+            C.PROF_ID,
+            (SELECT USER_NM FROM TB_MA_MEMBER WHERE USER_ID = C.PROF_ID) AS PROF_NM,
+            C.BOARD_REPLY,
+            CASE
+                WHEN EXISTS (SELECT 1 FROM TB_BOARD WHERE BOARD_MNG_SEQ = C.BOARD_MNG_SEQ AND PARENT_BOARD_SEQ = C.BOARD_SEQ) THEN '답변완료'
+                WHEN C.PARENT_BOARD_SEQ > 0 THEN '답변완료'
+                ELSE CASE C.BOARD_REPLY
+                    WHEN 'C' THEN '처리중(CS)'
+                    WHEN 'A' THEN '처리중(운영)'
+                    WHEN 'Y' THEN '답변완료'
+                    ELSE '답변대기'
+                END
+            END AS BOARD_REPLY_NM
+        FROM TB_BOARD C
+        INNER JOIN TB_BOARD_MNG D ON C.BOARD_MNG_SEQ = D.BOARD_MNG_SEQ
+        WHERE 1=1
+        <if test='onoffDiv != null and onoffDiv == "O"'>
+            AND D.ONOFF_DIV = 'O'
+        </if>
+        <if test='onoffDiv != null and onoffDiv == "F"'>
+            AND D.ONOFF_DIV = 'F'
+        </if>
+        AND D.REPLY_YN = 'Y'
+        AND C.PARENT_BOARD_SEQ = 0
+        AND C.BOARD_MNG_SEQ LIKE '%BOARD_%'
+        AND D.BOARD_MNG_NAME LIKE '%상담실%'
+        AND C.NOTICE_TOP_YN = 'N'
+        AND C.BOARD_SEQ NOT IN (SELECT PARENT_BOARD_SEQ FROM TB_BOARD WHERE PARENT_BOARD_SEQ > 0)
+        <choose>
+            <when test='searchPrfId != null and searchPrfId != ""'>
+                AND C.PROF_ID IS NOT NULL
+            </when>
+            <otherwise>
+                AND C.PROF_ID IS NULL
+            </otherwise>
+        </choose>
+        ORDER BY C.BOARD_SEQ DESC
+        LIMIT #{recordCountPerPage} OFFSET #{firstIndex}
+    </select>
+
+    <!-- 미응답 게시판 목록 건수 조회 -->
+    <select id="selectBoardNotAnswerListCount" parameterType="com.academy.board.service.BoardVO" resultType="int">
+        SELECT COUNT(*) AS CNT
+        FROM TB_BOARD C
+        INNER JOIN TB_BOARD_MNG D ON C.BOARD_MNG_SEQ = D.BOARD_MNG_SEQ
+        WHERE 1=1
+        <if test='onoffDiv != null and onoffDiv == "O"'>
+            AND D.ONOFF_DIV = 'O'
+        </if>
+        <if test='onoffDiv != null and onoffDiv == "F"'>
+            AND D.ONOFF_DIV = 'F'
+        </if>
+        AND D.REPLY_YN = 'Y'
+        AND C.PARENT_BOARD_SEQ = 0
+        AND C.BOARD_MNG_SEQ LIKE '%BOARD_%'
+        AND D.BOARD_MNG_NAME LIKE '%상담실%'
+        AND C.NOTICE_TOP_YN = 'N'
+        AND C.BOARD_SEQ NOT IN (SELECT PARENT_BOARD_SEQ FROM TB_BOARD WHERE PARENT_BOARD_SEQ > 0)
+        <choose>
+            <when test='searchPrfId != null and searchPrfId != ""'>
+                AND C.PROF_ID IS NOT NULL
+            </when>
+            <otherwise>
+                AND C.PROF_ID IS NULL
+            </otherwise>
+        </choose>
+    </select>
+
+    <!-- 직급 코드 목록 조회 -->
+    <select id="selectRankCodeList" parameterType="com.academy.board.service.BoardVO" resultType="org.json.simple.JSONObject">
+        SELECT
+            ID, CODE, NAME, ISUSE,
+            CASE ISUSE WHEN 'Y' THEN '활성' WHEN 'N' THEN '비활성' ELSE ISUSE END AS ISUSENM,
+            REG_DT, REG_ID, UPD_DT, UPD_ID
+        FROM TB_CATEGORY_INFO
+        WHERE ISUSE = 'Y'
+        AND P_CODE = 'CLASSCODE'
+        <if test='onoffDiv != null and onoffDiv == "O"'>
+            AND USE_ON = 'Y'
+        </if>
+        <if test='onoffDiv != null and onoffDiv == "F"'>
+            AND USE_OFF = 'Y'
+        </if>
+        ORDER BY CODE ASC
+    </select>
+
+    <!-- 게시판 카테고리 정보 등록 -->
+    <insert id="insertBoardCatInfo" parameterType="com.academy.board.service.BoardVO">
+        INSERT INTO TB_BOARD_CATEGORY_INFO (
+            BOARD_MNG_SEQ,
+            BOARD_SEQ,
+            CATEGORY_CODE
+        ) VALUES (
+            #{boardMngSeq},
+            #{boardSeq},
+            #{categoryCode}
+        )
+    </insert>
+
+    <!-- 게시판 카테고리 정보 조회 -->
+    <select id="selectBoardCodeList" parameterType="com.academy.board.service.BoardVO" resultType="org.json.simple.JSONObject">
+        SELECT CATEGORY_CODE FROM TB_BOARD_CATEGORY_INFO
+        WHERE BOARD_MNG_SEQ = #{boardMngSeq}
+        AND BOARD_SEQ = #{boardSeq}
+    </select>
+
+    <!-- 게시판 카테고리 정보 삭제 -->
+    <delete id="deleteBoardCatInfo" parameterType="com.academy.board.service.BoardVO">
+        DELETE FROM TB_BOARD_CATEGORY_INFO
+        WHERE BOARD_SEQ = #{boardSeq}
+        AND BOARD_MNG_SEQ = #{boardMngSeq}
+    </delete>
+
+    <!-- 게시판 상세 조회 (미응답용) -->
+    <select id="getBoardDetail" parameterType="com.academy.board.service.BoardVO" resultType="org.json.simple.JSONObject">
+        SELECT
+            <if test="parentBoardSeq != null and parentBoardSeq != 0">
+                (SELECT CONTENT FROM TB_BOARD WHERE BOARD_SEQ = A.PARENT_BOARD_SEQ) AS ORIGIN,
+            </if>
+            BOARD_MNG_SEQ,
+            BOARD_SEQ,
+            OPEN_YN,
+            SUBJECT,
+            CONTENT,
+            ANSWER,
+            FILE_PATH,
+            FILE_NAME,
+            REAL_FILE_NAME,
+            PARENT_BOARD_SEQ,
+            NOTICE_TOP_YN,
+            DATE_FORMAT(REG_DT, '%Y-%m-%d %H:%i:%s') AS REG_DT,
+            REG_ID,
+            UPD_DT,
+            UPD_ID,
+            HITS,
+            CREATENAME,
+            BOARD_REPLY,
+            CASE
+                WHEN EXISTS (SELECT 1 FROM TB_BOARD WHERE BOARD_MNG_SEQ = A.BOARD_MNG_SEQ AND PARENT_BOARD_SEQ = A.BOARD_SEQ) THEN '답변완료'
+                WHEN A.PARENT_BOARD_SEQ > 0 THEN '답변완료'
+                ELSE CASE A.BOARD_REPLY
+                    WHEN 'C' THEN '처리중(CS)'
+                    WHEN 'A' THEN '처리중(운영)'
+                    WHEN 'Y' THEN '답변완료'
+                    ELSE '답변대기'
+                END
+            END AS BOARD_REPLY_NM
+        FROM TB_BOARD A
+        WHERE BOARD_SEQ = #{boardSeq}
+    </select>
+
+    <!-- 원본글 상세 조회 (답변글에서 참조) -->
+    <select id="getBoardDetailOrigin" parameterType="com.academy.board.service.BoardVO" resultType="org.json.simple.JSONObject">
+        SELECT
+            BOARD_MNG_SEQ,
+            BOARD_SEQ,
+            OPEN_YN,
+            SUBJECT,
+            CONTENT,
+            ANSWER,
+            FILE_PATH,
+            FILE_NAME,
+            REAL_FILE_NAME,
+            PARENT_BOARD_SEQ,
+            NOTICE_TOP_YN,
+            DATE_FORMAT(REG_DT, '%Y-%m-%d %H:%i:%s') AS REG_DT,
+            REG_ID,
+            UPD_DT,
+            UPD_ID,
+            HITS,
+            CREATENAME,
+            BOARD_REPLY
+        FROM TB_BOARD
+        WHERE BOARD_SEQ = #{parentBoardSeq}
+    </select>
+
+    <!-- 답변 게시물 등록 -->
+    <insert id="insertBoardReply" parameterType="com.academy.board.service.BoardVO">
+        <selectKey keyProperty="boardSeq" resultType="String" order="BEFORE">
+            SELECT IFNULL(MAX(CAST(BOARD_SEQ AS UNSIGNED)), 0) + 1 FROM TB_BOARD
+        </selectKey>
+        INSERT INTO TB_BOARD (
+            BOARD_MNG_SEQ,
+            BOARD_SEQ,
+            OPEN_YN,
+            SUBJECT,
+            CONTENT,
+            PARENT_BOARD_SEQ,
+            NOTICE_TOP_YN,
+            REG_DT,
+            REG_ID,
+            UPD_DT,
+            UPD_ID,
+            HITS,
+            BOARD_TYPE,
+            CREATENAME
+        ) VALUES (
+            #{boardMngSeq},
+            #{boardSeq},
+            #{openYn},
+            #{subject},
+            #{content},
+            #{parentBoardSeq},
+            #{noticeTopYn},
+            now(),
+            #{regId},
+            now(),
+            #{regId},
+            0,
+            #{boardType},
+            #{createName}
+        )
+    </insert>
+
+    <!-- 게시판 수정 -->
+    <update id="updateBoard" parameterType="com.academy.board.service.BoardVO">
+        UPDATE TB_BOARD
+        SET
+            NOTICE_TOP_YN = #{noticeTopYn},
+            OPEN_YN = #{openYn},
+            SUBJECT = #{subject},
+            UPD_DT = now(),
+            UPD_ID = #{regId},
+            CONTENT = #{content}
+        WHERE BOARD_SEQ = #{boardSeq}
+    </update>
+
+    <!-- 조회수 증가 -->
+    <update id="updateBoardHits" parameterType="com.academy.board.service.BoardVO">
+        UPDATE TB_BOARD SET HITS = HITS + 1 WHERE BOARD_SEQ = #{boardSeq}
+    </update>
+
+    <!-- 답변 상태 수정 -->
+    <update id="updateBoardReply" parameterType="com.academy.board.service.BoardVO">
+        UPDATE TB_BOARD
+        SET BOARD_REPLY = #{boardReply}
+        WHERE BOARD_SEQ = #{boardSeq}
+        AND BOARD_MNG_SEQ = #{boardMngSeq}
+    </update>
+
+    <!-- 답변 존재 여부 확인 -->
+    <select id="selectReplyCount" parameterType="com.academy.board.service.BoardVO" resultType="int">
+        SELECT COUNT(*) AS CNT
+        FROM TB_BOARD
+        WHERE PARENT_BOARD_SEQ = #{boardSeq}
+    </select>
+
+    <!-- 답변 데이터 조회 -->
+    <select id="selectReplyData" parameterType="com.academy.board.service.BoardVO" resultType="org.json.simple.JSONObject">
+        SELECT
+            BOARD_SEQ,
+            FILE_PATH
+        FROM TB_BOARD
+        WHERE BOARD_MNG_SEQ = #{boardMngSeq}
+        AND PARENT_BOARD_SEQ = #{boardSeq}
+    </select>
+
+    <!-- 게시판 삭제 -->
+    <delete id="deleteBoard" parameterType="com.academy.board.service.BoardVO">
+        DELETE FROM TB_BOARD
+        WHERE BOARD_MNG_SEQ = #{boardMngSeq}
+        AND BOARD_SEQ = #{boardSeq}
+    </delete>
+
+    <!-- 게시판 첨부파일 목록 조회 -->
+    <select id="selectBoardFileList" parameterType="com.academy.board.service.BoardFileVO" resultType="org.json.simple.JSONObject">
+        SELECT
+            BOARD_SEQ,
+            FILE_NO,
+            FILE_NAME,
+            FILE_PATH
+        FROM TB_BOARD_FILE
+        WHERE BOARD_SEQ = #{boardSeq}
+    </select>
+
+    <!-- 게시판 이미지 첨부파일 목록 조회 -->
+    <select id="selectBoardFileImgList" parameterType="com.academy.board.service.BoardFileVO" resultType="org.json.simple.JSONObject">
+        SELECT
+            BOARD_SEQ,
+            FILE_NO,
+            FILE_NAME,
+            FILE_PATH
+        FROM TB_BOARD_FILE
+        WHERE BOARD_SEQ = #{boardSeq}
+        AND (LOWER(RIGHT(FILE_NAME, 3)) IN ('jpg', 'peg', 'png', 'bmp', 'gif')
+             OR LOWER(RIGHT(FILE_NAME, 4)) = 'jpeg')
+    </select>
+
+    <!-- 게시판 첨부파일 등록 -->
+    <insert id="insertBoardFile" parameterType="com.academy.board.service.BoardFileVO">
+        INSERT INTO TB_BOARD_FILE (
+            BOARD_MNG_SEQ,
+            BOARD_SEQ,
+            FILE_NO,
+            FILE_NAME,
+            FILE_PATH,
+            REG_ID,
+            REG_DT,
+            UPD_ID,
+            UPD_DT
+        ) VALUES (
+            #{boardMngSeq},
+            #{boardSeq},
+            (SELECT IFNULL(MAX(CAST(FILE_NO AS UNSIGNED)), 0) + 1 FROM TB_BOARD_FILE A),
+            #{fileName},
+            #{filePath},
+            #{regId},
+            now(),
+            #{regId},
+            now()
+        )
+    </insert>
+
+    <!-- 답변 게시판 첨부파일 등록 -->
+    <insert id="insertBoardReplyFile" parameterType="com.academy.board.service.BoardFileVO">
+        INSERT INTO TB_BOARD_FILE (
+            BOARD_MNG_SEQ,
+            BOARD_SEQ,
+            FILE_NO,
+            FILE_NAME,
+            FILE_PATH,
+            REG_ID,
+            REG_DT,
+            UPD_ID,
+            UPD_DT,
+            PARENT_BOARD_SEQ
+        ) VALUES (
+            #{boardMngSeq},
+            #{boardSeq},
+            (SELECT IFNULL(MAX(CAST(FILE_NO AS UNSIGNED)), 0) + 1 FROM TB_BOARD_FILE A),
+            #{fileName},
+            #{filePath},
+            #{regId},
+            now(),
+            #{regId},
+            now(),
+            #{parentBoardSeq}
+        )
+    </insert>
+
+    <!-- 게시판 첨부파일 삭제 (경로 기준) -->
+    <delete id="deleteBoardFileByPath" parameterType="com.academy.board.service.BoardFileVO">
+        DELETE FROM TB_BOARD_FILE
+        WHERE FILE_PATH = #{filePath}
+        AND BOARD_SEQ = #{boardSeq}
+    </delete>
+
+    <!-- 게시판 첨부파일 삭제 (게시글 기준) -->
+    <delete id="deleteBoardFileByBoard" parameterType="com.academy.board.service.BoardFileVO">
+        DELETE FROM TB_BOARD_FILE
+        WHERE BOARD_MNG_SEQ = #{boardMngSeq}
+        AND BOARD_SEQ = #{boardSeq}
+    </delete>
+
+</mapper>

--- a/src/main/resources/mapper/boardTeacherSQL.xml
+++ b/src/main/resources/mapper/boardTeacherSQL.xml
@@ -1,0 +1,247 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.academy.mapper.BoardTeacherMapper">
+
+    <!-- 강사용 게시판 목록 조회 -->
+    <select id="selectBoardTeacherList" parameterType="com.academy.board.service.BoardVO" resultType="org.json.simple.JSONObject">
+        SELECT
+            (SELECT NAME FROM TB_CATEGORY_INFO WHERE CODE = #{searchCategory}) AS CODENAME,
+            CAST(bb.BOARD_SEQ AS UNSIGNED) AS BOARD_SEQ,
+            bb.SUBJECT,
+            bb.CONTENT,
+            (SELECT FILE_NAME FROM TB_BOARD_FILE WHERE BOARD_SEQ = bb.BOARD_SEQ LIMIT 1) AS FILE_NAME,
+            bb.THUMBNAIL_FILE_NAME,
+            bb.PARENT_BOARD_SEQ,
+            bb.NOTICE_TOP_YN,
+            bb.HITS,
+            DATE_FORMAT(bb.REG_DT, '%Y-%m-%d %H:%i:%s') AS REG_DT,
+            (SELECT USER_NM FROM TB_MA_MEMBER WHERE USER_ID = bb.REG_ID) AS USER_NM,
+            DATE_FORMAT(bb.UPD_DT, '%Y-%m-%d %H:%i:%s') AS UPD_DT,
+            bb.UPD_ID,
+            bb.CREATENAME,
+            bb.RECOMMEND,
+            bb.ISSUE,
+            bb.OPEN_YN,
+            bb.PROF_ID,
+            (SELECT USER_NM FROM TB_MA_MEMBER WHERE USER_ID = bb.PROF_ID) AS PROF_NM
+        FROM TB_BOARD bb
+        INNER JOIN TB_BOARD_MNG cc ON bb.BOARD_MNG_SEQ = cc.BOARD_MNG_SEQ
+        WHERE 1=1
+        AND bb.BOARD_MNG_SEQ = #{boardMngSeq}
+        AND cc.BOARD_MNG_SEQ = #{boardMngSeq}
+        <choose>
+            <when test="searchOnoffDiv != null and searchOnoffDiv != ''">
+                AND cc.ONOFF_DIV = #{searchOnoffDiv}
+            </when>
+            <otherwise>
+                <if test='onoffDiv != null and onoffDiv == "T"'>
+                    AND cc.ONOFF_DIV = 'T'
+                </if>
+            </otherwise>
+        </choose>
+        <if test="searchText != null and searchText != ''">
+            <choose>
+                <when test='searchKind == "SEARCHSUBJECT"'>
+                    AND bb.SUBJECT LIKE CONCAT('%', #{searchText}, '%')
+                </when>
+                <when test='searchKind == "SEARCHNAME"'>
+                    AND bb.CREATENAME LIKE CONCAT('%', #{searchText}, '%')
+                </when>
+                <when test='searchKind == "SEARCHCONTENT"'>
+                    AND bb.CONTENT LIKE CONCAT('%', #{searchText}, '%')
+                </when>
+                <otherwise>
+                    AND (bb.SUBJECT LIKE CONCAT('%', #{searchText}, '%')
+                         OR bb.CREATENAME LIKE CONCAT('%', #{searchText}, '%')
+                         OR bb.CONTENT LIKE CONCAT('%', #{searchText}, '%'))
+                </otherwise>
+            </choose>
+        </if>
+        <if test="searchPrfId != null and searchPrfId != ''">
+            AND bb.PROF_ID = #{searchPrfId}
+        </if>
+        ORDER BY bb.NOTICE_TOP_YN DESC, bb.BOARD_SEQ DESC
+        LIMIT #{recordCountPerPage} OFFSET #{firstIndex}
+    </select>
+
+    <!-- 강사용 게시판 목록 건수 조회 -->
+    <select id="selectBoardTeacherListCount" parameterType="com.academy.board.service.BoardVO" resultType="int">
+        SELECT COUNT(*) AS CNT
+        FROM TB_BOARD bb
+        INNER JOIN TB_BOARD_MNG cc ON bb.BOARD_MNG_SEQ = cc.BOARD_MNG_SEQ
+        WHERE 1=1
+        AND bb.BOARD_MNG_SEQ = #{boardMngSeq}
+        AND cc.BOARD_MNG_SEQ = #{boardMngSeq}
+        <choose>
+            <when test="searchOnoffDiv != null and searchOnoffDiv != ''">
+                AND cc.ONOFF_DIV = #{searchOnoffDiv}
+            </when>
+            <otherwise>
+                <if test='onoffDiv != null and onoffDiv == "T"'>
+                    AND cc.ONOFF_DIV = 'T'
+                </if>
+            </otherwise>
+        </choose>
+        <if test="searchText != null and searchText != ''">
+            <choose>
+                <when test='searchKind == "SEARCHSUBJECT"'>
+                    AND bb.SUBJECT LIKE CONCAT('%', #{searchText}, '%')
+                </when>
+                <when test='searchKind == "SEARCHNAME"'>
+                    AND bb.CREATENAME LIKE CONCAT('%', #{searchText}, '%')
+                </when>
+                <when test='searchKind == "SEARCHCONTENT"'>
+                    AND bb.CONTENT LIKE CONCAT('%', #{searchText}, '%')
+                </when>
+                <otherwise>
+                    AND (bb.SUBJECT LIKE CONCAT('%', #{searchText}, '%')
+                         OR bb.CREATENAME LIKE CONCAT('%', #{searchText}, '%')
+                         OR bb.CONTENT LIKE CONCAT('%', #{searchText}, '%'))
+                </otherwise>
+            </choose>
+        </if>
+        <if test="searchPrfId != null and searchPrfId != ''">
+            AND bb.PROF_ID = #{searchPrfId}
+        </if>
+    </select>
+
+    <!-- 강사용 게시판 상세 조회 -->
+    <select id="getBoardTeacherDetail" parameterType="com.academy.board.service.BoardVO" resultType="org.json.simple.JSONObject">
+        SELECT
+            BOARD_MNG_SEQ,
+            BOARD_SEQ,
+            OPEN_YN,
+            SUBJECT,
+            CONTENT,
+            ANSWER,
+            FILE_PATH,
+            FILE_NAME,
+            REAL_FILE_NAME,
+            THUMBNAIL_FILE_NAME,
+            PARENT_BOARD_SEQ,
+            NOTICE_TOP_YN,
+            DATE_FORMAT(REG_DT, '%Y-%m-%d %H:%i:%s') AS REG_DT,
+            REG_ID,
+            UPD_DT,
+            UPD_ID,
+            HITS,
+            CREATENAME,
+            RECOMMEND,
+            ISSUE,
+            PROF_ID,
+            (SELECT USER_NM FROM TB_MA_MEMBER WHERE USER_ID = PROF_ID) AS PROF_NM
+        FROM TB_BOARD
+        WHERE BOARD_SEQ = #{boardSeq}
+    </select>
+
+    <!-- 강사용 게시판 등록 -->
+    <insert id="insertBoardTeacher" parameterType="com.academy.board.service.BoardVO">
+        <selectKey keyProperty="boardSeq" resultType="String" order="BEFORE">
+            SELECT IFNULL(MAX(CAST(BOARD_SEQ AS UNSIGNED)), 0) + 1 FROM TB_BOARD
+        </selectKey>
+        INSERT INTO TB_BOARD (
+            BOARD_MNG_SEQ,
+            BOARD_SEQ,
+            OPEN_YN,
+            SUBJECT,
+            CONTENT,
+            FILE_PATH,
+            FILE_NAME,
+            REAL_FILE_NAME,
+            THUMBNAIL_FILE_NAME,
+            PARENT_BOARD_SEQ,
+            NOTICE_TOP_YN,
+            REG_DT,
+            REG_ID,
+            UPD_DT,
+            UPD_ID,
+            HITS,
+            CREATENAME,
+            RECOMMEND,
+            ISSUE,
+            PROF_ID
+        ) VALUES (
+            #{boardMngSeq},
+            #{boardSeq},
+            #{openYn},
+            #{subject},
+            #{content},
+            #{filePath},
+            #{fileName},
+            #{realFileName},
+            #{thumbnailFileName},
+            0,
+            #{noticeTopYn},
+            now(),
+            #{regId},
+            now(),
+            #{regId},
+            0,
+            #{createName},
+            #{recommend},
+            #{issue},
+            #{profId}
+        )
+    </insert>
+
+    <!-- 강사용 게시판 수정 -->
+    <update id="updateBoardTeacher" parameterType="com.academy.board.service.BoardVO">
+        UPDATE TB_BOARD
+        SET
+            NOTICE_TOP_YN = #{noticeTopYn},
+            OPEN_YN = #{openYn},
+            SUBJECT = #{subject},
+            CONTENT = #{content},
+            <if test="thumbnailFileName != null and thumbnailFileName != ''">
+                THUMBNAIL_FILE_NAME = #{thumbnailFileName},
+            </if>
+            RECOMMEND = #{recommend},
+            ISSUE = #{issue},
+            PROF_ID = #{profId},
+            UPD_DT = now(),
+            UPD_ID = #{updId}
+        WHERE BOARD_SEQ = #{boardSeq}
+        AND BOARD_MNG_SEQ = #{boardMngSeq}
+    </update>
+
+    <!-- 이슈 여부 수정 -->
+    <update id="updateBoardIssue" parameterType="com.academy.board.service.BoardVO">
+        UPDATE TB_BOARD
+        SET
+            ISSUE = #{issue},
+            UPD_DT = now(),
+            UPD_ID = #{updId}
+        WHERE BOARD_SEQ = #{boardSeq}
+    </update>
+
+    <!-- 추천 여부 수정 -->
+    <update id="updateBoardRecommend" parameterType="com.academy.board.service.BoardVO">
+        UPDATE TB_BOARD
+        SET
+            RECOMMEND = #{recommend},
+            UPD_DT = now(),
+            UPD_ID = #{updId}
+        WHERE BOARD_SEQ = #{boardSeq}
+    </update>
+
+    <!-- 공개 여부 수정 -->
+    <update id="updateBoardOpenYn" parameterType="com.academy.board.service.BoardVO">
+        UPDATE TB_BOARD
+        SET
+            OPEN_YN = #{openYn},
+            UPD_DT = now(),
+            UPD_ID = #{updId}
+        WHERE BOARD_SEQ = #{boardSeq}
+    </update>
+
+    <!-- 메인 노출 여부 수정 -->
+    <update id="updateBoardMainYn" parameterType="com.academy.board.service.BoardVO">
+        UPDATE TB_BOARD
+        SET
+            MAIN_YN = #{mainYn},
+            UPD_DT = now(),
+            UPD_ID = #{updId}
+        WHERE BOARD_SEQ = #{boardSeq}
+    </update>
+
+</mapper>


### PR DESCRIPTION
Implemented the Board Management module, including the creation of `BoardCommentVO`, `BoardFileVO`, `BoardMngVO`, `BoardManagementMapper`, and `boardManagementSQL.xml` for managing boards, comments, and files. Added similar functionality for non-answered boards with `BoardNotAnswerMapper` and `boardNotAnswerSQL.xml`.