### PR TITLE
feat: add FreeOrder API module and MyBatis mapper implementation

### DIFF
--- a/src/main/java/com/academy/freeOrder/FreeOrderApi.java
+++ b/src/main/java/com/academy/freeOrder/FreeOrderApi.java
@@ -1,0 +1,485 @@
+package com.academy.freeOrder;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.TimeZone;
+
+import org.json.simple.JSONObject;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.academy.common.CORSFilter;
+import com.academy.common.PaginationInfo;
+import com.academy.freeOrder.service.FreeOrderService;
+import com.academy.freeOrder.service.FreeOrderVO;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * 무료 수강신청 관리 API Controller
+ * @author system
+ * @version 1.0
+ * @see
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *    수정일           수정자                수정내용
+ *  ---------------    --------------    ---------------------------
+ *  2025.12.11         system            무료 수강신청 관리 신규 생성
+ * </pre>
+ */
+@Tag(name = "FreeOrder", description = "무료 수강신청 관리 API")
+@RestController
+@RequestMapping("/api/freeOrder")
+public class FreeOrderApi extends CORSFilter {
+
+    @Value("${pageUnit:10}")
+    private int pageUnit;
+
+    private final FreeOrderService freeOrderService;
+
+    @Autowired
+    public FreeOrderApi(FreeOrderService freeOrderService) {
+        this.freeOrderService = freeOrderService;
+    }
+
+    // =====================================================
+    // 수강신청 관련 API
+    // =====================================================
+
+    /**
+     * 수강신청 회원 목록 조회
+     */
+    @Operation(summary = "수강신청 회원 목록 조회", description = "수강신청 가능한 회원 목록을 조회합니다.")
+    @GetMapping("/getMemberFreeOrderList")
+    public JSONObject getMemberFreeOrderList(@ModelAttribute FreeOrderVO freeOrderVO) {
+        HashMap<String, Object> resultMap = new HashMap<>();
+
+        try {
+            PaginationInfo paginationInfo = new PaginationInfo();
+            paginationInfo.setCurrentPageNo(freeOrderVO.getPageIndex());
+            paginationInfo.setRecordCountPerPage(freeOrderVO.getPageUnit() > 0 ? freeOrderVO.getPageUnit() : pageUnit);
+            paginationInfo.setPageSize(freeOrderVO.getPageSize());
+
+            freeOrderVO.setFirstIndex(paginationInfo.getFirstRecordIndex());
+            freeOrderVO.setLastIndex(paginationInfo.getLastRecordIndex());
+            freeOrderVO.setRecordCountPerPage(paginationInfo.getRecordCountPerPage());
+
+            List<JSONObject> list = freeOrderService.getMemberFreeOrderList(freeOrderVO);
+            int totalCount = freeOrderService.getMemberFreeOrderListCount(freeOrderVO);
+
+            paginationInfo.setTotalRecordCount(totalCount);
+
+            resultMap.put("list", list);
+            resultMap.put("totalCount", totalCount);
+            resultMap.put("totalPage", paginationInfo.getTotalPageCount());
+            resultMap.put("currentPage", freeOrderVO.getPageIndex());
+            resultMap.put("retMsg", "OK");
+        } catch (Exception e) {
+            resultMap.put("retMsg", "FAIL");
+            resultMap.put("errMsg", e.getMessage());
+        }
+
+        return new JSONObject(resultMap);
+    }
+
+    /**
+     * 강의 마스터 정보 조회 (수강신청 등록 팝업용)
+     */
+    @Operation(summary = "강의 마스터 정보 조회", description = "수강신청 등록을 위한 강의 마스터 정보를 조회합니다.")
+    @GetMapping("/getLectureMstInfo")
+    public JSONObject getLectureMstInfo(@ModelAttribute FreeOrderVO freeOrderVO) {
+        HashMap<String, Object> resultMap = new HashMap<>();
+
+        try {
+            JSONObject data = freeOrderService.getLectureMstInfo(freeOrderVO);
+            resultMap.put("data", data);
+            resultMap.put("retMsg", "OK");
+        } catch (Exception e) {
+            resultMap.put("retMsg", "FAIL");
+            resultMap.put("errMsg", e.getMessage());
+        }
+
+        return new JSONObject(resultMap);
+    }
+
+    // =====================================================
+    // 강의선택 팝업 관련 API
+    // =====================================================
+
+    /**
+     * 카테고리 목록 조회
+     */
+    @Operation(summary = "카테고리 목록 조회", description = "강의선택 팝업용 카테고리 목록을 조회합니다.")
+    @GetMapping("/getCategoryList")
+    public JSONObject getCategoryList(@ModelAttribute FreeOrderVO freeOrderVO) {
+        HashMap<String, Object> resultMap = new HashMap<>();
+
+        try {
+            List<JSONObject> list = freeOrderService.getCategoryList(freeOrderVO);
+            resultMap.put("list", list);
+            resultMap.put("retMsg", "OK");
+        } catch (Exception e) {
+            resultMap.put("retMsg", "FAIL");
+            resultMap.put("errMsg", e.getMessage());
+        }
+
+        return new JSONObject(resultMap);
+    }
+
+    /**
+     * 학습형태 목록 조회
+     */
+    @Operation(summary = "학습형태 목록 조회", description = "강의선택 팝업용 학습형태 목록을 조회합니다.")
+    @GetMapping("/getLearningFormList")
+    public JSONObject getLearningFormList(@ModelAttribute FreeOrderVO freeOrderVO) {
+        HashMap<String, Object> resultMap = new HashMap<>();
+
+        try {
+            List<JSONObject> list = freeOrderService.getLearningFormList(freeOrderVO);
+            resultMap.put("list", list);
+            resultMap.put("retMsg", "OK");
+        } catch (Exception e) {
+            resultMap.put("retMsg", "FAIL");
+            resultMap.put("errMsg", e.getMessage());
+        }
+
+        return new JSONObject(resultMap);
+    }
+
+    /**
+     * 과목 목록 조회
+     */
+    @Operation(summary = "과목 목록 조회", description = "강의선택 팝업용 과목 목록을 조회합니다.")
+    @GetMapping("/getSubjectList")
+    public JSONObject getSubjectList(@ModelAttribute FreeOrderVO freeOrderVO) {
+        HashMap<String, Object> resultMap = new HashMap<>();
+
+        try {
+            List<JSONObject> list = freeOrderService.getSubjectList(freeOrderVO);
+            resultMap.put("list", list);
+            resultMap.put("retMsg", "OK");
+        } catch (Exception e) {
+            resultMap.put("retMsg", "FAIL");
+            resultMap.put("errMsg", e.getMessage());
+        }
+
+        return new JSONObject(resultMap);
+    }
+
+    /**
+     * 강의선택 팝업 목록 조회
+     */
+    @Operation(summary = "강의선택 팝업 목록 조회", description = "수강신청용 강의 목록을 조회합니다.")
+    @GetMapping("/getLectureListForFreeOrder")
+    public JSONObject getLectureListForFreeOrder(@ModelAttribute FreeOrderVO freeOrderVO) {
+        HashMap<String, Object> resultMap = new HashMap<>();
+
+        try {
+            PaginationInfo paginationInfo = new PaginationInfo();
+            paginationInfo.setCurrentPageNo(freeOrderVO.getPageIndex());
+            paginationInfo.setRecordCountPerPage(freeOrderVO.getPageUnit() > 0 ? freeOrderVO.getPageUnit() : pageUnit);
+            paginationInfo.setPageSize(freeOrderVO.getPageSize());
+
+            freeOrderVO.setFirstIndex(paginationInfo.getFirstRecordIndex());
+            freeOrderVO.setLastIndex(paginationInfo.getLastRecordIndex());
+            freeOrderVO.setRecordCountPerPage(paginationInfo.getRecordCountPerPage());
+
+            List<JSONObject> list = freeOrderService.getLectureListForFreeOrder(freeOrderVO);
+            int totalCount = freeOrderService.getLectureListForFreeOrderCount(freeOrderVO);
+
+            paginationInfo.setTotalRecordCount(totalCount);
+
+            resultMap.put("list", list);
+            resultMap.put("totalCount", totalCount);
+            resultMap.put("totalPage", paginationInfo.getTotalPageCount());
+            resultMap.put("currentPage", freeOrderVO.getPageIndex());
+            resultMap.put("retMsg", "OK");
+        } catch (Exception e) {
+            resultMap.put("retMsg", "FAIL");
+            resultMap.put("errMsg", e.getMessage());
+        }
+
+        return new JSONObject(resultMap);
+    }
+
+    // =====================================================
+    // 수강신청 등록 관련 API
+    // =====================================================
+
+    /**
+     * 수강신청 등록
+     */
+    @Operation(summary = "수강신청 등록", description = "무료 수강신청을 등록합니다.")
+    @PostMapping("/insertFreeOrder")
+    public JSONObject insertFreeOrder(@ModelAttribute FreeOrderVO freeOrderVO, HttpServletRequest request) {
+        HashMap<String, Object> resultMap = new HashMap<>();
+
+        try {
+            // 세션에서 관리자 ID 조회
+            @SuppressWarnings("unchecked")
+            HashMap<String, String> sessionMap = (HashMap<String, String>) request.getSession().getAttribute("AdmUserInfo");
+            String adminUserId = sessionMap != null ? sessionMap.get("USER_ID") : "";
+
+            if (adminUserId == null || adminUserId.isEmpty()) {
+                resultMap.put("retMsg", "FAIL");
+                resultMap.put("errMsg", "관리자 로그인이 필요합니다.");
+                return new JSONObject(resultMap);
+            }
+
+            // 사용자 ID 처리 (쉼표를 슬래시로 변환)
+            String userid2 = freeOrderVO.getUserid2();
+            if (userid2 != null && !userid2.isEmpty()) {
+                userid2 = userid2.replace(',', '/');
+            }
+
+            String[] userIds = userid2 != null ? userid2.split("/") : new String[0];
+
+            // 현재 날짜
+            TimeZone tz = TimeZone.getTimeZone("Asia/Seoul");
+            SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd");
+            sdf.setTimeZone(tz);
+            String today = sdf.format(new Date());
+
+            String userIp = request.getRemoteAddr();
+            String leccode = freeOrderVO.getLeccode();
+
+            for (String userId : userIds) {
+                userId = userId.trim();
+                if (userId.isEmpty()) continue;
+
+                freeOrderVO.setUserid(userId);
+
+                // 사용자 존재여부 확인
+                JSONObject memberInfo = freeOrderService.getMemberExists(freeOrderVO);
+                if (memberInfo == null) continue;
+
+                // 주문번호 채번
+                freeOrderVO.setOrdernoCount("M");
+                String orderno = freeOrderService.getNextOrderNo(freeOrderVO);
+                freeOrderVO.setOrderno(orderno);
+                freeOrderVO.setMgntno(leccode);
+                freeOrderVO.setUserId(adminUserId);
+                freeOrderVO.setUserIp(userIp);
+
+                // 강의 타입에 따라 등록 처리
+                if (leccode != null && leccode.length() > 0) {
+                    String lecType = leccode.substring(0, 1);
+
+                    if ("D".equals(lecType)) {
+                        // 단과 수강신청
+                        freeOrderService.insertFreeOrder(freeOrderVO);
+                    } else if ("J".equals(lecType) || "N".equals(lecType) || "P".equals(lecType)) {
+                        // 종합반 수강신청
+                        freeOrderService.insertFreeOrderPackage(freeOrderVO);
+                    } else {
+                        // 연회원패키지 등록
+                        freeOrderService.insertFreeOrderYearPackage(freeOrderVO);
+                    }
+                }
+            }
+
+            resultMap.put("retMsg", "OK");
+            resultMap.put("message", "등록완료");
+        } catch (Exception e) {
+            resultMap.put("retMsg", "FAIL");
+            resultMap.put("errMsg", e.getMessage());
+        }
+
+        return new JSONObject(resultMap);
+    }
+
+    /**
+     * 다중 수강신청 등록
+     */
+    @Operation(summary = "다중 수강신청 등록", description = "여러 강좌에 대한 무료 수강신청을 등록합니다.")
+    @PostMapping("/insertFreeOrderMultiple")
+    public JSONObject insertFreeOrderMultiple(@ModelAttribute FreeOrderVO freeOrderVO, HttpServletRequest request) {
+        HashMap<String, Object> resultMap = new HashMap<>();
+
+        try {
+            // 세션에서 관리자 ID 조회
+            @SuppressWarnings("unchecked")
+            HashMap<String, String> sessionMap = (HashMap<String, String>) request.getSession().getAttribute("AdmUserInfo");
+            String adminUserId = sessionMap != null ? sessionMap.get("USER_ID") : "";
+
+            if (adminUserId == null || adminUserId.isEmpty()) {
+                resultMap.put("retMsg", "FAIL");
+                resultMap.put("errMsg", "관리자 로그인이 필요합니다.");
+                return new JSONObject(resultMap);
+            }
+
+            // 사용자 ID 및 강의코드 처리
+            String userid2 = freeOrderVO.getUserid2();
+            if (userid2 != null && !userid2.isEmpty()) {
+                userid2 = userid2.replace(',', '/');
+            }
+
+            String leccode = freeOrderVO.getLeccode();
+            if (leccode != null && leccode.endsWith("/")) {
+                leccode = leccode.substring(0, leccode.length() - 1);
+            }
+
+            String[] userIds = userid2 != null ? userid2.split("/") : new String[0];
+            String[] leccodes = leccode != null ? leccode.split("/") : new String[0];
+
+            String userIp = request.getRemoteAddr();
+
+            for (String userId : userIds) {
+                userId = userId.trim();
+                if (userId.isEmpty()) continue;
+
+                freeOrderVO.setUserid(userId);
+
+                // 사용자 존재여부 확인
+                JSONObject memberInfo = freeOrderService.getMemberExists(freeOrderVO);
+                if (memberInfo == null) continue;
+
+                for (String lec : leccodes) {
+                    lec = lec.trim();
+                    if (lec.isEmpty()) continue;
+
+                    // 주문번호 채번
+                    freeOrderVO.setOrdernoCount("M");
+                    String orderno = freeOrderService.getNextOrderNo(freeOrderVO);
+                    freeOrderVO.setOrderno(orderno);
+                    freeOrderVO.setLeccode(lec);
+                    freeOrderVO.setMgntno(lec);
+                    freeOrderVO.setUserId(adminUserId);
+                    freeOrderVO.setUserIp(userIp);
+
+                    // 강의 타입에 따라 등록 처리
+                    String lecType = lec.substring(0, 1);
+
+                    if ("D".equals(lecType)) {
+                        freeOrderService.insertFreeOrder(freeOrderVO);
+                    } else {
+                        freeOrderService.insertFreeOrderPackage(freeOrderVO);
+                    }
+                }
+            }
+
+            resultMap.put("retMsg", "OK");
+            resultMap.put("message", "등록완료");
+        } catch (Exception e) {
+            resultMap.put("retMsg", "FAIL");
+            resultMap.put("errMsg", e.getMessage());
+        }
+
+        return new JSONObject(resultMap);
+    }
+
+    // =====================================================
+    // 수강변경 관련 API
+    // =====================================================
+
+    /**
+     * 수강변경 목록 조회
+     */
+    @Operation(summary = "수강변경 목록 조회", description = "수강변경 목록을 조회합니다.")
+    @GetMapping("/getChangeLectureList")
+    public JSONObject getChangeLectureList(@ModelAttribute FreeOrderVO freeOrderVO) {
+        HashMap<String, Object> resultMap = new HashMap<>();
+
+        try {
+            PaginationInfo paginationInfo = new PaginationInfo();
+            paginationInfo.setCurrentPageNo(freeOrderVO.getPageIndex());
+            paginationInfo.setRecordCountPerPage(freeOrderVO.getPageUnit() > 0 ? freeOrderVO.getPageUnit() : pageUnit);
+            paginationInfo.setPageSize(freeOrderVO.getPageSize());
+
+            freeOrderVO.setFirstIndex(paginationInfo.getFirstRecordIndex());
+            freeOrderVO.setLastIndex(paginationInfo.getLastRecordIndex());
+            freeOrderVO.setRecordCountPerPage(paginationInfo.getRecordCountPerPage());
+
+            List<JSONObject> list = freeOrderService.getChangeLectureList(freeOrderVO);
+            int totalCount = freeOrderService.getChangeLectureListCount(freeOrderVO);
+
+            paginationInfo.setTotalRecordCount(totalCount);
+
+            resultMap.put("list", list);
+            resultMap.put("totalCount", totalCount);
+            resultMap.put("totalPage", paginationInfo.getTotalPageCount());
+            resultMap.put("currentPage", freeOrderVO.getPageIndex());
+            resultMap.put("retMsg", "OK");
+        } catch (Exception e) {
+            resultMap.put("retMsg", "FAIL");
+            resultMap.put("errMsg", e.getMessage());
+        }
+
+        return new JSONObject(resultMap);
+    }
+
+    /**
+     * 수강변경 상세 조회
+     */
+    @Operation(summary = "수강변경 상세 조회", description = "수강변경 상세 정보를 조회합니다.")
+    @GetMapping("/getChangeViewDetail")
+    public JSONObject getChangeViewDetail(@ModelAttribute FreeOrderVO freeOrderVO) {
+        HashMap<String, Object> resultMap = new HashMap<>();
+
+        try {
+            // 결제승인 상세
+            JSONObject approvalsDetail = freeOrderService.getApprovalsDetail(freeOrderVO);
+            resultMap.put("payInfo", approvalsDetail);
+
+            // 배송정보 조회
+            int deliversCount = freeOrderService.getDeliversCount(freeOrderVO);
+            if (deliversCount > 0) {
+                JSONObject deliversDetail = freeOrderService.getDeliversDetail(freeOrderVO);
+                resultMap.put("delInfo", deliversDetail);
+            }
+
+            // 주문자 정보
+            JSONObject orderInfo = freeOrderService.getChangeViewOrderInfo(freeOrderVO);
+            resultMap.put("orderInfo", orderInfo);
+
+            // 강의/도서 목록
+            List<JSONObject> lecList = freeOrderService.getChangeViewList(freeOrderVO);
+            resultMap.put("lecList", lecList);
+
+            resultMap.put("retMsg", "OK");
+        } catch (Exception e) {
+            resultMap.put("retMsg", "FAIL");
+            resultMap.put("errMsg", e.getMessage());
+        }
+
+        return new JSONObject(resultMap);
+    }
+
+    /**
+     * 수강변경 처리
+     */
+    @Operation(summary = "수강변경 처리", description = "수강을 변경합니다.")
+    @PostMapping("/updateChangeLecture")
+    public JSONObject updateChangeLecture(@ModelAttribute FreeOrderVO freeOrderVO, HttpServletRequest request) {
+        HashMap<String, Object> resultMap = new HashMap<>();
+
+        try {
+            // 세션에서 관리자 ID 조회
+            @SuppressWarnings("unchecked")
+            HashMap<String, String> sessionMap = (HashMap<String, String>) request.getSession().getAttribute("AdmUserInfo");
+            String adminUserId = sessionMap != null ? sessionMap.get("USER_ID") : "";
+
+            freeOrderVO.setUserId(adminUserId);
+
+            freeOrderService.updateChangeLecture(freeOrderVO);
+
+            resultMap.put("retMsg", "OK");
+            resultMap.put("message", "변경완료");
+        } catch (Exception e) {
+            resultMap.put("retMsg", "FAIL");
+            resultMap.put("errMsg", e.getMessage());
+        }
+
+        return new JSONObject(resultMap);
+    }
+}

--- a/src/main/java/com/academy/freeOrder/README.md
+++ b/src/main/java/com/academy/freeOrder/README.md
@@ -1,0 +1,217 @@
+# 무료 수강신청 관리 패키지
+
+무료 수강신청 관리 기능을 제공하는 패키지입니다.
+
+## 패키지 구조
+
+```
+freeOrder/
+├── FreeOrderApi.java               # REST Controller
+├── README.md
+└── service/
+    ├── FreeOrderService.java       # 서비스 클래스
+    └── FreeOrderVO.java            # Value Object
+```
+
+## 기능 설명
+
+관리자가 회원에게 무료 수강신청을 등록하거나 수강변경을 처리하는 기능을 제공합니다.
+
+### 주요 기능
+
+#### 수강신청 관리
+- 수강신청 가능 회원 목록 조회
+- 강의 마스터 정보 조회
+- 수강신청 등록 (단과/종합반/연회원패키지)
+- 다중 수강신청 등록
+
+#### 강의선택 팝업
+- 카테고리 목록 조회
+- 학습형태 목록 조회
+- 과목 목록 조회
+- 강의 목록 조회 (검색 조건 지원)
+
+#### 수강변경 관리
+- 수강변경 목록 조회
+- 수강변경 상세 조회
+- 수강변경 처리 (취소 + 신규등록)
+
+## API 엔드포인트
+
+### 수강신청
+| HTTP | URL | 설명 |
+|------|-----|------|
+| GET | `/api/freeOrder/getMemberFreeOrderList` | 수강신청 회원 목록 조회 |
+| GET | `/api/freeOrder/getLectureMstInfo` | 강의 마스터 정보 조회 |
+| POST | `/api/freeOrder/insertFreeOrder` | 수강신청 등록 |
+| POST | `/api/freeOrder/insertFreeOrderMultiple` | 다중 수강신청 등록 |
+
+### 강의선택 팝업
+| HTTP | URL | 설명 |
+|------|-----|------|
+| GET | `/api/freeOrder/getCategoryList` | 카테고리 목록 조회 |
+| GET | `/api/freeOrder/getLearningFormList` | 학습형태 목록 조회 |
+| GET | `/api/freeOrder/getSubjectList` | 과목 목록 조회 |
+| GET | `/api/freeOrder/getLectureListForFreeOrder` | 강의 목록 조회 |
+
+### 수강변경
+| HTTP | URL | 설명 |
+|------|-----|------|
+| GET | `/api/freeOrder/getChangeLectureList` | 수강변경 목록 조회 |
+| GET | `/api/freeOrder/getChangeViewDetail` | 수강변경 상세 조회 |
+| POST | `/api/freeOrder/updateChangeLecture` | 수강변경 처리 |
+
+## 관련 테이블
+
+### 주문 관련
+| 테이블명 | 설명 |
+|---------|------|
+| TB_ORDERS | 주문 마스터 테이블 |
+| TB_ORDER_MGNT_NO | 주문 관리번호 테이블 |
+| TB_APPROVALS | 결제승인 테이블 |
+| TB_MYLECTURE | 수강신청 테이블 |
+| TB_ORDER_YEARPACKAGE | 연회원패키지 주문 테이블 |
+| TB_RENEW_HISTORY | 수강변경 이력 테이블 |
+| TB_DELIVERS | 배송정보 테이블 |
+
+### 강의 관련
+| 테이블명 | 설명 |
+|---------|------|
+| TB_LEC_MST | 강의 마스터 테이블 |
+| TB_LEC_JONG | 종합반 강좌 목록 테이블 |
+| TB_LEC_BRIDGE | 강의 브릿지 테이블 |
+| TB_CATEGORY_INFO | 카테고리 정보 테이블 |
+| TB_LEARNING_FORM_INFO | 학습형태 정보 테이블 |
+| TB_SUBJECT_INFO | 과목 정보 테이블 |
+| TB_MA_MEMBER | 회원 테이블 |
+| TB_CA_BOOK | 도서 테이블 |
+
+### TB_ORDER_MGNT_NO 테이블 주요 컬럼
+
+| 컬럼명 | 타입 | 설명 |
+|--------|------|------|
+| ORDERNO | VARCHAR | 주문번호 |
+| MGNTNO | VARCHAR | 관리번호 (강의코드) |
+| CNT | INT | 수량 |
+| ISCANCEL | VARCHAR | 취소여부 |
+| PRICE | INT | 가격 |
+| STATUSCODE | VARCHAR | 상태코드 |
+| CONFIRMDATE | DATETIME | 확인일시 |
+| SDATE | VARCHAR | 시작일 |
+| WMV_PMP | VARCHAR | WMV/PMP 구분 |
+| OPEN_ADMIN_ID | VARCHAR | 등록 관리자 ID |
+| PTYPE | VARCHAR | 상품타입 (D:단과, J:종합반 등) |
+| MEMO | TEXT | 메모 |
+
+### TB_MYLECTURE 테이블 주요 컬럼
+
+| 컬럼명 | 타입 | 설명 |
+|--------|------|------|
+| ORDERNO | VARCHAR | 주문번호 |
+| USERID | VARCHAR | 사용자 ID |
+| PACKAGE_NO | VARCHAR | 패키지번호 |
+| LECTURE_NO | VARCHAR | 강의번호 |
+| START_DATE | DATE | 시작일 |
+| END_DATE | DATE | 종료일 |
+| PERIOD | INT | 수강기간 |
+| STUDY_PERCENT | INT | 학습진도율 |
+| PLAYYN | VARCHAR | 재생여부 |
+| REG_DT | DATETIME | 등록일시 |
+
+## 강의 타입 구분
+
+| 코드 | 설명 |
+|------|------|
+| D | 단과 강의 |
+| J | 종합반 |
+| N | N종합반 |
+| P | P패키지 |
+| Y | 연회원패키지 |
+
+## 주문 상태 코드
+
+| 코드 | 설명 |
+|------|------|
+| DLV100 | 입금확인중 |
+| DLV105 | 입금완료 |
+| DLV110 | 배송준비중 |
+| DLV120 | 배송중 |
+| DLV130 | 배송완료 |
+| DLV140 | 취소요청 |
+| DLV150 | 취소완료 |
+| DLV160 | 교환요청 |
+| DLV170 | 교환배송중 |
+| DLV180 | 교환완료 |
+| DLV220 | 환불요청 |
+| DLV230 | 환불완료 |
+| DLV240 | 결제에러 |
+
+## 검색 조건
+
+### 회원 목록
+| 파라미터 | 타입 | 설명 |
+|---------|------|------|
+| keyword | String | 회원명/아이디 검색 |
+
+### 강의 목록
+| 파라미터 | 타입 | 설명 |
+|---------|------|------|
+| sCatCd | String | 카테고리 코드 |
+| sMenuId | String | 학습형태 코드 |
+| sSjtCd | String | 과목 코드 |
+| searchType | String | 검색 타입 (1:강사명, 2:강의코드, 3:강의제목) |
+| searchKeyword | String | 검색어 |
+
+### 수강변경 목록
+| 파라미터 | 타입 | 설명 |
+|---------|------|------|
+| keyword | String | 회원명/아이디 검색 |
+
+## 사용 예시
+
+### 수강신청 회원 목록 조회
+```
+GET /api/freeOrder/getMemberFreeOrderList?pageIndex=1&keyword=홍길동
+```
+
+### 강의 목록 조회
+```
+GET /api/freeOrder/getLectureListForFreeOrder?pageIndex=1&sCatCd=GOSI&searchType=3&searchKeyword=행정법
+```
+
+### 수강신청 등록
+```
+POST /api/freeOrder/insertFreeOrder
+Content-Type: application/x-www-form-urlencoded
+
+userid2=user001,user002&leccode=D202400001&startDate=20240115&subjectPeriod=30&statuscode=DLV105&subjectPrice=0
+```
+
+### 다중 수강신청 등록
+```
+POST /api/freeOrder/insertFreeOrderMultiple
+Content-Type: application/x-www-form-urlencoded
+
+userid2=user001&leccode=D202400001/D202400002/D202400003/&startDate=20240115&subjectPeriod=30&statuscode=DLV105
+```
+
+### 수강변경 처리
+```
+POST /api/freeOrder/updateChangeLecture
+Content-Type: application/x-www-form-urlencoded
+
+orderno=M20240115000001&userid=user001&leccode2=D202400001&leccode=D202400002&startDate=20240115&subjectPeriod=30&statuscode=DLV105
+```
+
+## 관련 Mapper
+
+- **FreeOrderMapper.java**: `com.academy.mapper.FreeOrderMapper`
+- **freeOrder.xml**: `src/main/resources/mapper/freeOrder.xml`
+
+---
+
+## Copyright
+
+<img src="../../../../../../../../UM_CI.png" alt="UM Systems" width="10%">
+
+**Copyright (c) 2021 운몽시스템즈(UM Systems). All rights reserved.**

--- a/src/main/java/com/academy/freeOrder/service/FreeOrderService.java
+++ b/src/main/java/com/academy/freeOrder/service/FreeOrderService.java
@@ -1,0 +1,262 @@
+package com.academy.freeOrder.service;
+
+import java.io.Serializable;
+import java.util.List;
+
+import org.json.simple.JSONObject;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.academy.mapper.FreeOrderMapper;
+
+/**
+ * 무료 수강신청 관리 서비스 클래스
+ * @author system
+ * @version 1.0
+ * @see
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *    수정일           수정자                수정내용
+ *  ---------------    --------------    ---------------------------
+ *  2025.12.11         system            무료 수강신청 관리 신규 생성
+ * </pre>
+ */
+@Service
+public class FreeOrderService implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final FreeOrderMapper freeOrderMapper;
+
+    @Autowired
+    public FreeOrderService(FreeOrderMapper freeOrderMapper) {
+        this.freeOrderMapper = freeOrderMapper;
+    }
+
+    // =====================================================
+    // 수강신청 관련
+    // =====================================================
+
+    /**
+     * 수강신청 회원 목록 조회
+     */
+    public List<JSONObject> getMemberFreeOrderList(FreeOrderVO freeOrderVO) {
+        return freeOrderMapper.selectMemberFreeOrderList(freeOrderVO);
+    }
+
+    /**
+     * 수강신청 회원 목록 건수 조회
+     */
+    public int getMemberFreeOrderListCount(FreeOrderVO freeOrderVO) {
+        return freeOrderMapper.selectMemberFreeOrderListCount(freeOrderVO);
+    }
+
+    /**
+     * 강의 마스터 정보 조회 (수강신청 등록 팝업용)
+     */
+    public JSONObject getLectureMstInfo(FreeOrderVO freeOrderVO) {
+        return freeOrderMapper.selectLectureMstInfo(freeOrderVO);
+    }
+
+    /**
+     * 강의 마스터 정보 조회 (수강변경 팝업용 - 이전 강의)
+     */
+    public JSONObject getLectureMstInfoPrev(FreeOrderVO freeOrderVO) {
+        return freeOrderMapper.selectLectureMstInfoPrev(freeOrderVO);
+    }
+
+    // =====================================================
+    // 강의선택 팝업 관련
+    // =====================================================
+
+    /**
+     * 카테고리 목록 조회
+     */
+    public List<JSONObject> getCategoryList(FreeOrderVO freeOrderVO) {
+        return freeOrderMapper.selectCategoryList(freeOrderVO);
+    }
+
+    /**
+     * 학습형태 목록 조회
+     */
+    public List<JSONObject> getLearningFormList(FreeOrderVO freeOrderVO) {
+        return freeOrderMapper.selectLearningFormList(freeOrderVO);
+    }
+
+    /**
+     * 과목 목록 조회
+     */
+    public List<JSONObject> getSubjectList(FreeOrderVO freeOrderVO) {
+        return freeOrderMapper.selectSubjectList(freeOrderVO);
+    }
+
+    /**
+     * 강의선택 팝업 목록 조회
+     */
+    public List<JSONObject> getLectureListForFreeOrder(FreeOrderVO freeOrderVO) {
+        return freeOrderMapper.selectLectureListForFreeOrder(freeOrderVO);
+    }
+
+    /**
+     * 강의선택 팝업 목록 건수 조회
+     */
+    public int getLectureListForFreeOrderCount(FreeOrderVO freeOrderVO) {
+        return freeOrderMapper.selectLectureListForFreeOrderCount(freeOrderVO);
+    }
+
+    // =====================================================
+    // 수강신청 등록 관련
+    // =====================================================
+
+    /**
+     * 주문번호 채번
+     */
+    public String getNextOrderNo(FreeOrderVO freeOrderVO) {
+        return freeOrderMapper.selectNextOrderNo(freeOrderVO);
+    }
+
+    /**
+     * 사용자 존재여부 확인
+     */
+    public JSONObject getMemberExists(FreeOrderVO freeOrderVO) {
+        return freeOrderMapper.selectMemberExists(freeOrderVO);
+    }
+
+    /**
+     * 수강신청 등록 처리 (단과)
+     */
+    @Transactional
+    public void insertFreeOrder(FreeOrderVO freeOrderVO) {
+        // 1. 주문관리번호 등록
+        freeOrderMapper.insertOrderMgntNo(freeOrderVO);
+        // 2. 주문 등록
+        freeOrderMapper.insertOrders(freeOrderVO);
+        // 3. 결제승인 등록
+        freeOrderMapper.insertApprovals(freeOrderVO);
+        // 4. 수강신청 등록
+        freeOrderMapper.insertMyLecture(freeOrderVO);
+    }
+
+    /**
+     * 수강신청 등록 처리 (종합반)
+     */
+    @Transactional
+    public void insertFreeOrderPackage(FreeOrderVO freeOrderVO) {
+        // 1. 주문관리번호 등록
+        freeOrderMapper.insertOrderMgntNo(freeOrderVO);
+        // 2. 주문 등록
+        freeOrderMapper.insertOrders(freeOrderVO);
+        // 3. 결제승인 등록
+        freeOrderMapper.insertApprovals(freeOrderVO);
+        // 4. 종합반 강좌 목록 조회 후 각 강좌별 수강신청 등록
+        List<JSONObject> lectureList = freeOrderMapper.selectPackageLectureList(freeOrderVO);
+        if (lectureList != null && !lectureList.isEmpty()) {
+            for (JSONObject lecture : lectureList) {
+                FreeOrderVO lectureVO = new FreeOrderVO();
+                lectureVO.setOrderno(freeOrderVO.getOrderno());
+                lectureVO.setUserid(freeOrderVO.getUserid());
+                lectureVO.setMgntno(freeOrderVO.getMgntno());
+                lectureVO.setLeccode((String) lecture.get("MST_LECCODE"));
+                lectureVO.setStartDate(freeOrderVO.getStartDate());
+                lectureVO.setSubjectPeriod(freeOrderVO.getSubjectPeriod());
+                freeOrderMapper.insertMyLecture(lectureVO);
+            }
+        }
+    }
+
+    /**
+     * 연회원패키지 등록 처리
+     */
+    @Transactional
+    public void insertFreeOrderYearPackage(FreeOrderVO freeOrderVO) {
+        // 1. 주문관리번호 등록
+        freeOrderMapper.insertOrderMgntNo(freeOrderVO);
+        // 2. 주문 등록
+        freeOrderMapper.insertOrders(freeOrderVO);
+        // 3. 결제승인 등록
+        freeOrderMapper.insertApprovals(freeOrderVO);
+        // 4. 연회원패키지 등록
+        freeOrderMapper.insertOrderYearPackage(freeOrderVO);
+    }
+
+    /**
+     * 종합반 강좌 목록 조회
+     */
+    public List<JSONObject> getPackageLectureList(FreeOrderVO freeOrderVO) {
+        return freeOrderMapper.selectPackageLectureList(freeOrderVO);
+    }
+
+    // =====================================================
+    // 수강변경 관련
+    // =====================================================
+
+    /**
+     * 수강변경 목록 조회
+     */
+    public List<JSONObject> getChangeLectureList(FreeOrderVO freeOrderVO) {
+        return freeOrderMapper.selectChangeLectureList(freeOrderVO);
+    }
+
+    /**
+     * 수강변경 목록 건수 조회
+     */
+    public int getChangeLectureListCount(FreeOrderVO freeOrderVO) {
+        return freeOrderMapper.selectChangeLectureListCount(freeOrderVO);
+    }
+
+    /**
+     * 수강변경 상세 목록 조회 (강의/도서 정보)
+     */
+    public List<JSONObject> getChangeViewList(FreeOrderVO freeOrderVO) {
+        return freeOrderMapper.selectChangeViewList(freeOrderVO);
+    }
+
+    /**
+     * 수강변경 상세 목록 조회 (주문자 정보)
+     */
+    public JSONObject getChangeViewOrderInfo(FreeOrderVO freeOrderVO) {
+        return freeOrderMapper.selectChangeViewOrderInfo(freeOrderVO);
+    }
+
+    /**
+     * 수강변경 처리
+     */
+    @Transactional
+    public void updateChangeLecture(FreeOrderVO freeOrderVO) {
+        // 1. 기존 주문 취소 처리
+        freeOrderMapper.updateOrderCancel(freeOrderVO);
+        // 2. 새 주문관리번호 등록
+        freeOrderMapper.insertOrderMgntNo(freeOrderVO);
+        // 3. 수강변경 이력 등록
+        freeOrderMapper.insertRenewHistory(freeOrderVO);
+        // 4. 새 수강신청 등록
+        freeOrderMapper.insertMyLecture(freeOrderVO);
+    }
+
+    // =====================================================
+    // 주문 상세 관련
+    // =====================================================
+
+    /**
+     * 결제승인 상세 조회
+     */
+    public JSONObject getApprovalsDetail(FreeOrderVO freeOrderVO) {
+        return freeOrderMapper.selectApprovalsDetail(freeOrderVO);
+    }
+
+    /**
+     * 배송정보 건수 조회
+     */
+    public int getDeliversCount(FreeOrderVO freeOrderVO) {
+        return freeOrderMapper.selectDeliversCount(freeOrderVO);
+    }
+
+    /**
+     * 배송정보 상세 조회
+     */
+    public JSONObject getDeliversDetail(FreeOrderVO freeOrderVO) {
+        return freeOrderMapper.selectDeliversDetail(freeOrderVO);
+    }
+}

--- a/src/main/java/com/academy/freeOrder/service/FreeOrderVO.java
+++ b/src/main/java/com/academy/freeOrder/service/FreeOrderVO.java
@@ -1,0 +1,642 @@
+package com.academy.freeOrder.service;
+
+import java.io.Serializable;
+
+import com.academy.common.CommonVO;
+
+/**
+ * 무료 수강신청 VO 클래스
+ * @author system
+ * @version 1.0
+ * @see
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *    수정일           수정자                수정내용
+ *  ---------------    --------------    ---------------------------
+ *  2025.12.11         system            무료 수강신청 관리 신규 생성
+ * </pre>
+ */
+public class FreeOrderVO extends CommonVO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    // =====================================================
+    // 수강신청 기본 정보
+    // =====================================================
+
+    /** 주문번호 */
+    private String orderno;
+
+    /** 사용자 ID */
+    private String userid;
+
+    /** 사용자 ID (복수) */
+    private String userid2;
+
+    /** 사용자명 */
+    private String userNm;
+
+    /** 생년월일 */
+    private String birthDay;
+
+    /** 전화번호 */
+    private String telNo;
+
+    /** 휴대폰 */
+    private String phoneNo;
+
+    /** 이메일 */
+    private String email;
+
+    /** 우편번호 */
+    private String zipCode;
+
+    /** 주소1 */
+    private String address1;
+
+    /** 주소2 */
+    private String address2;
+
+    // =====================================================
+    // 강의 정보
+    // =====================================================
+
+    /** 강의코드 */
+    private String leccode;
+
+    /** 강의코드 (이전) */
+    private String leccode2;
+
+    /** 패키지번호 */
+    private String packageNo;
+
+    /** 관리번호 */
+    private String mgntno;
+
+    /** 강의제목 */
+    private String subjectTitle;
+
+    /** 강의가격 */
+    private String subjectPrice;
+
+    /** 수강기간 */
+    private String subjectPeriod;
+
+    /** 할인율 */
+    private String subjectDiscount;
+
+    /** 강의수 */
+    private String subjectMovie;
+
+    /** 시작일 */
+    private String startDate;
+
+    /** 종료일 */
+    private String endDate;
+
+    /** 상태코드 */
+    private String statuscode;
+
+    /** WMV 체크 */
+    private String wmvCheck;
+
+    /** 메모 */
+    private String memo;
+
+    /** 강의타입 선택 */
+    private String lecTypeChoice;
+
+    // =====================================================
+    // 카테고리/학습형태/과목 정보
+    // =====================================================
+
+    /** 카테고리 코드 */
+    private String catCd;
+
+    /** 카테고리명 */
+    private String catNm;
+
+    /** 학습형태 코드 */
+    private String menuId;
+
+    /** 학습형태명 */
+    private String menuNm;
+
+    /** 과목 코드 */
+    private String subjectSjtCd;
+
+    /** 과목명 */
+    private String subjectNm;
+
+    /** 강사 ID */
+    private String subjectTeacher;
+
+    // =====================================================
+    // 검색 조건
+    // =====================================================
+
+    /** 검색 키워드 */
+    private String keyword;
+
+    /** 검색 카테고리 */
+    private String sCatCd;
+
+    /** 검색 과목 코드 */
+    private String sSjtCd;
+
+    /** 검색 학습형태 */
+    private String sMenuId;
+
+    /** 검색 타입 */
+    private String searchType;
+
+    /** 검색 키워드 */
+    private String searchKeyword;
+
+    /** 명령 */
+    private String cmd;
+
+    /** 명령 카운트 */
+    private String cmdcnt;
+
+    // =====================================================
+    // 결제 정보
+    // =====================================================
+
+    /** 가격 */
+    private String price;
+
+    /** 추가가격 */
+    private String addPrice;
+
+    /** 결제코드 */
+    private String payCode;
+
+    /** 결제코드명 */
+    private String payCodeName;
+
+    /** 계좌번호 코드명 */
+    private String acctNoName;
+
+    /** 가상계좌은행 */
+    private String vcdBank;
+
+    /** 결제자명 */
+    private String payName;
+
+    /** 포인트 */
+    private String point;
+
+    /** 가상계좌번호 */
+    private String vacct;
+
+    /** TID */
+    private String tid;
+
+    // =====================================================
+    // 관리자 정보
+    // =====================================================
+
+    /** 관리자 ID */
+    private String userId;
+
+    /** 사용자 IP */
+    private String userIp;
+
+    /** 채번 카운트 타입 */
+    private String ordernoCount;
+
+    // Getters and Setters
+    public String getOrderno() {
+        return orderno;
+    }
+
+    public void setOrderno(String orderno) {
+        this.orderno = orderno;
+    }
+
+    public String getUserid() {
+        return userid;
+    }
+
+    public void setUserid(String userid) {
+        this.userid = userid;
+    }
+
+    public String getUserid2() {
+        return userid2;
+    }
+
+    public void setUserid2(String userid2) {
+        this.userid2 = userid2;
+    }
+
+    public String getUserNm() {
+        return userNm;
+    }
+
+    public void setUserNm(String userNm) {
+        this.userNm = userNm;
+    }
+
+    public String getBirthDay() {
+        return birthDay;
+    }
+
+    public void setBirthDay(String birthDay) {
+        this.birthDay = birthDay;
+    }
+
+    public String getTelNo() {
+        return telNo;
+    }
+
+    public void setTelNo(String telNo) {
+        this.telNo = telNo;
+    }
+
+    public String getPhoneNo() {
+        return phoneNo;
+    }
+
+    public void setPhoneNo(String phoneNo) {
+        this.phoneNo = phoneNo;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getZipCode() {
+        return zipCode;
+    }
+
+    public void setZipCode(String zipCode) {
+        this.zipCode = zipCode;
+    }
+
+    public String getAddress1() {
+        return address1;
+    }
+
+    public void setAddress1(String address1) {
+        this.address1 = address1;
+    }
+
+    public String getAddress2() {
+        return address2;
+    }
+
+    public void setAddress2(String address2) {
+        this.address2 = address2;
+    }
+
+    public String getLeccode() {
+        return leccode;
+    }
+
+    public void setLeccode(String leccode) {
+        this.leccode = leccode;
+    }
+
+    public String getLeccode2() {
+        return leccode2;
+    }
+
+    public void setLeccode2(String leccode2) {
+        this.leccode2 = leccode2;
+    }
+
+    public String getPackageNo() {
+        return packageNo;
+    }
+
+    public void setPackageNo(String packageNo) {
+        this.packageNo = packageNo;
+    }
+
+    public String getMgntno() {
+        return mgntno;
+    }
+
+    public void setMgntno(String mgntno) {
+        this.mgntno = mgntno;
+    }
+
+    public String getSubjectTitle() {
+        return subjectTitle;
+    }
+
+    public void setSubjectTitle(String subjectTitle) {
+        this.subjectTitle = subjectTitle;
+    }
+
+    public String getSubjectPrice() {
+        return subjectPrice;
+    }
+
+    public void setSubjectPrice(String subjectPrice) {
+        this.subjectPrice = subjectPrice;
+    }
+
+    public String getSubjectPeriod() {
+        return subjectPeriod;
+    }
+
+    public void setSubjectPeriod(String subjectPeriod) {
+        this.subjectPeriod = subjectPeriod;
+    }
+
+    public String getSubjectDiscount() {
+        return subjectDiscount;
+    }
+
+    public void setSubjectDiscount(String subjectDiscount) {
+        this.subjectDiscount = subjectDiscount;
+    }
+
+    public String getSubjectMovie() {
+        return subjectMovie;
+    }
+
+    public void setSubjectMovie(String subjectMovie) {
+        this.subjectMovie = subjectMovie;
+    }
+
+    public String getStartDate() {
+        return startDate;
+    }
+
+    public void setStartDate(String startDate) {
+        this.startDate = startDate;
+    }
+
+    public String getEndDate() {
+        return endDate;
+    }
+
+    public void setEndDate(String endDate) {
+        this.endDate = endDate;
+    }
+
+    public String getStatuscode() {
+        return statuscode;
+    }
+
+    public void setStatuscode(String statuscode) {
+        this.statuscode = statuscode;
+    }
+
+    public String getWmvCheck() {
+        return wmvCheck;
+    }
+
+    public void setWmvCheck(String wmvCheck) {
+        this.wmvCheck = wmvCheck;
+    }
+
+    public String getMemo() {
+        return memo;
+    }
+
+    public void setMemo(String memo) {
+        this.memo = memo;
+    }
+
+    public String getLecTypeChoice() {
+        return lecTypeChoice;
+    }
+
+    public void setLecTypeChoice(String lecTypeChoice) {
+        this.lecTypeChoice = lecTypeChoice;
+    }
+
+    public String getCatCd() {
+        return catCd;
+    }
+
+    public void setCatCd(String catCd) {
+        this.catCd = catCd;
+    }
+
+    public String getCatNm() {
+        return catNm;
+    }
+
+    public void setCatNm(String catNm) {
+        this.catNm = catNm;
+    }
+
+    public String getMenuId() {
+        return menuId;
+    }
+
+    public void setMenuId(String menuId) {
+        this.menuId = menuId;
+    }
+
+    public String getMenuNm() {
+        return menuNm;
+    }
+
+    public void setMenuNm(String menuNm) {
+        this.menuNm = menuNm;
+    }
+
+    public String getSubjectSjtCd() {
+        return subjectSjtCd;
+    }
+
+    public void setSubjectSjtCd(String subjectSjtCd) {
+        this.subjectSjtCd = subjectSjtCd;
+    }
+
+    public String getSubjectNm() {
+        return subjectNm;
+    }
+
+    public void setSubjectNm(String subjectNm) {
+        this.subjectNm = subjectNm;
+    }
+
+    public String getSubjectTeacher() {
+        return subjectTeacher;
+    }
+
+    public void setSubjectTeacher(String subjectTeacher) {
+        this.subjectTeacher = subjectTeacher;
+    }
+
+    public String getKeyword() {
+        return keyword;
+    }
+
+    public void setKeyword(String keyword) {
+        this.keyword = keyword;
+    }
+
+    public String getsCatCd() {
+        return sCatCd;
+    }
+
+    public void setsCatCd(String sCatCd) {
+        this.sCatCd = sCatCd;
+    }
+
+    public String getsSjtCd() {
+        return sSjtCd;
+    }
+
+    public void setsSjtCd(String sSjtCd) {
+        this.sSjtCd = sSjtCd;
+    }
+
+    public String getsMenuId() {
+        return sMenuId;
+    }
+
+    public void setsMenuId(String sMenuId) {
+        this.sMenuId = sMenuId;
+    }
+
+    public String getSearchType() {
+        return searchType;
+    }
+
+    public void setSearchType(String searchType) {
+        this.searchType = searchType;
+    }
+
+    public String getSearchKeyword() {
+        return searchKeyword;
+    }
+
+    public void setSearchKeyword(String searchKeyword) {
+        this.searchKeyword = searchKeyword;
+    }
+
+    public String getCmd() {
+        return cmd;
+    }
+
+    public void setCmd(String cmd) {
+        this.cmd = cmd;
+    }
+
+    public String getCmdcnt() {
+        return cmdcnt;
+    }
+
+    public void setCmdcnt(String cmdcnt) {
+        this.cmdcnt = cmdcnt;
+    }
+
+    public String getPrice() {
+        return price;
+    }
+
+    public void setPrice(String price) {
+        this.price = price;
+    }
+
+    public String getAddPrice() {
+        return addPrice;
+    }
+
+    public void setAddPrice(String addPrice) {
+        this.addPrice = addPrice;
+    }
+
+    public String getPayCode() {
+        return payCode;
+    }
+
+    public void setPayCode(String payCode) {
+        this.payCode = payCode;
+    }
+
+    public String getPayCodeName() {
+        return payCodeName;
+    }
+
+    public void setPayCodeName(String payCodeName) {
+        this.payCodeName = payCodeName;
+    }
+
+    public String getAcctNoName() {
+        return acctNoName;
+    }
+
+    public void setAcctNoName(String acctNoName) {
+        this.acctNoName = acctNoName;
+    }
+
+    public String getVcdBank() {
+        return vcdBank;
+    }
+
+    public void setVcdBank(String vcdBank) {
+        this.vcdBank = vcdBank;
+    }
+
+    public String getPayName() {
+        return payName;
+    }
+
+    public void setPayName(String payName) {
+        this.payName = payName;
+    }
+
+    public String getPoint() {
+        return point;
+    }
+
+    public void setPoint(String point) {
+        this.point = point;
+    }
+
+    public String getVacct() {
+        return vacct;
+    }
+
+    public void setVacct(String vacct) {
+        this.vacct = vacct;
+    }
+
+    public String getTid() {
+        return tid;
+    }
+
+    public void setTid(String tid) {
+        this.tid = tid;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getUserIp() {
+        return userIp;
+    }
+
+    public void setUserIp(String userIp) {
+        this.userIp = userIp;
+    }
+
+    public String getOrdernoCount() {
+        return ordernoCount;
+    }
+
+    public void setOrdernoCount(String ordernoCount) {
+        this.ordernoCount = ordernoCount;
+    }
+}

--- a/src/main/java/com/academy/mapper/FreeOrderMapper.java
+++ b/src/main/java/com/academy/mapper/FreeOrderMapper.java
@@ -1,0 +1,222 @@
+package com.academy.mapper;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.json.simple.JSONObject;
+
+import com.academy.freeOrder.service.FreeOrderVO;
+
+/**
+ * 무료 수강신청 관리에 관한 데이터 접근 클래스를 정의한다.
+ * @author system
+ * @since 2025.12.11
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일          수정자           수정내용
+ *  ----------------    --------    ---------------------------
+ *   2025.12.11         system          신규 생성
+ * </pre>
+ */
+@Mapper
+public interface FreeOrderMapper {
+
+    // =====================================================
+    // 수강신청 관련
+    // =====================================================
+
+    /**
+     * 수강신청 회원 목록 조회
+     * @param freeOrderVO 검색조건
+     * @return List 수강신청 회원 목록
+     */
+    List<JSONObject> selectMemberFreeOrderList(FreeOrderVO freeOrderVO);
+
+    /**
+     * 수강신청 회원 목록 건수 조회
+     * @param freeOrderVO 검색조건
+     * @return int 수강신청 회원 목록 건수
+     */
+    int selectMemberFreeOrderListCount(FreeOrderVO freeOrderVO);
+
+    /**
+     * 강의 마스터 정보 조회 (수강신청 등록 팝업용)
+     * @param freeOrderVO 검색조건
+     * @return JSONObject 강의 마스터 정보
+     */
+    JSONObject selectLectureMstInfo(FreeOrderVO freeOrderVO);
+
+    /**
+     * 강의 마스터 정보 조회 (수강변경 팝업용 - 이전 강의)
+     * @param freeOrderVO 검색조건
+     * @return JSONObject 강의 마스터 정보
+     */
+    JSONObject selectLectureMstInfoPrev(FreeOrderVO freeOrderVO);
+
+    // =====================================================
+    // 강의선택 팝업 관련
+    // =====================================================
+
+    /**
+     * 카테고리 목록 조회
+     * @param freeOrderVO 검색조건
+     * @return List 카테고리 목록
+     */
+    List<JSONObject> selectCategoryList(FreeOrderVO freeOrderVO);
+
+    /**
+     * 학습형태 목록 조회
+     * @param freeOrderVO 검색조건
+     * @return List 학습형태 목록
+     */
+    List<JSONObject> selectLearningFormList(FreeOrderVO freeOrderVO);
+
+    /**
+     * 과목 목록 조회
+     * @param freeOrderVO 검색조건
+     * @return List 과목 목록
+     */
+    List<JSONObject> selectSubjectList(FreeOrderVO freeOrderVO);
+
+    /**
+     * 강의선택 팝업 목록 조회
+     * @param freeOrderVO 검색조건
+     * @return List 강의 목록
+     */
+    List<JSONObject> selectLectureListForFreeOrder(FreeOrderVO freeOrderVO);
+
+    /**
+     * 강의선택 팝업 목록 건수 조회
+     * @param freeOrderVO 검색조건
+     * @return int 강의 목록 건수
+     */
+    int selectLectureListForFreeOrderCount(FreeOrderVO freeOrderVO);
+
+    // =====================================================
+    // 수강신청 등록 관련
+    // =====================================================
+
+    /**
+     * 주문번호 채번
+     * @param freeOrderVO 채번 조건
+     * @return String 주문번호
+     */
+    String selectNextOrderNo(FreeOrderVO freeOrderVO);
+
+    /**
+     * 사용자 존재여부 확인
+     * @param freeOrderVO 검색조건
+     * @return JSONObject 사용자 정보
+     */
+    JSONObject selectMemberExists(FreeOrderVO freeOrderVO);
+
+    /**
+     * 주문관리번호 등록 (tb_order_mgnt_no)
+     * @param freeOrderVO 주문 정보
+     */
+    void insertOrderMgntNo(FreeOrderVO freeOrderVO);
+
+    /**
+     * 주문 등록 (tb_orders)
+     * @param freeOrderVO 주문 정보
+     */
+    void insertOrders(FreeOrderVO freeOrderVO);
+
+    /**
+     * 결제승인 등록 (tb_approvals)
+     * @param freeOrderVO 결제 정보
+     */
+    void insertApprovals(FreeOrderVO freeOrderVO);
+
+    /**
+     * 수강신청 등록 (TB_MYLECTURE)
+     * @param freeOrderVO 수강신청 정보
+     */
+    void insertMyLecture(FreeOrderVO freeOrderVO);
+
+    /**
+     * 연회원패키지 등록 (TB_ORDER_YEARPACKAGE)
+     * @param freeOrderVO 수강신청 정보
+     */
+    void insertOrderYearPackage(FreeOrderVO freeOrderVO);
+
+    /**
+     * 종합반 강좌 목록 조회
+     * @param freeOrderVO 검색조건
+     * @return List 강좌 목록
+     */
+    List<JSONObject> selectPackageLectureList(FreeOrderVO freeOrderVO);
+
+    // =====================================================
+    // 수강변경 관련
+    // =====================================================
+
+    /**
+     * 수강변경 목록 조회
+     * @param freeOrderVO 검색조건
+     * @return List 수강변경 목록
+     */
+    List<JSONObject> selectChangeLectureList(FreeOrderVO freeOrderVO);
+
+    /**
+     * 수강변경 목록 건수 조회
+     * @param freeOrderVO 검색조건
+     * @return int 수강변경 목록 건수
+     */
+    int selectChangeLectureListCount(FreeOrderVO freeOrderVO);
+
+    /**
+     * 수강변경 상세 목록 조회 (강의/도서 정보)
+     * @param freeOrderVO 검색조건
+     * @return List 수강변경 상세 목록
+     */
+    List<JSONObject> selectChangeViewList(FreeOrderVO freeOrderVO);
+
+    /**
+     * 수강변경 상세 목록 조회 (주문자 정보)
+     * @param freeOrderVO 검색조건
+     * @return JSONObject 수강변경 상세 정보
+     */
+    JSONObject selectChangeViewOrderInfo(FreeOrderVO freeOrderVO);
+
+    /**
+     * 주문 취소 처리 (수강변경 시)
+     * @param freeOrderVO 주문 정보
+     */
+    void updateOrderCancel(FreeOrderVO freeOrderVO);
+
+    /**
+     * 수강변경 이력 등록 (TB_RENEW_HISTORY)
+     * @param freeOrderVO 변경 이력 정보
+     */
+    void insertRenewHistory(FreeOrderVO freeOrderVO);
+
+    // =====================================================
+    // 주문 상세 관련
+    // =====================================================
+
+    /**
+     * 결제승인 상세 조회
+     * @param freeOrderVO 검색조건
+     * @return JSONObject 결제승인 상세 정보
+     */
+    JSONObject selectApprovalsDetail(FreeOrderVO freeOrderVO);
+
+    /**
+     * 배송정보 건수 조회
+     * @param freeOrderVO 검색조건
+     * @return int 배송정보 건수
+     */
+    int selectDeliversCount(FreeOrderVO freeOrderVO);
+
+    /**
+     * 배송정보 상세 조회
+     * @param freeOrderVO 검색조건
+     * @return JSONObject 배송정보 상세
+     */
+    JSONObject selectDeliversDetail(FreeOrderVO freeOrderVO);
+}

--- a/src/main/resources/mapper/freeOrder.xml
+++ b/src/main/resources/mapper/freeOrder.xml
@@ -1,0 +1,691 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.academy.mapper.FreeOrderMapper">
+
+    <!-- =====================================================
+         수강신청 관련
+         ===================================================== -->
+
+    <!-- 수강신청 회원 목록 조회 -->
+    <select id="selectMemberFreeOrderList" parameterType="com.academy.freeOrder.service.FreeOrderVO" resultType="org.json.simple.JSONObject">
+        SELECT
+            USER_ID,
+            USER_NM,
+            BIRTH_DAY,
+            PHONE_NO,
+            TEL_NO,
+            EMAIL
+        FROM TB_MA_MEMBER
+        WHERE USER_ROLE = 'USER'
+        <if test="keyword != null and keyword != ''">
+            AND (USER_NM LIKE CONCAT('%', #{keyword}, '%') OR USER_ID LIKE CONCAT('%', #{keyword}, '%'))
+        </if>
+        ORDER BY REG_DT DESC
+        LIMIT #{recordCountPerPage} OFFSET #{firstIndex}
+    </select>
+
+    <!-- 수강신청 회원 목록 건수 조회 -->
+    <select id="selectMemberFreeOrderListCount" parameterType="com.academy.freeOrder.service.FreeOrderVO" resultType="int">
+        SELECT COUNT(*)
+        FROM TB_MA_MEMBER
+        WHERE USER_ROLE = 'USER'
+        <if test="keyword != null and keyword != ''">
+            AND (USER_NM LIKE CONCAT('%', #{keyword}, '%') OR USER_ID LIKE CONCAT('%', #{keyword}, '%'))
+        </if>
+    </select>
+
+    <!-- 강의 마스터 정보 조회 (수강신청 등록 팝업용) -->
+    <select id="selectLectureMstInfo" parameterType="com.academy.freeOrder.service.FreeOrderVO" resultType="org.json.simple.JSONObject">
+        SELECT
+            a.SUBJECT_JANG,
+            a.SUBJECT_PASS,
+            a.SEQ,
+            a.LECCODE,
+            a.CATEGORY_CD AS CAT_CD,
+            b.NAME AS CAT_NM,
+            a.LEARNING_CD AS MENU_ID,
+            c.NAME AS MENU_NM,
+            a.SUBJECT_TEACHER,
+            d.USER_NM,
+            a.SUBJECT_TITLE,
+            a.SUBJECT_DESC,
+            a.SUBJECT_MEMO,
+            a.SUBJECT_KEYWORD,
+            a.SUBJECT_PERIOD,
+            a.SUBJECT_OFF_OPEN_YEAR,
+            a.SUBJECT_OFF_OPEN_MONTH,
+            a.SUBJECT_DISCOUNT,
+            a.SUBJECT_POINT,
+            a.SUBJECT_MOVIE,
+            a.SUBJECT_PMP,
+            a.SUBJECT_MOVIE_PMP,
+            a.SUBJECT_SUMNAIL,
+            a.SUBJECT_EVENT_IMAGE,
+            a.SUBJECT_OUTSIDE,
+            a.SUBJECT_OPTION,
+            a.SUBJECT_ISUSE,
+            a.UPD_ID AS UPDATE_ID,
+            a.REG_DT,
+            a.UPD_DT AS UPDATE_DT,
+            a.SUBJECT_SJT_CD,
+            a.LEC_TYPE_CHOICE,
+            a.SUBJECT_OFF_OPEN_DAY,
+            a.SUBJECT_VOD_DEFAULT_PATH,
+            a.SUBJECT_WIDE_DEFAULT_PATH,
+            a.SUBJECT_PMP_DEFAULT_PATH,
+            a.SUBJECT_PRICE,
+            a.SUBJECT_MP4_DEFAULT_PATH,
+            IFNULL(a.RE_COURSE, 'N') AS RE_COURSE,
+            a.SUBJECT_MOVIE_MP4,
+            a.SUBJECT_MOVIE_VOD_MP4,
+            a.LEC_SCHEDULE,
+            DATE_FORMAT(NOW(), '%Y%m%d') AS TO_DATE
+        FROM TB_LEC_MST a
+        LEFT OUTER JOIN TB_CATEGORY_INFO b ON a.CATEGORY_CD = b.CODE
+        LEFT OUTER JOIN TB_LEARNING_FORM_INFO c ON a.LEARNING_CD = c.CODE AND c.LEC_DIV = 'LEC_A'
+        LEFT OUTER JOIN TB_MA_MEMBER d ON a.SUBJECT_TEACHER = d.USER_ID
+        WHERE a.LECCODE = #{leccode}
+    </select>
+
+    <!-- 강의 마스터 정보 조회 (수강변경 팝업용 - 이전 강의) -->
+    <select id="selectLectureMstInfoPrev" parameterType="com.academy.freeOrder.service.FreeOrderVO" resultType="org.json.simple.JSONObject">
+        SELECT
+            a.SUBJECT_JANG,
+            a.SUBJECT_PASS,
+            a.SEQ,
+            a.LECCODE,
+            a.CATEGORY_CD AS CAT_CD,
+            b.NAME AS CAT_NM,
+            a.LEARNING_CD AS MENU_ID,
+            c.NAME AS MENU_NM,
+            a.SUBJECT_TEACHER,
+            d.USER_NM,
+            a.SUBJECT_TITLE,
+            a.SUBJECT_DESC,
+            a.SUBJECT_MEMO,
+            a.SUBJECT_KEYWORD,
+            a.SUBJECT_PERIOD,
+            a.SUBJECT_OFF_OPEN_YEAR,
+            a.SUBJECT_OFF_OPEN_MONTH,
+            a.SUBJECT_DISCOUNT,
+            a.SUBJECT_POINT,
+            a.SUBJECT_MOVIE,
+            a.SUBJECT_PMP,
+            a.SUBJECT_MOVIE_PMP,
+            a.SUBJECT_SUMNAIL,
+            a.SUBJECT_EVENT_IMAGE,
+            a.SUBJECT_OUTSIDE,
+            a.SUBJECT_OPTION,
+            a.SUBJECT_ISUSE,
+            a.UPD_ID AS UPDATE_ID,
+            a.REG_DT,
+            a.UPD_DT AS UPDATE_DT,
+            a.SUBJECT_SJT_CD,
+            a.LEC_TYPE_CHOICE,
+            a.SUBJECT_OFF_OPEN_DAY,
+            a.SUBJECT_VOD_DEFAULT_PATH,
+            a.SUBJECT_PMP_DEFAULT_PATH,
+            a.SUBJECT_PRICE,
+            a.SUBJECT_MP4_DEFAULT_PATH,
+            IFNULL(a.RE_COURSE, 'N') AS RE_COURSE,
+            a.SUBJECT_MOVIE_MP4,
+            a.SUBJECT_MOVIE_VOD_MP4,
+            a.LEC_SCHEDULE,
+            DATE_FORMAT(NOW(), '%Y%m%d') AS TO_DATE
+        FROM TB_LEC_MST a
+        LEFT OUTER JOIN TB_CATEGORY_INFO b ON a.CATEGORY_CD = b.CODE
+        LEFT OUTER JOIN TB_LEARNING_FORM_INFO c ON a.LEARNING_CD = c.CODE AND c.LEC_DIV = 'LEC_A'
+        LEFT OUTER JOIN TB_MA_MEMBER d ON a.SUBJECT_TEACHER = d.USER_ID
+        WHERE a.LECCODE = #{packageNo}
+    </select>
+
+    <!-- =====================================================
+         강의선택 팝업 관련
+         ===================================================== -->
+
+    <!-- 카테고리 목록 조회 -->
+    <select id="selectCategoryList" parameterType="com.academy.freeOrder.service.FreeOrderVO" resultType="org.json.simple.JSONObject">
+        SELECT
+            CODE,
+            NAME
+        FROM TB_CATEGORY_INFO
+        WHERE ISUSE = 'Y'
+        AND CODE IS NOT NULL
+        AND CODE != 'HOME'
+        AND CODE != '999'
+        AND P_CODE = 'CLASSCODE'
+        ORDER BY CODE ASC
+    </select>
+
+    <!-- 학습형태 목록 조회 -->
+    <select id="selectLearningFormList" parameterType="com.academy.freeOrder.service.FreeOrderVO" resultType="org.json.simple.JSONObject">
+        SELECT
+            CODE,
+            CONCAT(
+                (SELECT CODE_NM FROM TB_BA_CONFIG_CD WHERE SYS_CD = 'LEC_FORM' AND CODE_CD = A.LEC_DIV AND ISUSE = 'Y'),
+                '-',
+                NAME
+            ) AS NAME
+        FROM TB_LEARNING_FORM_INFO A
+        WHERE ISUSE = 'Y'
+        ORDER BY CODE
+    </select>
+
+    <!-- 과목 목록 조회 -->
+    <select id="selectSubjectList" parameterType="com.academy.freeOrder.service.FreeOrderVO" resultType="org.json.simple.JSONObject">
+        SELECT
+            SUBJECT_CD,
+            SUBJECT_NM
+        FROM TB_SUBJECT_INFO
+        WHERE ISUSE = 'Y'
+        ORDER BY SUBJECT_CD
+    </select>
+
+    <!-- 강의선택 팝업 목록 조회 -->
+    <select id="selectLectureListForFreeOrder" parameterType="com.academy.freeOrder.service.FreeOrderVO" resultType="org.json.simple.JSONObject">
+        SELECT
+            a.SEQ,
+            a.LECCODE,
+            a.CATEGORY_CD,
+            b.NAME AS CAT_NM,
+            a.LEARNING_CD AS MENU_ID,
+            c.NAME AS MENU_NM,
+            a.SUBJECT_TITLE,
+            a.SUBJECT_OFF_OPEN_MONTH,
+            a.SUBJECT_OFF_OPEN_YEAR,
+            a.REG_DT,
+            d.USER_NM,
+            a.SUBJECT_ISUSE,
+            e.SUBJECT_NM,
+            f.BRIDGE_LECCODE,
+            a.SUBJECT_DISCOUNT,
+            a.SUBJECT_PRICE,
+            a.SUBJECT_MOVIE,
+            a.SUBJECT_PERIOD
+        FROM TB_LEC_MST a
+        LEFT OUTER JOIN TB_CATEGORY_INFO b ON a.CATEGORY_CD = b.CODE
+        LEFT OUTER JOIN TB_LEARNING_FORM_INFO c ON a.LEARNING_CD = c.CODE
+        LEFT OUTER JOIN TB_MA_MEMBER d ON a.SUBJECT_TEACHER = d.USER_ID
+        LEFT OUTER JOIN TB_SUBJECT_INFO e ON a.SUBJECT_SJT_CD = e.SUBJECT_CD
+        LEFT OUTER JOIN TB_LEC_BRIDGE f ON a.LECCODE = f.LECCODE
+        WHERE a.LEC_TYPE_CHOICE IN ('D', 'J', 'N', 'P', 'Y')
+        <if test="sCatCd != null and sCatCd != ''">
+            AND a.CATEGORY_CD = #{sCatCd}
+        </if>
+        <if test="sMenuId != null and sMenuId != ''">
+            AND a.LEARNING_CD = #{sMenuId}
+        </if>
+        <if test="sSjtCd != null and sSjtCd != ''">
+            AND a.SUBJECT_SJT_CD = #{sSjtCd}
+        </if>
+        <if test="searchKeyword != null and searchKeyword != ''">
+            <choose>
+                <when test="searchType == '1'">
+                    AND d.USER_NM LIKE CONCAT('%', #{searchKeyword}, '%')
+                </when>
+                <when test="searchType == '2'">
+                    AND a.LECCODE LIKE CONCAT('%', #{searchKeyword}, '%')
+                </when>
+                <when test="searchType == '3'">
+                    AND a.SUBJECT_TITLE LIKE CONCAT('%', #{searchKeyword}, '%')
+                </when>
+            </choose>
+        </if>
+        ORDER BY a.LEC_TYPE_CHOICE ASC, a.SUBJECT_SJT_CD ASC, a.SEQ DESC,
+                 CONCAT(a.SUBJECT_OFF_OPEN_YEAR, a.SUBJECT_OFF_OPEN_MONTH, a.SUBJECT_OFF_OPEN_DAY) DESC
+        LIMIT #{recordCountPerPage} OFFSET #{firstIndex}
+    </select>
+
+    <!-- 강의선택 팝업 목록 건수 조회 -->
+    <select id="selectLectureListForFreeOrderCount" parameterType="com.academy.freeOrder.service.FreeOrderVO" resultType="int">
+        SELECT COUNT(*)
+        FROM TB_LEC_MST a
+        LEFT OUTER JOIN TB_CATEGORY_INFO b ON a.CATEGORY_CD = b.CODE
+        LEFT OUTER JOIN TB_LEARNING_FORM_INFO c ON a.LEARNING_CD = c.CODE AND c.LEC_DIV = 'LEC_A'
+        LEFT OUTER JOIN TB_MA_MEMBER d ON a.SUBJECT_TEACHER = d.USER_ID
+        LEFT OUTER JOIN TB_SUBJECT_INFO e ON a.SUBJECT_SJT_CD = e.SUBJECT_CD
+        LEFT OUTER JOIN TB_LEC_BRIDGE f ON a.LECCODE = f.LECCODE
+        WHERE a.LEC_TYPE_CHOICE IN ('D', 'J', 'N', 'P', 'Y')
+        <if test="sCatCd != null and sCatCd != ''">
+            AND a.CATEGORY_CD = #{sCatCd}
+        </if>
+        <if test="sMenuId != null and sMenuId != ''">
+            AND a.LEARNING_CD = #{sMenuId}
+        </if>
+        <if test="sSjtCd != null and sSjtCd != ''">
+            AND a.SUBJECT_SJT_CD = #{sSjtCd}
+        </if>
+        <if test="searchKeyword != null and searchKeyword != ''">
+            <choose>
+                <when test="searchType == '1'">
+                    AND d.USER_NM LIKE CONCAT('%', #{searchKeyword}, '%')
+                </when>
+                <when test="searchType == '2'">
+                    AND a.LECCODE LIKE CONCAT('%', #{searchKeyword}, '%')
+                </when>
+                <when test="searchType == '3'">
+                    AND a.SUBJECT_TITLE LIKE CONCAT('%', #{searchKeyword}, '%')
+                </when>
+            </choose>
+        </if>
+    </select>
+
+    <!-- =====================================================
+         수강신청 등록 관련
+         ===================================================== -->
+
+    <!-- 주문번호 채번 (MySQL 함수 또는 시퀀스 대체) -->
+    <select id="selectNextOrderNo" parameterType="com.academy.freeOrder.service.FreeOrderVO" resultType="String">
+        SELECT CONCAT(#{ordernoCount}, DATE_FORMAT(NOW(), '%Y%m%d'),
+               LPAD(IFNULL(
+                   (SELECT MAX(CAST(SUBSTRING(ORDERNO, 10) AS UNSIGNED)) + 1
+                    FROM TB_ORDERS
+                    WHERE ORDERNO LIKE CONCAT(#{ordernoCount}, DATE_FORMAT(NOW(), '%Y%m%d'), '%')),
+                   1), 5, '0')
+        ) AS ORDERNO_COUNT
+    </select>
+
+    <!-- 사용자 존재여부 확인 -->
+    <select id="selectMemberExists" parameterType="com.academy.freeOrder.service.FreeOrderVO" resultType="org.json.simple.JSONObject">
+        SELECT USER_ID, USER_NM
+        FROM TB_MA_MEMBER
+        WHERE USER_ID = #{userid}
+    </select>
+
+    <!-- 주문관리번호 등록 (tb_order_mgnt_no) -->
+    <insert id="insertOrderMgntNo" parameterType="com.academy.freeOrder.service.FreeOrderVO">
+        INSERT INTO TB_ORDER_MGNT_NO (
+            ORDERNO,
+            MGNTNO,
+            CNT,
+            ISCANCEL,
+            PRICE,
+            STATUSCODE,
+            CONFIRMDATE,
+            SDATE,
+            ISCONFIRM,
+            WMV_PMP,
+            ORDERURL,
+            OPEN_ADMIN_ID,
+            PTYPE,
+            MEMO
+        ) VALUES (
+            #{orderno},
+            #{leccode},
+            1,
+            0,
+            #{subjectPrice},
+            #{statuscode},
+            NOW(),
+            #{startDate},
+            NOW(),
+            #{wmvCheck},
+            #{userIp},
+            #{userId},
+            SUBSTRING(#{leccode}, 1, 1),
+            #{memo}
+        )
+    </insert>
+
+    <!-- 주문 등록 (tb_orders) -->
+    <insert id="insertOrders" parameterType="com.academy.freeOrder.service.FreeOrderVO">
+        INSERT INTO TB_ORDERS (
+            ORDERNO,
+            USER_ID,
+            USER_NM,
+            TEL_NO,
+            PHONE_NO,
+            ZIP_CODE,
+            ADDRESS1,
+            ADDRESS2,
+            EMAIL,
+            REG_DT,
+            OFF_LINE
+        )
+        SELECT
+            #{orderno},
+            #{userid},
+            USER_NM,
+            TEL_NO,
+            PHONE_NO,
+            ZIP_CODE,
+            ADDRESS1,
+            ADDRESS2,
+            EMAIL,
+            NOW(),
+            '0'
+        FROM TB_MA_MEMBER
+        WHERE USER_ID = #{userid}
+    </insert>
+
+    <!-- 결제승인 등록 (tb_approvals) -->
+    <insert id="insertApprovals" parameterType="com.academy.freeOrder.service.FreeOrderVO">
+        INSERT INTO TB_APPROVALS (
+            ORDERNO,
+            PRICE,
+            ADDPRICE,
+            PAYCODE,
+            ACCTNOCODE,
+            PAYNAME,
+            POINT,
+            REG_DT
+        )
+        SELECT
+            #{orderno},
+            #{subjectPrice},
+            0,
+            'PAY100',
+            'ACT110',
+            USER_NM,
+            0,
+            NOW()
+        FROM TB_MA_MEMBER
+        WHERE USER_ID = #{userid}
+    </insert>
+
+    <!-- 수강신청 등록 (TB_MYLECTURE) -->
+    <insert id="insertMyLecture" parameterType="com.academy.freeOrder.service.FreeOrderVO">
+        INSERT INTO TB_MYLECTURE (
+            ORDERNO,
+            USERID,
+            PACKAGE_NO,
+            LECTURE_NO,
+            START_DATE,
+            END_DATE,
+            PERIOD,
+            STUDY_PERCENT,
+            PLAYYN,
+            REG_DT
+        ) VALUES (
+            #{orderno},
+            #{userid},
+            #{mgntno},
+            #{leccode},
+            STR_TO_DATE(#{startDate}, '%Y%m%d'),
+            DATE_ADD(STR_TO_DATE(#{startDate}, '%Y%m%d'), INTERVAL #{subjectPeriod} - 1 DAY),
+            #{subjectPeriod},
+            0,
+            'Y',
+            NOW()
+        )
+    </insert>
+
+    <!-- 연회원패키지 등록 (TB_ORDER_YEARPACKAGE) -->
+    <insert id="insertOrderYearPackage" parameterType="com.academy.freeOrder.service.FreeOrderVO">
+        INSERT INTO TB_ORDER_YEARPACKAGE (
+            ORDERNO,
+            PACKAGE_NO,
+            SUBJECT_TEACHER,
+            LEARNING_CD,
+            REG_DT,
+            START_DATE,
+            END_DATE
+        )
+        SELECT
+            #{orderno},
+            #{mgntno},
+            B.SUBJECT_TEACHER,
+            'M0101',
+            NOW(),
+            NOW(),
+            DATE_ADD(NOW(), INTERVAL #{subjectPeriod} - 1 DAY)
+        FROM TB_LEC_JONG A
+        INNER JOIN TB_LEC_MST B ON A.MST_LECCODE = B.LECCODE
+        WHERE A.LECCODE = #{mgntno}
+        GROUP BY B.SUBJECT_TEACHER
+    </insert>
+
+    <!-- 종합반 강좌 목록 조회 -->
+    <select id="selectPackageLectureList" parameterType="com.academy.freeOrder.service.FreeOrderVO" resultType="org.json.simple.JSONObject">
+        SELECT MST_LECCODE
+        FROM TB_LEC_JONG
+        WHERE LECCODE = #{leccode}
+    </select>
+
+    <!-- =====================================================
+         수강변경 관련
+         ===================================================== -->
+
+    <!-- 수강변경 목록 조회 -->
+    <select id="selectChangeLectureList" parameterType="com.academy.freeOrder.service.FreeOrderVO" resultType="org.json.simple.JSONObject">
+        SELECT
+            a.ORDERNO,
+            a.USER_ID,
+            a.USER_NM AS USER_NAME,
+            b.MGNTNO AS PACKAGE_NO,
+            d.SUBJECT_TITLE AS PACKAGE_NAME,
+            b.PRICE,
+            b.STATUSCODE,
+            CASE b.STATUSCODE
+                WHEN 'DLV100' THEN '입금확인중'
+                WHEN 'DLV105' THEN '입금완료'
+                WHEN 'DLV110' THEN '배송준비중'
+                WHEN 'DLV120' THEN '배송중'
+                WHEN 'DLV130' THEN '배송완료'
+                WHEN 'DLV140' THEN '취소요청'
+                WHEN 'DLV150' THEN '취소완료'
+                WHEN 'DLV160' THEN '교환요청'
+                WHEN 'DLV170' THEN '교환배송중'
+                WHEN 'DLV180' THEN '교환완료'
+                WHEN 'DLV220' THEN '환불요청'
+                WHEN 'DLV230' THEN '환불완료'
+                WHEN 'DLV240' THEN '결제에러'
+            END AS STATUSNAME,
+            DATE_FORMAT(a.REG_DT, '%Y-%m-%d %H:%i:%s') AS REGDATE
+        FROM TB_ORDERS a
+        INNER JOIN TB_ORDER_MGNT_NO b ON a.ORDERNO = b.ORDERNO
+        INNER JOIN TB_LEC_MST d ON b.MGNTNO = d.LECCODE
+        INNER JOIN TB_MA_MEMBER e ON a.USER_ID = e.USER_ID
+        WHERE b.PTYPE != 'L'
+        <if test="keyword != null and keyword != ''">
+            AND (a.USER_NM LIKE CONCAT('%', #{keyword}, '%') OR a.USER_ID LIKE CONCAT('%', #{keyword}, '%'))
+        </if>
+        ORDER BY a.REG_DT DESC, a.USER_NM, b.STATUSCODE
+        LIMIT #{recordCountPerPage} OFFSET #{firstIndex}
+    </select>
+
+    <!-- 수강변경 목록 건수 조회 -->
+    <select id="selectChangeLectureListCount" parameterType="com.academy.freeOrder.service.FreeOrderVO" resultType="int">
+        SELECT COUNT(*)
+        FROM TB_ORDERS a
+        INNER JOIN TB_ORDER_MGNT_NO b ON a.ORDERNO = b.ORDERNO
+        INNER JOIN TB_LEC_MST d ON b.MGNTNO = d.LECCODE
+        INNER JOIN TB_MA_MEMBER e ON a.USER_ID = e.USER_ID
+        WHERE b.PTYPE != 'L'
+        <if test="keyword != null and keyword != ''">
+            AND (a.USER_NM LIKE CONCAT('%', #{keyword}, '%') OR a.USER_ID LIKE CONCAT('%', #{keyword}, '%'))
+        </if>
+    </select>
+
+    <!-- 수강변경 상세 목록 조회 (강의/도서 정보) -->
+    <select id="selectChangeViewList" parameterType="com.academy.freeOrder.service.FreeOrderVO" resultType="org.json.simple.JSONObject">
+        SELECT * FROM (
+            SELECT
+                a.LECCODE AS PACKAGE_NO,
+                a.SUBJECT_TITLE AS PACKAGE_NAME,
+                b.SDATE,
+                c.ORDERNO,
+                c.USER_ID AS USERID,
+                '동영상강좌' AS GBNNAME,
+                a.SUBJECT_TITLE AS NAME,
+                a.SUBJECT_PRICE AS PRICE,
+                a.SUBJECT_DISCOUNT AS RATE,
+                b.PRICE AS REALPRICE,
+                b.CNT,
+                b.STATUSCODE,
+                b.WMV_PMP,
+                IFNULL((SELECT NEW_PACKAGE_NO FROM TB_RENEW_HISTORY WHERE ORDERNO = b.ORDERNO AND NEW_PACKAGE_NO = b.MGNTNO), '') AS NEW_PACKAGE_NO1,
+                (b.PRICE * b.CNT) AS TOT_PRICE,
+                CASE b.STATUSCODE
+                    WHEN 'DLV100' THEN '입금확인중'
+                    WHEN 'DLV105' THEN '입금완료'
+                    WHEN 'DLV110' THEN '배송준비중'
+                    WHEN 'DLV120' THEN '배송중'
+                    WHEN 'DLV130' THEN '배송완료'
+                    WHEN 'DLV140' THEN '취소요청'
+                    WHEN 'DLV150' THEN '취소완료'
+                    WHEN 'DLV160' THEN '교환요청'
+                    WHEN 'DLV170' THEN '교환배송중'
+                    WHEN 'DLV180' THEN '교환완료'
+                    WHEN 'DLV220' THEN '환불요청'
+                    WHEN 'DLV230' THEN '환불완료'
+                    WHEN 'DLV240' THEN '결제에러'
+                END AS STATUSCODENAME,
+                IFNULL(f.OLD_PACKAGE_NO, '') AS OLD_PACKAGE_NO2,
+                IFNULL(f.NEW_PACKAGE_NO, '') AS NEW_PACKAGE_NO2,
+                b.ISCANCEL,
+                b.ISCONFIRM,
+                b.CANCELDATE
+            FROM TB_LEC_MST a
+            INNER JOIN TB_ORDER_MGNT_NO b ON a.LECCODE = b.MGNTNO
+            LEFT OUTER JOIN TB_RENEW_HISTORY f ON f.ORDERNO = b.ORDERNO AND f.OLD_PACKAGE_NO = b.MGNTNO
+            INNER JOIN TB_ORDERS c ON b.ORDERNO = c.ORDERNO
+            WHERE c.ORDERNO = #{orderno}
+
+            UNION ALL
+
+            SELECT
+                a.RSC_ID AS PACKAGE_NO,
+                a.BOOK_NM AS PACKAGE_NAME,
+                b.SDATE,
+                c.ORDERNO,
+                c.USER_ID AS USERID,
+                '도서' AS GBNNAME,
+                a.BOOK_NM AS NAME,
+                a.PRICE AS PRICE,
+                a.DISCOUNT AS RATE,
+                b.PRICE AS REALPRICE,
+                b.CNT,
+                b.STATUSCODE,
+                '도서' AS WMV_PMP,
+                IFNULL((SELECT NEW_PACKAGE_NO FROM TB_RENEW_HISTORY WHERE ORDERNO = b.ORDERNO AND NEW_PACKAGE_NO = b.MGNTNO), '') AS NEW_PACKAGE_NO1,
+                (b.PRICE * b.CNT) AS TOT_PRICE,
+                CASE b.STATUSCODE
+                    WHEN 'DLV100' THEN '입금확인중'
+                    WHEN 'DLV105' THEN '입금완료'
+                    WHEN 'DLV110' THEN '배송준비중'
+                    WHEN 'DLV120' THEN '배송중'
+                    WHEN 'DLV130' THEN '배송완료'
+                    WHEN 'DLV140' THEN '취소요청'
+                    WHEN 'DLV150' THEN '취소완료'
+                    WHEN 'DLV160' THEN '교환요청'
+                    WHEN 'DLV170' THEN '교환배송중'
+                    WHEN 'DLV180' THEN '교환완료'
+                    WHEN 'DLV220' THEN '환불요청'
+                    WHEN 'DLV230' THEN '환불완료'
+                    WHEN 'DLV240' THEN '결제에러'
+                END AS STATUSCODENAME,
+                IFNULL(f.OLD_PACKAGE_NO, '') AS OLD_PACKAGE_NO2,
+                IFNULL(f.NEW_PACKAGE_NO, '') AS NEW_PACKAGE_NO2,
+                b.ISCANCEL,
+                b.ISCONFIRM,
+                b.CANCELDATE
+            FROM TB_CA_BOOK a
+            INNER JOIN TB_ORDER_MGNT_NO b ON a.RSC_ID = b.MGNTNO
+            LEFT OUTER JOIN TB_RENEW_HISTORY f ON f.ORDERNO = b.ORDERNO AND f.OLD_PACKAGE_NO = b.MGNTNO
+            INNER JOIN TB_ORDERS c ON b.ORDERNO = c.ORDERNO
+            WHERE c.ORDERNO = #{orderno}
+        ) TBL
+        ORDER BY ISCONFIRM DESC, CANCELDATE DESC
+    </select>
+
+    <!-- 수강변경 상세 목록 조회 (주문자 정보) -->
+    <select id="selectChangeViewOrderInfo" parameterType="com.academy.freeOrder.service.FreeOrderVO" resultType="org.json.simple.JSONObject">
+        SELECT
+            a.*,
+            b.BIRTH_DAY AS BIRTH_DT
+        FROM TB_ORDERS a
+        LEFT OUTER JOIN TB_MA_MEMBER b ON a.USER_ID = b.USER_ID
+        WHERE a.ORDERNO = #{orderno}
+    </select>
+
+    <!-- 주문 취소 처리 (수강변경 시) -->
+    <update id="updateOrderCancel" parameterType="com.academy.freeOrder.service.FreeOrderVO">
+        UPDATE TB_ORDER_MGNT_NO
+        SET
+            ISCANCEL = '1',
+            STATUSCODE = 'DLV150',
+            CANCELDATE = NOW()
+        WHERE ORDERNO = #{orderno}
+        AND MGNTNO = #{leccode2}
+    </update>
+
+    <!-- 수강변경 이력 등록 (TB_RENEW_HISTORY) -->
+    <insert id="insertRenewHistory" parameterType="com.academy.freeOrder.service.FreeOrderVO">
+        INSERT INTO TB_RENEW_HISTORY (
+            ORDERNO,
+            OLD_PACKAGE_NO,
+            NEW_PACKAGE_NO,
+            REGDATE
+        ) VALUES (
+            #{orderno},
+            #{leccode2},
+            #{leccode},
+            NOW()
+        )
+    </insert>
+
+    <!-- =====================================================
+         주문 상세 관련
+         ===================================================== -->
+
+    <!-- 결제승인 상세 조회 -->
+    <select id="selectApprovalsDetail" parameterType="com.academy.freeOrder.service.FreeOrderVO" resultType="org.json.simple.JSONObject">
+        SELECT
+            b.PRICE,
+            a.ADDPRICE,
+            a.PAYCODE AS PAYCODENAME,
+            CASE WHEN a.PAYCODE = 'PAY120' THEN a.VACCT ELSE ' ' END AS ACCTNONAME,
+            CASE WHEN a.VCDBANK = '' THEN NULL ELSE a.VCDBANK END AS VCDBANK,
+            a.PAYNAME,
+            a.PAYCODE,
+            a.POINT,
+            a.RETURNVALUE,
+            a.VACCT,
+            c.TID
+        FROM TB_APPROVALS a
+        INNER JOIN (
+            SELECT ORDERNO, SUM(PRICE * CNT) AS PRICE
+            FROM TB_ORDER_MGNT_NO
+            WHERE ORDERNO = #{orderno}
+            GROUP BY ORDERNO
+        ) b ON a.ORDERNO = b.ORDERNO
+        INNER JOIN TB_ORDERS c ON a.ORDERNO = c.ORDERNO
+        WHERE a.ORDERNO = #{orderno}
+    </select>
+
+    <!-- 배송정보 건수 조회 -->
+    <select id="selectDeliversCount" parameterType="com.academy.freeOrder.service.FreeOrderVO" resultType="int">
+        SELECT COUNT(*)
+        FROM TB_DELIVERS
+        WHERE ORDERNO = #{orderno}
+    </select>
+
+    <!-- 배송정보 상세 조회 -->
+    <select id="selectDeliversDetail" parameterType="com.academy.freeOrder.service.FreeOrderVO" resultType="org.json.simple.JSONObject">
+        SELECT
+            a.SENDNO,
+            a.USERNAME,
+            a.TELNO,
+            a.CELLNO,
+            a.ZIPCD,
+            SUBSTRING(a.ZIPCD, 1, 3) AS ZIPCD_SET1,
+            CASE
+                WHEN LENGTH(a.ZIPCD) = 6 THEN SUBSTRING(a.ZIPCD, 4, 3)
+                ELSE SUBSTRING(a.ZIPCD, 5, 3)
+            END AS ZIPCD_SET2,
+            a.ADDR,
+            a.MEMO,
+            a.SENDDATE,
+            a.DLEORDER,
+            CASE a.DLEORDER
+                WHEN 'DLE100' THEN '택배수령'
+                WHEN 'DLE110' THEN '직접수령'
+                ELSE '택배수령'
+            END AS DLEORDER_NM
+        FROM TB_DELIVERS a
+        WHERE a.ORDERNO = #{orderno}
+    </select>
+
+</mapper>


### PR DESCRIPTION
Added the FreeOrder API module and MyBatis mapper for managing free course enrollment:
- Created `FreeOrderApi` controller with endpoints for handling course applications, categories, and lectures.
- Implemented `freeOrder.xml` mapper to support database operations for course enrollment, category, and lecture queries.
- Introduced `FreeOrderVO` for encapsulating free order-related data.