### PR TITLE
feat: add Index module with CRUD operations and menu management APIs

### DIFF
--- a/src/main/java/com/academy/index/IndexApi.java
+++ b/src/main/java/com/academy/index/IndexApi.java
@@ -1,0 +1,219 @@
+package com.academy.index;
+
+import java.util.HashMap;
+import java.util.List;
+
+import org.json.simple.JSONObject;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.academy.common.CORSFilter;
+import com.academy.common.PaginationInfo;
+import com.academy.index.service.IndexService;
+import com.academy.index.service.IndexVO;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * 인덱스/메뉴 관리 API
+ */
+@Tag(name = "Index", description = "인덱스/메뉴 관리 API")
+@RestController
+@RequestMapping("/api/index")
+public class IndexApi extends CORSFilter {
+
+    private final IndexService indexService;
+
+    @Autowired
+    public IndexApi(IndexService indexService) {
+        this.indexService = indexService;
+    }
+
+    // === 메뉴 조회 ===
+    @Operation(summary = "TOP 메뉴 목록 조회", description = "사용자 권한에 따른 TOP 메뉴 목록을 조회합니다.")
+    @GetMapping(value = "/getTopMenuList")
+    public JSONObject getTopMenuList(@ModelAttribute IndexVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            List<IndexVO> list = indexService.getTopMenuList(vo);
+            jsonObject.put("data", list);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    @Operation(summary = "LEFT 메뉴 목록 조회", description = "TOP 메뉴에 따른 LEFT 메뉴 목록을 조회합니다.")
+    @GetMapping(value = "/getLeftMenuList")
+    public JSONObject getLeftMenuList(@ModelAttribute IndexVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            List<IndexVO> list = indexService.getLeftMenuList(vo);
+            jsonObject.put("data", list);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    @Operation(summary = "LEFT 메뉴 트리 조회", description = "TOP 메뉴에 따른 LEFT 메뉴 트리를 조회합니다.")
+    @GetMapping(value = "/getLeftMenuTree")
+    public JSONObject getLeftMenuTree(@ModelAttribute IndexVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            List<IndexVO> list = indexService.getLeftMenuTree(vo);
+            jsonObject.put("data", list);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    // === 메뉴 마스터 관리 ===
+    @Operation(summary = "메뉴 목록 조회", description = "메뉴 마스터 목록을 조회합니다.")
+    @GetMapping(value = "/getMenuList")
+    public JSONObject getMenuList(@ModelAttribute IndexVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            int totalCount = indexService.getMenuListCount(vo);
+
+            PaginationInfo paginationInfo = new PaginationInfo();
+            paginationInfo.setCurrentPageNo(vo.getPageIndex());
+            paginationInfo.setRecordCountPerPage(vo.getPageUnit());
+            paginationInfo.setPageSize(vo.getPageSize());
+            paginationInfo.setTotalRecordCount(totalCount);
+
+            vo.setFirstIndex(paginationInfo.getFirstRecordIndex());
+            vo.setLastIndex(paginationInfo.getLastRecordIndex());
+            vo.setRecordCountPerPage(paginationInfo.getRecordCountPerPage());
+
+            List<IndexVO> list = indexService.getMenuList(vo);
+
+            jsonObject.put("data", list);
+            jsonObject.put("totalCount", totalCount);
+            jsonObject.put("paginationInfo", paginationInfo);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    @Operation(summary = "메뉴 상세 조회", description = "메뉴 상세 정보를 조회합니다.")
+    @GetMapping(value = "/getMenuDetail")
+    public JSONObject getMenuDetail(@ModelAttribute IndexVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            IndexVO detail = indexService.getMenuDetail(vo);
+            jsonObject.put("data", detail);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    @Operation(summary = "메뉴 등록", description = "메뉴를 등록합니다.")
+    @PostMapping(value = "/insertMenu")
+    public JSONObject insertMenu(@ModelAttribute IndexVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            int result = indexService.insertMenu(vo);
+            jsonObject.put("data", result);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    @Operation(summary = "메뉴 수정", description = "메뉴 정보를 수정합니다.")
+    @PostMapping(value = "/updateMenu")
+    public JSONObject updateMenu(@ModelAttribute IndexVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            int result = indexService.updateMenu(vo);
+            jsonObject.put("data", result);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    @Operation(summary = "메뉴 삭제", description = "메뉴를 삭제합니다.")
+    @PostMapping(value = "/deleteMenu")
+    public JSONObject deleteMenu(@ModelAttribute IndexVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            int result = indexService.deleteMenu(vo);
+            jsonObject.put("data", result);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    // === 사이트 메뉴 권한 관리 ===
+    @Operation(summary = "사이트 메뉴 권한 목록 조회", description = "사이트별 메뉴 권한 목록을 조회합니다.")
+    @GetMapping(value = "/getSiteMenuList")
+    public JSONObject getSiteMenuList(@ModelAttribute IndexVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            List<IndexVO> list = indexService.getSiteMenuList(vo);
+            jsonObject.put("data", list);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    @Operation(summary = "사이트 메뉴 권한 등록", description = "사이트에 메뉴 권한을 등록합니다.")
+    @PostMapping(value = "/insertSiteMenu")
+    public JSONObject insertSiteMenu(@ModelAttribute IndexVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            int result = indexService.insertSiteMenu(vo);
+            jsonObject.put("data", result);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    @Operation(summary = "사이트 메뉴 권한 삭제", description = "사이트의 메뉴 권한을 삭제합니다.")
+    @PostMapping(value = "/deleteSiteMenu")
+    public JSONObject deleteSiteMenu(@ModelAttribute IndexVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            int result = indexService.deleteSiteMenu(vo);
+            jsonObject.put("data", result);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+}

--- a/src/main/java/com/academy/index/README.md
+++ b/src/main/java/com/academy/index/README.md
@@ -1,0 +1,176 @@
+# 인덱스/메뉴 관리 패키지
+
+관리자 메뉴 구성 및 권한 관리 기능을 제공하는 패키지입니다.
+
+## 패키지 구조
+
+```
+index/
+├── IndexApi.java                   # REST Controller
+├── README.md
+└── service/
+    ├── IndexService.java           # 서비스 클래스
+    └── IndexVO.java                # VO
+```
+
+## 기능 설명
+
+관리자 시스템의 TOP 메뉴, LEFT 메뉴 구성 및 메뉴 권한 관리 기능을 제공합니다.
+
+### 주요 기능
+
+#### 메뉴 조회
+- TOP 메뉴 목록 조회 (사용자 권한별)
+- LEFT 메뉴 목록 조회 (TOP 메뉴별)
+- LEFT 메뉴 트리 조회 (재귀적 하위 메뉴 포함)
+
+#### 메뉴 마스터 관리
+- 메뉴 목록/상세 조회
+- 메뉴 등록/수정/삭제
+
+#### 사이트 메뉴 권한 관리
+- 사이트별 메뉴 권한 목록 조회
+- 사이트 메뉴 권한 등록/삭제
+
+## API 엔드포인트
+
+### 메뉴 조회
+| HTTP | URL | 설명 |
+|------|-----|------|
+| GET | `/api/index/getTopMenuList` | TOP 메뉴 목록 조회 |
+| GET | `/api/index/getLeftMenuList` | LEFT 메뉴 목록 조회 |
+| GET | `/api/index/getLeftMenuTree` | LEFT 메뉴 트리 조회 |
+
+### 메뉴 마스터 관리
+| HTTP | URL | 설명 |
+|------|-----|------|
+| GET | `/api/index/getMenuList` | 메뉴 목록 조회 |
+| GET | `/api/index/getMenuDetail` | 메뉴 상세 조회 |
+| POST | `/api/index/insertMenu` | 메뉴 등록 |
+| POST | `/api/index/updateMenu` | 메뉴 수정 |
+| POST | `/api/index/deleteMenu` | 메뉴 삭제 |
+
+### 사이트 메뉴 권한 관리
+| HTTP | URL | 설명 |
+|------|-----|------|
+| GET | `/api/index/getSiteMenuList` | 사이트 메뉴 권한 목록 조회 |
+| POST | `/api/index/insertSiteMenu` | 사이트 메뉴 권한 등록 |
+| POST | `/api/index/deleteSiteMenu` | 사이트 메뉴 권한 삭제 |
+
+## 관련 테이블
+
+| 테이블명 | 설명 |
+|---------|------|
+| TB_SG_MENU_MST | 메뉴 마스터 테이블 |
+| TB_SG_SITE_MENU | 사이트별 메뉴 권한 테이블 |
+
+### TB_SG_MENU_MST 테이블 주요 컬럼
+
+| 컬럼명 | 타입 | 설명 |
+|--------|------|------|
+| MENU_ID | VARCHAR | 메뉴 ID (PK) |
+| MENU_NM | VARCHAR | 메뉴명 |
+| P_MENUID | VARCHAR | 상위 메뉴 ID |
+| MENU_URL | VARCHAR | 메뉴 URL |
+| MENU_SEQ | INT | 메뉴 순서 |
+| TARGET | VARCHAR | 타겟 (_self, _blank 등) |
+| ISUSE | VARCHAR | 사용여부 (Y/N) |
+
+### TB_SG_SITE_MENU 테이블 주요 컬럼
+
+| 컬럼명 | 타입 | 설명 |
+|--------|------|------|
+| SITE_ID | VARCHAR | 사이트 ID (권한 역할) |
+| MENU_ID | VARCHAR | 메뉴 ID |
+
+## 메뉴 타입
+
+| 타입 | 설명 |
+|------|------|
+| OM_ROOT | 온라인 메뉴 루트 |
+| FM_ROOT | 오프라인 메뉴 루트 |
+| TM_ROOT | 테스트 메뉴 루트 |
+
+## 온/오프라인 구분 (onoffDiv)
+
+| 코드 | 설명 |
+|------|------|
+| A | 전체 (온라인 + 오프라인) |
+| O | 온라인만 |
+| F | 오프라인만 |
+| T | 테스트 |
+
+## 검색 조건
+
+### 메뉴 조회
+| 파라미터 | 타입 | 설명 |
+|---------|------|------|
+| adminRole | String | 관리자 권한 (사이트 ID) |
+| menuType | String | 메뉴 타입 (OM_ROOT, FM_ROOT, TM_ROOT) |
+| topMenuId | String | TOP 메뉴 ID |
+
+### 메뉴 마스터
+| 파라미터 | 타입 | 설명 |
+|---------|------|------|
+| pMenuId | String | 상위 메뉴 ID |
+| searchKeyword | String | 메뉴명 검색 |
+| isuse | String | 사용여부 (Y/N) |
+
+## 사용 예시
+
+### TOP 메뉴 목록 조회
+```
+GET /api/index/getTopMenuList?adminRole=ADMIN&menuType=OM_ROOT
+```
+
+### LEFT 메뉴 트리 조회
+```
+GET /api/index/getLeftMenuTree?adminRole=ADMIN&topMenuId=MENU001
+```
+
+### 메뉴 등록
+```
+POST /api/index/insertMenu
+Content-Type: application/x-www-form-urlencoded
+
+menuId=MENU_NEW&menuNm=새 메뉴&pMenuId=OM_ROOT&menuUrl=/new/menu&menuSeq=10&target=_self&isuse=Y
+```
+
+### 사이트 메뉴 권한 등록
+```
+POST /api/index/insertSiteMenu
+Content-Type: application/x-www-form-urlencoded
+
+siteId=ADMIN&menuId=MENU_NEW
+```
+
+## 메뉴 트리 구조
+
+메뉴는 계층적 구조로 구성됩니다:
+
+```
+ROOT (OM_ROOT / FM_ROOT / TM_ROOT)
+├── TOP_MENU_1
+│   ├── LEFT_MENU_1_1
+│   │   ├── SUB_MENU_1_1_1
+│   │   └── SUB_MENU_1_1_2
+│   └── LEFT_MENU_1_2
+├── TOP_MENU_2
+│   └── LEFT_MENU_2_1
+└── ...
+```
+
+`selectLeftMenuTree`는 MySQL의 재귀 CTE(Common Table Expression)를 사용하여 계층적 메뉴 구조를 조회합니다.
+
+## 관련 Mapper
+
+- **IndexMapper.java**: `com.academy.mapper.IndexMapper`
+- **index.xml**: `src/main/resources/mapper/index.xml`
+
+---
+
+## Copyright
+
+<img src="../../../../../../../../UM_CI.png" alt="UM Systems" width="10%">
+
+**Copyright (c) 2021 운몽시스템즈(UM Systems). All rights reserved.**

--- a/src/main/java/com/academy/index/service/IndexService.java
+++ b/src/main/java/com/academy/index/service/IndexService.java
@@ -1,0 +1,82 @@
+package com.academy.index.service;
+
+import java.io.Serializable;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.academy.mapper.IndexMapper;
+
+/**
+ * 인덱스/메뉴 관리 서비스
+ */
+@Service
+public class IndexService implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final IndexMapper indexMapper;
+
+    @Autowired
+    public IndexService(IndexMapper indexMapper) {
+        this.indexMapper = indexMapper;
+    }
+
+    // === 메뉴 관리 ===
+    public List<IndexVO> getTopMenuList(IndexVO vo) {
+        return indexMapper.selectTopMenuList(vo);
+    }
+
+    public List<IndexVO> getLeftMenuList(IndexVO vo) {
+        return indexMapper.selectLeftMenuList(vo);
+    }
+
+    public List<IndexVO> getLeftMenuTree(IndexVO vo) {
+        return indexMapper.selectLeftMenuTree(vo);
+    }
+
+    // === 메뉴 마스터 관리 ===
+    public List<IndexVO> getMenuList(IndexVO vo) {
+        return indexMapper.selectMenuList(vo);
+    }
+
+    public int getMenuListCount(IndexVO vo) {
+        return indexMapper.selectMenuListCount(vo);
+    }
+
+    public IndexVO getMenuDetail(IndexVO vo) {
+        return indexMapper.selectMenuDetail(vo);
+    }
+
+    @Transactional
+    public int insertMenu(IndexVO vo) {
+        return indexMapper.insertMenu(vo);
+    }
+
+    @Transactional
+    public int updateMenu(IndexVO vo) {
+        return indexMapper.updateMenu(vo);
+    }
+
+    @Transactional
+    public int deleteMenu(IndexVO vo) {
+        return indexMapper.deleteMenu(vo);
+    }
+
+    // === 사이트 메뉴 권한 관리 ===
+    public List<IndexVO> getSiteMenuList(IndexVO vo) {
+        return indexMapper.selectSiteMenuList(vo);
+    }
+
+    @Transactional
+    public int insertSiteMenu(IndexVO vo) {
+        return indexMapper.insertSiteMenu(vo);
+    }
+
+    @Transactional
+    public int deleteSiteMenu(IndexVO vo) {
+        return indexMapper.deleteSiteMenu(vo);
+    }
+}

--- a/src/main/java/com/academy/index/service/IndexVO.java
+++ b/src/main/java/com/academy/index/service/IndexVO.java
@@ -1,0 +1,196 @@
+package com.academy.index.service;
+
+import com.academy.common.CommonVO;
+
+/**
+ * 인덱스/메뉴 관리 VO
+ * - 메뉴 관리 (TB_SG_MENU_MST, TB_SG_SITE_MENU)
+ * - 로그인 이력 관리
+ */
+public class IndexVO extends CommonVO {
+
+    private static final long serialVersionUID = 1L;
+
+    // === 메뉴 정보 (TB_SG_MENU_MST) ===
+    private String menuId;          // 메뉴 ID
+    private String menuNm;          // 메뉴명
+    private String pMenuId;         // 상위 메뉴 ID
+    private String menuUrl;         // 메뉴 URL
+    private Integer menuSeq;        // 메뉴 순서
+    private String target;          // 타겟 (_self, _blank 등)
+    private String isuse;           // 사용여부 (Y/N)
+    private Integer menuLevel;      // 메뉴 레벨 (트리 깊이)
+
+    // === 사이트 메뉴 (TB_SG_SITE_MENU) ===
+    private String siteId;          // 사이트 ID (권한 역할)
+
+    // === 사용자 정보 ===
+    private String userId;          // 사용자 ID
+    private String userNm;          // 사용자명
+    private String adminRole;       // 관리자 권한
+    private String onoffDiv;        // 온/오프라인 구분 (A/O/F/T)
+
+    // === 로그인 이력 ===
+    private String loginIp;         // 로그인 IP
+    private String loginDate;       // 로그인 일시
+    private Integer logCnt;         // 로그 조회 개수
+
+    // === 검색/필터 조건 ===
+    private String menuType;        // 메뉴 타입 (OM_ROOT, FM_ROOT, TM_ROOT)
+    private String topMenuId;       // 탑 메뉴 ID
+    private String searchKeyword;   // 키워드 검색
+
+    // === Getters and Setters ===
+
+    public String getMenuId() {
+        return menuId;
+    }
+
+    public void setMenuId(String menuId) {
+        this.menuId = menuId;
+    }
+
+    public String getMenuNm() {
+        return menuNm;
+    }
+
+    public void setMenuNm(String menuNm) {
+        this.menuNm = menuNm;
+    }
+
+    public String getpMenuId() {
+        return pMenuId;
+    }
+
+    public void setpMenuId(String pMenuId) {
+        this.pMenuId = pMenuId;
+    }
+
+    public String getMenuUrl() {
+        return menuUrl;
+    }
+
+    public void setMenuUrl(String menuUrl) {
+        this.menuUrl = menuUrl;
+    }
+
+    public Integer getMenuSeq() {
+        return menuSeq;
+    }
+
+    public void setMenuSeq(Integer menuSeq) {
+        this.menuSeq = menuSeq;
+    }
+
+    public String getTarget() {
+        return target;
+    }
+
+    public void setTarget(String target) {
+        this.target = target;
+    }
+
+    public String getIsuse() {
+        return isuse;
+    }
+
+    public void setIsuse(String isuse) {
+        this.isuse = isuse;
+    }
+
+    public Integer getMenuLevel() {
+        return menuLevel;
+    }
+
+    public void setMenuLevel(Integer menuLevel) {
+        this.menuLevel = menuLevel;
+    }
+
+    public String getSiteId() {
+        return siteId;
+    }
+
+    public void setSiteId(String siteId) {
+        this.siteId = siteId;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getUserNm() {
+        return userNm;
+    }
+
+    public void setUserNm(String userNm) {
+        this.userNm = userNm;
+    }
+
+    public String getAdminRole() {
+        return adminRole;
+    }
+
+    public void setAdminRole(String adminRole) {
+        this.adminRole = adminRole;
+    }
+
+    public String getOnoffDiv() {
+        return onoffDiv;
+    }
+
+    public void setOnoffDiv(String onoffDiv) {
+        this.onoffDiv = onoffDiv;
+    }
+
+    public String getLoginIp() {
+        return loginIp;
+    }
+
+    public void setLoginIp(String loginIp) {
+        this.loginIp = loginIp;
+    }
+
+    public String getLoginDate() {
+        return loginDate;
+    }
+
+    public void setLoginDate(String loginDate) {
+        this.loginDate = loginDate;
+    }
+
+    public Integer getLogCnt() {
+        return logCnt;
+    }
+
+    public void setLogCnt(Integer logCnt) {
+        this.logCnt = logCnt;
+    }
+
+    public String getMenuType() {
+        return menuType;
+    }
+
+    public void setMenuType(String menuType) {
+        this.menuType = menuType;
+    }
+
+    public String getTopMenuId() {
+        return topMenuId;
+    }
+
+    public void setTopMenuId(String topMenuId) {
+        this.topMenuId = topMenuId;
+    }
+
+    public String getSearchKeyword() {
+        return searchKeyword;
+    }
+
+    public void setSearchKeyword(String searchKeyword) {
+        this.searchKeyword = searchKeyword;
+    }
+}

--- a/src/main/java/com/academy/lectureOff/LectureOffApi.java
+++ b/src/main/java/com/academy/lectureOff/LectureOffApi.java
@@ -1,0 +1,570 @@
+package com.academy.lectureOff;
+
+import java.util.HashMap;
+import java.util.List;
+
+import org.json.simple.JSONObject;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.academy.common.CORSFilter;
+import com.academy.common.PaginationInfo;
+import com.academy.lectureOff.service.LectureOffService;
+import com.academy.lectureOff.service.LectureOffVO;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * 오프라인 강의 관리 API
+ */
+@Tag(name = "LectureOff", description = "오프라인 강의 관리 API")
+@RestController
+@RequestMapping("/api/lectureOff")
+public class LectureOffApi extends CORSFilter {
+
+    private final LectureOffService lectureOffService;
+
+    @Autowired
+    public LectureOffApi(LectureOffService lectureOffService) {
+        this.lectureOffService = lectureOffService;
+    }
+
+    // =============================================
+    // 단과 강의 관리
+    // =============================================
+    @Operation(summary = "단과 강의 목록 조회", description = "오프라인 단과 강의 목록을 조회합니다.")
+    @GetMapping(value = "/getLectureList")
+    public JSONObject getLectureList(@ModelAttribute LectureOffVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            int totalCount = lectureOffService.getLectureListCount(vo);
+
+            PaginationInfo paginationInfo = new PaginationInfo();
+            paginationInfo.setCurrentPageNo(vo.getPageIndex());
+            paginationInfo.setRecordCountPerPage(vo.getPageUnit());
+            paginationInfo.setPageSize(vo.getPageSize());
+            paginationInfo.setTotalRecordCount(totalCount);
+
+            vo.setFirstIndex(paginationInfo.getFirstRecordIndex());
+            vo.setLastIndex(paginationInfo.getLastRecordIndex());
+            vo.setRecordCountPerPage(paginationInfo.getRecordCountPerPage());
+
+            List<LectureOffVO> list = lectureOffService.getLectureList(vo);
+
+            jsonObject.put("data", list);
+            jsonObject.put("totalCount", totalCount);
+            jsonObject.put("paginationInfo", paginationInfo);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    @Operation(summary = "단과 강의 상세 조회", description = "단과 강의 상세 정보를 조회합니다.")
+    @GetMapping(value = "/getLectureDetail")
+    public JSONObject getLectureDetail(@ModelAttribute LectureOffVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            LectureOffVO detail = lectureOffService.getLectureDetail(vo);
+            List<LectureOffVO> bridgeList = lectureOffService.getLectureBridgeList(vo);
+            List<LectureOffVO> bookList = lectureOffService.getLectureBookList(vo);
+            List<LectureOffVO> dateList = lectureOffService.getLectureDateList(vo);
+
+            jsonObject.put("data", detail);
+            jsonObject.put("bridgeList", bridgeList);
+            jsonObject.put("bookList", bookList);
+            jsonObject.put("dateList", dateList);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    @Operation(summary = "단과 강의 등록", description = "오프라인 단과 강의를 등록합니다.")
+    @PostMapping(value = "/insertLecture")
+    public JSONObject insertLecture(@ModelAttribute LectureOffVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            int result = lectureOffService.insertLecture(vo);
+            jsonObject.put("data", result);
+            jsonObject.put("leccode", vo.getLeccode());
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    @Operation(summary = "단과 강의 수정", description = "오프라인 단과 강의를 수정합니다.")
+    @PostMapping(value = "/updateLecture")
+    public JSONObject updateLecture(@ModelAttribute LectureOffVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            int result = lectureOffService.updateLecture(vo);
+            jsonObject.put("data", result);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    @Operation(summary = "단과 강의 삭제", description = "오프라인 단과 강의를 삭제합니다.")
+    @PostMapping(value = "/deleteLecture")
+    public JSONObject deleteLecture(@ModelAttribute LectureOffVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            int result = lectureOffService.deleteLecture(vo);
+            jsonObject.put("data", result);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    // =============================================
+    // 강의 브릿지 관리
+    // =============================================
+    @Operation(summary = "강의 브릿지 목록 조회", description = "강의 브릿지 목록을 조회합니다.")
+    @GetMapping(value = "/getLectureBridgeList")
+    public JSONObject getLectureBridgeList(@ModelAttribute LectureOffVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            List<LectureOffVO> list = lectureOffService.getLectureBridgeList(vo);
+            jsonObject.put("data", list);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    @Operation(summary = "강의 브릿지 등록", description = "강의 브릿지를 등록합니다.")
+    @PostMapping(value = "/insertLectureBridge")
+    public JSONObject insertLectureBridge(@ModelAttribute LectureOffVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            int result = lectureOffService.insertLectureBridge(vo);
+            jsonObject.put("data", result);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    @Operation(summary = "강의 브릿지 삭제", description = "강의 브릿지를 삭제합니다.")
+    @PostMapping(value = "/deleteLectureBridge")
+    public JSONObject deleteLectureBridge(@ModelAttribute LectureOffVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            int result = lectureOffService.deleteLectureBridge(vo);
+            jsonObject.put("data", result);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    // =============================================
+    // 강의 교재 관리
+    // =============================================
+    @Operation(summary = "강의 교재 목록 조회", description = "강의 교재 목록을 조회합니다.")
+    @GetMapping(value = "/getLectureBookList")
+    public JSONObject getLectureBookList(@ModelAttribute LectureOffVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            List<LectureOffVO> list = lectureOffService.getLectureBookList(vo);
+            jsonObject.put("data", list);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    @Operation(summary = "교재 검색 목록 조회", description = "등록 가능한 교재를 검색합니다.")
+    @GetMapping(value = "/getBookSearchList")
+    public JSONObject getBookSearchList(@ModelAttribute LectureOffVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            List<LectureOffVO> list = lectureOffService.getBookSearchList(vo);
+            jsonObject.put("data", list);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    @Operation(summary = "강의 교재 등록", description = "강의 교재를 등록합니다.")
+    @PostMapping(value = "/insertLectureBook")
+    public JSONObject insertLectureBook(@ModelAttribute LectureOffVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            int result = lectureOffService.insertLectureBook(vo);
+            jsonObject.put("data", result);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    @Operation(summary = "강의 교재 삭제", description = "강의 교재를 삭제합니다.")
+    @PostMapping(value = "/deleteLectureBook")
+    public JSONObject deleteLectureBook(@ModelAttribute LectureOffVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            int result = lectureOffService.deleteLectureBook(vo);
+            jsonObject.put("data", result);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    // =============================================
+    // 강의 일정 관리
+    // =============================================
+    @Operation(summary = "강의 일정 목록 조회", description = "강의 일정 목록을 조회합니다.")
+    @GetMapping(value = "/getLectureDateList")
+    public JSONObject getLectureDateList(@ModelAttribute LectureOffVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            List<LectureOffVO> list = lectureOffService.getLectureDateList(vo);
+            jsonObject.put("data", list);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    @Operation(summary = "강의 일정 등록", description = "강의 일정을 등록합니다.")
+    @PostMapping(value = "/insertLectureDate")
+    public JSONObject insertLectureDate(@ModelAttribute LectureOffVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            int result = lectureOffService.insertLectureDate(vo);
+            jsonObject.put("data", result);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    @Operation(summary = "강의 일정 삭제", description = "강의 일정을 삭제합니다.")
+    @PostMapping(value = "/deleteLectureDate")
+    public JSONObject deleteLectureDate(@ModelAttribute LectureOffVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            int result = lectureOffService.deleteLectureDate(vo);
+            jsonObject.put("data", result);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    // =============================================
+    // 종합반 강의 관리
+    // =============================================
+    @Operation(summary = "종합반 강의 목록 조회", description = "종합반 강의 목록을 조회합니다.")
+    @GetMapping(value = "/getJongLectureList")
+    public JSONObject getJongLectureList(@ModelAttribute LectureOffVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            int totalCount = lectureOffService.getJongLectureListCount(vo);
+
+            PaginationInfo paginationInfo = new PaginationInfo();
+            paginationInfo.setCurrentPageNo(vo.getPageIndex());
+            paginationInfo.setRecordCountPerPage(vo.getPageUnit());
+            paginationInfo.setPageSize(vo.getPageSize());
+            paginationInfo.setTotalRecordCount(totalCount);
+
+            vo.setFirstIndex(paginationInfo.getFirstRecordIndex());
+            vo.setLastIndex(paginationInfo.getLastRecordIndex());
+            vo.setRecordCountPerPage(paginationInfo.getRecordCountPerPage());
+
+            List<LectureOffVO> list = lectureOffService.getJongLectureList(vo);
+
+            jsonObject.put("data", list);
+            jsonObject.put("totalCount", totalCount);
+            jsonObject.put("paginationInfo", paginationInfo);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    @Operation(summary = "종합반 강의 상세 조회", description = "종합반 강의 상세 정보를 조회합니다.")
+    @GetMapping(value = "/getJongLectureDetail")
+    public JSONObject getJongLectureDetail(@ModelAttribute LectureOffVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            LectureOffVO detail = lectureOffService.getJongLectureDetail(vo);
+            List<LectureOffVO> detailList = lectureOffService.getJongLectureDetailList(vo);
+
+            jsonObject.put("data", detail);
+            jsonObject.put("detailList", detailList);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    @Operation(summary = "종합반 강의 등록", description = "종합반 강의를 등록합니다.")
+    @PostMapping(value = "/insertJongLecture")
+    public JSONObject insertJongLecture(@ModelAttribute LectureOffVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            int result = lectureOffService.insertJongLecture(vo);
+            jsonObject.put("data", result);
+            jsonObject.put("jongseq", vo.getJongseq());
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    @Operation(summary = "종합반 강의 수정", description = "종합반 강의를 수정합니다.")
+    @PostMapping(value = "/updateJongLecture")
+    public JSONObject updateJongLecture(@ModelAttribute LectureOffVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            int result = lectureOffService.updateJongLecture(vo);
+            jsonObject.put("data", result);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    @Operation(summary = "종합반 강의 삭제", description = "종합반 강의를 삭제합니다.")
+    @PostMapping(value = "/deleteJongLecture")
+    public JSONObject deleteJongLecture(@ModelAttribute LectureOffVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            int result = lectureOffService.deleteJongLecture(vo);
+            jsonObject.put("data", result);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    // =============================================
+    // 종합반 강의 구성 관리
+    // =============================================
+    @Operation(summary = "종합반 강의 구성 목록 조회", description = "종합반에 포함된 단과 강의 목록을 조회합니다.")
+    @GetMapping(value = "/getJongLectureDetailList")
+    public JSONObject getJongLectureDetailList(@ModelAttribute LectureOffVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            List<LectureOffVO> list = lectureOffService.getJongLectureDetailList(vo);
+            jsonObject.put("data", list);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    @Operation(summary = "종합반 강의 구성 등록", description = "종합반에 단과 강의를 추가합니다.")
+    @PostMapping(value = "/insertJongLectureDetail")
+    public JSONObject insertJongLectureDetail(@ModelAttribute LectureOffVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            int result = lectureOffService.insertJongLectureDetail(vo);
+            jsonObject.put("data", result);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    @Operation(summary = "종합반 강의 구성 삭제", description = "종합반에서 단과 강의를 삭제합니다.")
+    @PostMapping(value = "/deleteJongLectureDetail")
+    public JSONObject deleteJongLectureDetail(@ModelAttribute LectureOffVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            int result = lectureOffService.deleteJongLectureDetail(vo);
+            jsonObject.put("data", result);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    // =============================================
+    // 선택형 종합반 관리
+    // =============================================
+    @Operation(summary = "선택형 종합반 목록 조회", description = "선택형 종합반 목록을 조회합니다.")
+    @GetMapping(value = "/getChoiceJongList")
+    public JSONObject getChoiceJongList(@ModelAttribute LectureOffVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            List<LectureOffVO> list = lectureOffService.getChoiceJongList(vo);
+            jsonObject.put("data", list);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    @Operation(summary = "선택형 종합반 등록", description = "선택형 종합반을 등록합니다.")
+    @PostMapping(value = "/insertChoiceJong")
+    public JSONObject insertChoiceJong(@ModelAttribute LectureOffVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            int result = lectureOffService.insertChoiceJong(vo);
+            jsonObject.put("data", result);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    @Operation(summary = "선택형 종합반 삭제", description = "선택형 종합반을 삭제합니다.")
+    @PostMapping(value = "/deleteChoiceJong")
+    public JSONObject deleteChoiceJong(@ModelAttribute LectureOffVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            int result = lectureOffService.deleteChoiceJong(vo);
+            jsonObject.put("data", result);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    // =============================================
+    // 카테고리/과목/강사 조회
+    // =============================================
+    @Operation(summary = "카테고리 목록 조회", description = "카테고리 목록을 조회합니다.")
+    @GetMapping(value = "/getCategoryList")
+    public JSONObject getCategoryList(@ModelAttribute LectureOffVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            List<LectureOffVO> list = lectureOffService.getCategoryList(vo);
+            jsonObject.put("data", list);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    @Operation(summary = "과목 목록 조회", description = "과목 목록을 조회합니다.")
+    @GetMapping(value = "/getSubjectList")
+    public JSONObject getSubjectList(@ModelAttribute LectureOffVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            List<LectureOffVO> list = lectureOffService.getSubjectList(vo);
+            jsonObject.put("data", list);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    @Operation(summary = "강사 목록 조회", description = "강사 목록을 조회합니다.")
+    @GetMapping(value = "/getTeacherList")
+    public JSONObject getTeacherList(@ModelAttribute LectureOffVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            List<LectureOffVO> list = lectureOffService.getTeacherList(vo);
+            jsonObject.put("data", list);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    // =============================================
+    // 강의코드 생성
+    // =============================================
+    @Operation(summary = "다음 강의코드 조회", description = "새로운 강의코드를 생성합니다.")
+    @GetMapping(value = "/getNextLeccode")
+    public JSONObject getNextLeccode(@ModelAttribute LectureOffVO vo) {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            String nextLeccode = lectureOffService.getNextLeccode(vo);
+            jsonObject.put("data", nextLeccode);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+
+    @Operation(summary = "다음 종합반 SEQ 조회", description = "새로운 종합반 SEQ를 생성합니다.")
+    @GetMapping(value = "/getNextJongseq")
+    public JSONObject getNextJongseq() {
+        HashMap<String, Object> jsonObject = new HashMap<>();
+        try {
+            int nextJongseq = lectureOffService.getNextJongseq();
+            jsonObject.put("data", nextJongseq);
+            jsonObject.put("retMsg", "OK");
+        } catch (Exception e) {
+            jsonObject.put("retMsg", "FAIL");
+            jsonObject.put("error", e.getMessage());
+        }
+        return new JSONObject(jsonObject);
+    }
+}

--- a/src/main/java/com/academy/lectureOff/README.md
+++ b/src/main/java/com/academy/lectureOff/README.md
@@ -1,0 +1,225 @@
+# 오프라인 강의 관리 패키지
+
+오프라인 학원 강의(단과/종합반)를 관리하는 패키지입니다.
+
+## 패키지 구조
+
+```
+lectureOff/
+├── LectureOffApi.java              # REST Controller
+├── README.md
+└── service/
+    ├── LectureOffService.java      # 서비스 클래스
+    └── LectureOffVO.java           # VO
+```
+
+## 기능 설명
+
+오프라인 학원에서 운영하는 단과 강의 및 종합반 강의의 등록, 수정, 삭제, 조회 기능을 제공합니다.
+
+### 주요 기능
+
+#### 단과 강의 관리
+- 단과 강의 목록/상세 조회
+- 단과 강의 등록/수정/삭제
+- 강의 브릿지 관리 (연관 강의)
+- 강의 교재 관리
+- 강의 일정 관리
+
+#### 종합반 강의 관리
+- 종합반 강의 목록/상세 조회
+- 종합반 강의 등록/수정/삭제
+- 종합반 강의 구성 관리 (단과 강의 매핑)
+- 선택형 종합반 관리
+
+#### 공통 기능
+- 카테고리/과목/강사 목록 조회
+- 강의코드/종합반 SEQ 자동 생성
+
+## API 엔드포인트
+
+### 단과 강의 관리
+| HTTP | URL | 설명 |
+|------|-----|------|
+| GET | `/api/lectureOff/getLectureList` | 단과 강의 목록 조회 |
+| GET | `/api/lectureOff/getLectureDetail` | 단과 강의 상세 조회 |
+| POST | `/api/lectureOff/insertLecture` | 단과 강의 등록 |
+| POST | `/api/lectureOff/updateLecture` | 단과 강의 수정 |
+| POST | `/api/lectureOff/deleteLecture` | 단과 강의 삭제 |
+
+### 강의 브릿지 관리
+| HTTP | URL | 설명 |
+|------|-----|------|
+| GET | `/api/lectureOff/getLectureBridgeList` | 강의 브릿지 목록 조회 |
+| POST | `/api/lectureOff/insertLectureBridge` | 강의 브릿지 등록 |
+| POST | `/api/lectureOff/deleteLectureBridge` | 강의 브릿지 삭제 |
+
+### 강의 교재 관리
+| HTTP | URL | 설명 |
+|------|-----|------|
+| GET | `/api/lectureOff/getLectureBookList` | 강의 교재 목록 조회 |
+| GET | `/api/lectureOff/getBookSearchList` | 교재 검색 목록 조회 |
+| POST | `/api/lectureOff/insertLectureBook` | 강의 교재 등록 |
+| POST | `/api/lectureOff/deleteLectureBook` | 강의 교재 삭제 |
+
+### 강의 일정 관리
+| HTTP | URL | 설명 |
+|------|-----|------|
+| GET | `/api/lectureOff/getLectureDateList` | 강의 일정 목록 조회 |
+| POST | `/api/lectureOff/insertLectureDate` | 강의 일정 등록 |
+| POST | `/api/lectureOff/deleteLectureDate` | 강의 일정 삭제 |
+
+### 종합반 강의 관리
+| HTTP | URL | 설명 |
+|------|-----|------|
+| GET | `/api/lectureOff/getJongLectureList` | 종합반 강의 목록 조회 |
+| GET | `/api/lectureOff/getJongLectureDetail` | 종합반 강의 상세 조회 |
+| POST | `/api/lectureOff/insertJongLecture` | 종합반 강의 등록 |
+| POST | `/api/lectureOff/updateJongLecture` | 종합반 강의 수정 |
+| POST | `/api/lectureOff/deleteJongLecture` | 종합반 강의 삭제 |
+
+### 종합반 강의 구성 관리
+| HTTP | URL | 설명 |
+|------|-----|------|
+| GET | `/api/lectureOff/getJongLectureDetailList` | 종합반 강의 구성 목록 조회 |
+| POST | `/api/lectureOff/insertJongLectureDetail` | 종합반 강의 구성 등록 |
+| POST | `/api/lectureOff/deleteJongLectureDetail` | 종합반 강의 구성 삭제 |
+
+### 선택형 종합반 관리
+| HTTP | URL | 설명 |
+|------|-----|------|
+| GET | `/api/lectureOff/getChoiceJongList` | 선택형 종합반 목록 조회 |
+| POST | `/api/lectureOff/insertChoiceJong` | 선택형 종합반 등록 |
+| POST | `/api/lectureOff/deleteChoiceJong` | 선택형 종합반 삭제 |
+
+### 공통 조회
+| HTTP | URL | 설명 |
+|------|-----|------|
+| GET | `/api/lectureOff/getCategoryList` | 카테고리 목록 조회 |
+| GET | `/api/lectureOff/getSubjectList` | 과목 목록 조회 |
+| GET | `/api/lectureOff/getTeacherList` | 강사 목록 조회 |
+| GET | `/api/lectureOff/getNextLeccode` | 다음 강의코드 조회 |
+| GET | `/api/lectureOff/getNextJongseq` | 다음 종합반 SEQ 조회 |
+
+## 관련 테이블
+
+| 테이블명 | 설명 |
+|---------|------|
+| TB_OFF_LEC_MST | 단과 강의 마스터 테이블 |
+| TB_OFF_LEC_BRIDGE | 강의 브릿지 테이블 (연관 강의) |
+| TB_OFF_PLUS_CA_BOOK | 강의 교재 테이블 |
+| TB_OFF_LECTURE_DATE | 강의 일정 테이블 |
+| TB_OFF_LEC_JONG_MST | 종합반 마스터 테이블 |
+| TB_OFF_LEC_JONG | 종합반 강의 구성 테이블 |
+| TB_OFF_CHOICE_JONG_NO | 선택형 종합반 테이블 |
+
+### TB_OFF_LEC_MST 테이블 주요 컬럼
+
+| 컬럼명 | 타입 | 설명 |
+|--------|------|------|
+| SEQ | INT | 시퀀스 (PK, AUTO_INCREMENT) |
+| LECCODE | VARCHAR | 강의 코드 (UK) |
+| CATEGORY_CD | VARCHAR | 카테고리 코드 |
+| LEARNING_CD | VARCHAR | 과목 코드 |
+| SUBJECT_TITLE | VARCHAR | 강의 제목 |
+| TEACHER_KEY | VARCHAR | 강사 키 |
+| LEL_DATE | VARCHAR | 개강일 |
+| LEC_GUBUN | VARCHAR | 강의 구분 |
+| KIND | VARCHAR | 종류 |
+| FORM | VARCHAR | 형태 |
+| LEC_NUM | INT | 강의 횟수 |
+| PRICE | INT | 정가 |
+| SALE_PRICE | INT | 판매가 |
+| POINT_USER | INT | 적립 포인트 |
+| LIMIT_DAY | INT | 수강 기간 |
+| MOBILE | VARCHAR | 모바일 여부 |
+| ORG_PRICE | INT | 원가 |
+| ISUSE | CHAR(1) | 사용여부 (Y/N) |
+| INDATE | DATETIME | 등록일 |
+| LEC_INFO | TEXT | 강의 정보 |
+| LEC_CONTENT | TEXT | 강의 내용 |
+| LEC_TIME | VARCHAR | 강의 시간 |
+| PLACE | VARCHAR | 강의 장소 |
+
+### TB_OFF_LEC_JONG_MST 테이블 주요 컬럼
+
+| 컬럼명 | 타입 | 설명 |
+|--------|------|------|
+| JONGSEQ | INT | 종합반 SEQ (PK, AUTO_INCREMENT) |
+| MST_LECCODE | VARCHAR | 마스터 강의코드 |
+| GUBUN | VARCHAR | 구분 |
+| JONG_NM | VARCHAR | 종합반 명 |
+| JONG_PRICE | INT | 종합반 정가 |
+| JONG_SALE_PRICE | INT | 종합반 판매가 |
+| ISUSE | CHAR(1) | 사용여부 (Y/N) |
+| INDATE | DATETIME | 등록일 |
+| JONG_INFO | TEXT | 종합반 정보 |
+| JONG_CONTENT | TEXT | 종합반 내용 |
+
+## 검색 조건
+
+### 단과 강의 목록
+| 파라미터 | 타입 | 설명 |
+|---------|------|------|
+| categoryCd | String | 카테고리 코드 |
+| learningCd | String | 과목 코드 |
+| teacherKey | String | 강사 키 |
+| isuse | String | 사용여부 (Y/N) |
+| searchKeyword | String | 강의 제목 검색 |
+
+### 종합반 강의 목록
+| 파라미터 | 타입 | 설명 |
+|---------|------|------|
+| gubun | String | 구분 |
+| isuse | String | 사용여부 (Y/N) |
+| searchKeyword | String | 종합반 명 검색 |
+
+## 강의코드 형식
+
+강의코드는 자동 생성되며 다음과 같은 형식입니다:
+- 형식: `OFF` + `YYYYMMDD` + `0001`
+- 예시: `OFF202312120001`
+
+## 사용 예시
+
+### 단과 강의 목록 조회
+```
+GET /api/lectureOff/getLectureList?categoryCd=CAT001&isuse=Y&pageIndex=1&pageUnit=10
+```
+
+### 단과 강의 등록
+```
+POST /api/lectureOff/insertLecture
+Content-Type: application/x-www-form-urlencoded
+
+leccode=OFF202312120001&categoryCd=CAT001&learningCd=LRN001&subjectTitle=테스트 강의&teacherKey=TCH001&price=100000&salePrice=80000&isuse=Y
+```
+
+### 종합반 강의 등록
+```
+POST /api/lectureOff/insertJongLecture
+Content-Type: application/x-www-form-urlencoded
+
+gubun=A&jongNm=종합반 테스트&jongPrice=500000&jongSalePrice=400000&isuse=Y
+```
+
+### 종합반 강의 구성 등록
+```
+POST /api/lectureOff/insertJongLectureDetail
+Content-Type: application/x-www-form-urlencoded
+
+jongseq=1&mstLeccode=OFF202312120001&sort=1
+```
+
+## 관련 Mapper
+
+- **LectureOffMapper.java**: `com.academy.mapper.LectureOffMapper`
+- **lectureOff.xml**: `src/main/resources/mapper/lectureOff.xml`
+
+---
+
+## Copyright
+
+<img src="../../../../../../../../UM_CI.png" alt="UM Systems" width="10%">
+
+**Copyright (c) 2021 운몽시스템즈(UM Systems). All rights reserved.**

--- a/src/main/java/com/academy/lectureOff/service/LectureOffService.java
+++ b/src/main/java/com/academy/lectureOff/service/LectureOffService.java
@@ -1,0 +1,237 @@
+package com.academy.lectureOff.service;
+
+import java.io.Serializable;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.academy.mapper.LectureOffMapper;
+
+/**
+ * 오프라인 강의 관리 서비스
+ */
+@Service
+public class LectureOffService implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final LectureOffMapper lectureOffMapper;
+
+    @Autowired
+    public LectureOffService(LectureOffMapper lectureOffMapper) {
+        this.lectureOffMapper = lectureOffMapper;
+    }
+
+    // === 단과 강의 관리 ===
+    public List<LectureOffVO> getLectureList(LectureOffVO vo) {
+        return lectureOffMapper.selectLectureList(vo);
+    }
+
+    public int getLectureListCount(LectureOffVO vo) {
+        return lectureOffMapper.selectLectureListCount(vo);
+    }
+
+    public LectureOffVO getLectureDetail(LectureOffVO vo) {
+        return lectureOffMapper.selectLectureDetail(vo);
+    }
+
+    @Transactional
+    public int insertLecture(LectureOffVO vo) {
+        return lectureOffMapper.insertLecture(vo);
+    }
+
+    @Transactional
+    public int updateLecture(LectureOffVO vo) {
+        return lectureOffMapper.updateLecture(vo);
+    }
+
+    @Transactional
+    public int deleteLecture(LectureOffVO vo) {
+        // 관련 데이터 삭제
+        lectureOffMapper.deleteLectureBridgeByLeccode(vo);
+        lectureOffMapper.deleteLectureBookByLeccode(vo);
+        lectureOffMapper.deleteLectureDateByLeccode(vo);
+        // 강의 삭제
+        return lectureOffMapper.deleteLecture(vo);
+    }
+
+    // === 강의 브릿지 관리 ===
+    public List<LectureOffVO> getLectureBridgeList(LectureOffVO vo) {
+        return lectureOffMapper.selectLectureBridgeList(vo);
+    }
+
+    @Transactional
+    public int insertLectureBridge(LectureOffVO vo) {
+        return lectureOffMapper.insertLectureBridge(vo);
+    }
+
+    @Transactional
+    public int deleteLectureBridge(LectureOffVO vo) {
+        return lectureOffMapper.deleteLectureBridge(vo);
+    }
+
+    @Transactional
+    public void saveLectureBridgeList(LectureOffVO vo, List<LectureOffVO> bridgeList) {
+        // 기존 브릿지 삭제
+        lectureOffMapper.deleteLectureBridgeByLeccode(vo);
+        // 새 브릿지 등록
+        for (LectureOffVO bridge : bridgeList) {
+            bridge.setLeccode(vo.getLeccode());
+            lectureOffMapper.insertLectureBridge(bridge);
+        }
+    }
+
+    // === 강의 교재 관리 ===
+    public List<LectureOffVO> getLectureBookList(LectureOffVO vo) {
+        return lectureOffMapper.selectLectureBookList(vo);
+    }
+
+    public List<LectureOffVO> getBookSearchList(LectureOffVO vo) {
+        return lectureOffMapper.selectBookSearchList(vo);
+    }
+
+    @Transactional
+    public int insertLectureBook(LectureOffVO vo) {
+        return lectureOffMapper.insertLectureBook(vo);
+    }
+
+    @Transactional
+    public int deleteLectureBook(LectureOffVO vo) {
+        return lectureOffMapper.deleteLectureBook(vo);
+    }
+
+    @Transactional
+    public void saveLectureBookList(LectureOffVO vo, List<LectureOffVO> bookList) {
+        // 기존 교재 삭제
+        lectureOffMapper.deleteLectureBookByLeccode(vo);
+        // 새 교재 등록
+        for (LectureOffVO book : bookList) {
+            book.setLeccode(vo.getLeccode());
+            lectureOffMapper.insertLectureBook(book);
+        }
+    }
+
+    // === 강의 일정 관리 ===
+    public List<LectureOffVO> getLectureDateList(LectureOffVO vo) {
+        return lectureOffMapper.selectLectureDateList(vo);
+    }
+
+    @Transactional
+    public int insertLectureDate(LectureOffVO vo) {
+        return lectureOffMapper.insertLectureDate(vo);
+    }
+
+    @Transactional
+    public int deleteLectureDate(LectureOffVO vo) {
+        return lectureOffMapper.deleteLectureDate(vo);
+    }
+
+    @Transactional
+    public void saveLectureDateList(LectureOffVO vo, List<LectureOffVO> dateList) {
+        // 기존 일정 삭제
+        lectureOffMapper.deleteLectureDateByLeccode(vo);
+        // 새 일정 등록
+        for (LectureOffVO date : dateList) {
+            date.setLeccode(vo.getLeccode());
+            lectureOffMapper.insertLectureDate(date);
+        }
+    }
+
+    // === 종합반 강의 관리 ===
+    public List<LectureOffVO> getJongLectureList(LectureOffVO vo) {
+        return lectureOffMapper.selectJongLectureList(vo);
+    }
+
+    public int getJongLectureListCount(LectureOffVO vo) {
+        return lectureOffMapper.selectJongLectureListCount(vo);
+    }
+
+    public LectureOffVO getJongLectureDetail(LectureOffVO vo) {
+        return lectureOffMapper.selectJongLectureDetail(vo);
+    }
+
+    @Transactional
+    public int insertJongLecture(LectureOffVO vo) {
+        return lectureOffMapper.insertJongLecture(vo);
+    }
+
+    @Transactional
+    public int updateJongLecture(LectureOffVO vo) {
+        return lectureOffMapper.updateJongLecture(vo);
+    }
+
+    @Transactional
+    public int deleteJongLecture(LectureOffVO vo) {
+        // 관련 구성 데이터 삭제
+        lectureOffMapper.deleteJongLectureDetailByJongseq(vo);
+        // 종합반 삭제
+        return lectureOffMapper.deleteJongLecture(vo);
+    }
+
+    // === 종합반 강의 구성 관리 ===
+    public List<LectureOffVO> getJongLectureDetailList(LectureOffVO vo) {
+        return lectureOffMapper.selectJongLectureDetailList(vo);
+    }
+
+    @Transactional
+    public int insertJongLectureDetail(LectureOffVO vo) {
+        return lectureOffMapper.insertJongLectureDetail(vo);
+    }
+
+    @Transactional
+    public int deleteJongLectureDetail(LectureOffVO vo) {
+        return lectureOffMapper.deleteJongLectureDetail(vo);
+    }
+
+    @Transactional
+    public void saveJongLectureDetailList(LectureOffVO vo, List<LectureOffVO> detailList) {
+        // 기존 구성 삭제
+        lectureOffMapper.deleteJongLectureDetailByJongseq(vo);
+        // 새 구성 등록
+        int sort = 1;
+        for (LectureOffVO detail : detailList) {
+            detail.setJongseq(vo.getJongseq());
+            detail.setSort(sort++);
+            lectureOffMapper.insertJongLectureDetail(detail);
+        }
+    }
+
+    // === 선택형 종합반 관리 ===
+    public List<LectureOffVO> getChoiceJongList(LectureOffVO vo) {
+        return lectureOffMapper.selectChoiceJongList(vo);
+    }
+
+    @Transactional
+    public int insertChoiceJong(LectureOffVO vo) {
+        return lectureOffMapper.insertChoiceJong(vo);
+    }
+
+    @Transactional
+    public int deleteChoiceJong(LectureOffVO vo) {
+        return lectureOffMapper.deleteChoiceJong(vo);
+    }
+
+    // === 카테고리/과목/강사 조회 ===
+    public List<LectureOffVO> getCategoryList(LectureOffVO vo) {
+        return lectureOffMapper.selectCategoryList(vo);
+    }
+
+    public List<LectureOffVO> getSubjectList(LectureOffVO vo) {
+        return lectureOffMapper.selectSubjectList(vo);
+    }
+
+    public List<LectureOffVO> getTeacherList(LectureOffVO vo) {
+        return lectureOffMapper.selectTeacherList(vo);
+    }
+
+    // === 강의코드 생성 ===
+    public String getNextLeccode(LectureOffVO vo) {
+        return lectureOffMapper.selectNextLeccode(vo);
+    }
+
+    public int getNextJongseq() {
+        return lectureOffMapper.selectNextJongseq();
+    }
+}

--- a/src/main/java/com/academy/lectureOff/service/LectureOffVO.java
+++ b/src/main/java/com/academy/lectureOff/service/LectureOffVO.java
@@ -1,0 +1,754 @@
+package com.academy.lectureOff.service;
+
+import com.academy.common.CommonVO;
+
+/**
+ * 오프라인 강의 관리 VO
+ * - 단과 강의 (TB_OFF_LEC_MST)
+ * - 강의 브릿지 (TB_OFF_LEC_BRIDGE)
+ * - 종합반 강의 (TB_OFF_LEC_JONG)
+ * - 강의 일정 (TB_OFF_LECTURE_DATE)
+ * - 강의 교재 (TB_OFF_PLUS_CA_BOOK)
+ */
+public class LectureOffVO extends CommonVO {
+
+    private static final long serialVersionUID = 1L;
+
+    // === 강의 마스터 (TB_OFF_LEC_MST) ===
+    private Integer seq;                // 순번
+    private String leccode;             // 강의 코드
+    private String categoryCd;          // 직종 코드
+    private String categoryNm;          // 직종명
+    private String learningCd;          // 학습형태 코드
+    private String learningNm;          // 학습형태명
+    private String subjectType;         // 과목 타입
+    private String subjectGubun;        // 과목 구분
+    private String subjectMemberCnt;    // 수강인원
+    private String subjectTeacher;      // 강사 ID
+    private String subjectTeacherNm;    // 강사명
+    private String subjectTeacherPayment; // 강사 수당
+    private String subjectSjtCd;        // 과목 코드
+    private String subjectNm;           // 과목명
+    private String subjectTitle;        // 강의 제목
+    private String subjectDesc;         // 강의 설명
+    private String subjectKeyword;      // 키워드
+    private String subjectOpenDate;     // 개강일
+    private String subjectEndDate;      // 종강일
+    private String lecSchedule;         // 강의 스케줄
+    private String week1;               // 월요일
+    private String week2;               // 화요일
+    private String week3;               // 수요일
+    private String week4;               // 목요일
+    private String week5;               // 금요일
+    private String week6;               // 토요일
+    private String week7;               // 일요일
+    private String subjectDiscount;     // 할인율
+    private Integer subjectPrice;       // 정가
+    private Integer subjectRealPrice;   // 실제가
+    private String subjectSumnail;      // 썸네일
+    private String subjectIsuse;        // 사용여부 (Y/N)
+    private String lecTypeChoice;       // 강의타입 (D:단과, J:종합반, N:선택형종합반)
+    private String lecGubun;            // 강의 구분
+    private String recGubun;            // 녹화 구분
+    private String plan;                // 강의 계획
+    private Integer lecCount;           // 강의 횟수
+    private String lecProcess;          // 진행 상태
+    private String regDt;               // 등록일
+    private String regId;               // 등록자
+    private String updDt;               // 수정일
+    private String updId;               // 수정자
+
+    // === 강의 브릿지 (TB_OFF_LEC_BRIDGE) ===
+    private String bridgeLeccode;       // 브릿지 강의코드
+    private Integer bseq;               // 브릿지 순번
+
+    // === 종합반 (TB_OFF_LEC_JONG) ===
+    private Integer jongseq;            // 종합반 순번
+    private String mstLeccode;          // 마스터 강의코드
+    private String gubun;               // 구분 (1:필수, 2:선택)
+    private Integer sort;               // 정렬순서
+
+    // === 강의 일정 (TB_OFF_LECTURE_DATE) ===
+    private Integer num;                // 차시
+    private String lecDate;             // 강의일
+
+    // === 강의 교재 (TB_OFF_PLUS_CA_BOOK) ===
+    private Integer idx;                // 인덱스
+    private String rscId;               // 교재 ID
+    private String bookNm;              // 교재명
+    private String flag;                // 교재 구분 (J:주교재, B:부교재, S:수강생교재)
+    private String subjectBookMemo;     // 교재 메모
+
+    // === 수강자 정보 ===
+    private String userId;              // 사용자 ID
+    private String userNm;              // 사용자명
+    private String phoneNo;             // 전화번호
+    private String orderno;             // 주문번호
+    private Integer realprice;          // 실결제금액
+    private String paycode;             // 결제코드
+    private String payNm;               // 결제명
+    private Integer offerercnt;         // 수강인원
+
+    // === 선택형 종합반 ===
+    private Integer no;                 // 선택번호
+
+    // === 검색 조건 ===
+    private String searchKind;          // 직종 검색
+    private String searchForm;          // 학습형태 검색
+    private String searchYear;          // 연도 검색
+    private String searchOpenDate;      // 개강일 시작
+    private String searchEndDate;       // 개강일 종료
+    private String searchSubjectIsuse;  // 사용여부 검색
+    private String searchLecProcess;    // 진행상태 검색
+    private String searchType;          // 검색 타입
+    private String searchText;          // 검색어
+    private String searchPayYn;         // 유/무료 검색
+    private String searchOpenPage;      // 페이지 타입
+    private String searchPayType;       // 결제타입 검색
+    private String prefix;              // 코드 접두어
+    private String updateFlag;          // 수정 플래그 (ALL:전체)
+    private String bridgeLec;           // 브릿지 강의코드
+    private String bridgeLecs;          // 브릿지 강의코드 목록
+
+    // === Getters and Setters ===
+
+    public Integer getSeq() {
+        return seq;
+    }
+
+    public void setSeq(Integer seq) {
+        this.seq = seq;
+    }
+
+    public String getLeccode() {
+        return leccode;
+    }
+
+    public void setLeccode(String leccode) {
+        this.leccode = leccode;
+    }
+
+    public String getCategoryCd() {
+        return categoryCd;
+    }
+
+    public void setCategoryCd(String categoryCd) {
+        this.categoryCd = categoryCd;
+    }
+
+    public String getCategoryNm() {
+        return categoryNm;
+    }
+
+    public void setCategoryNm(String categoryNm) {
+        this.categoryNm = categoryNm;
+    }
+
+    public String getLearningCd() {
+        return learningCd;
+    }
+
+    public void setLearningCd(String learningCd) {
+        this.learningCd = learningCd;
+    }
+
+    public String getLearningNm() {
+        return learningNm;
+    }
+
+    public void setLearningNm(String learningNm) {
+        this.learningNm = learningNm;
+    }
+
+    public String getSubjectType() {
+        return subjectType;
+    }
+
+    public void setSubjectType(String subjectType) {
+        this.subjectType = subjectType;
+    }
+
+    public String getSubjectGubun() {
+        return subjectGubun;
+    }
+
+    public void setSubjectGubun(String subjectGubun) {
+        this.subjectGubun = subjectGubun;
+    }
+
+    public String getSubjectMemberCnt() {
+        return subjectMemberCnt;
+    }
+
+    public void setSubjectMemberCnt(String subjectMemberCnt) {
+        this.subjectMemberCnt = subjectMemberCnt;
+    }
+
+    public String getSubjectTeacher() {
+        return subjectTeacher;
+    }
+
+    public void setSubjectTeacher(String subjectTeacher) {
+        this.subjectTeacher = subjectTeacher;
+    }
+
+    public String getSubjectTeacherNm() {
+        return subjectTeacherNm;
+    }
+
+    public void setSubjectTeacherNm(String subjectTeacherNm) {
+        this.subjectTeacherNm = subjectTeacherNm;
+    }
+
+    public String getSubjectTeacherPayment() {
+        return subjectTeacherPayment;
+    }
+
+    public void setSubjectTeacherPayment(String subjectTeacherPayment) {
+        this.subjectTeacherPayment = subjectTeacherPayment;
+    }
+
+    public String getSubjectSjtCd() {
+        return subjectSjtCd;
+    }
+
+    public void setSubjectSjtCd(String subjectSjtCd) {
+        this.subjectSjtCd = subjectSjtCd;
+    }
+
+    public String getSubjectNm() {
+        return subjectNm;
+    }
+
+    public void setSubjectNm(String subjectNm) {
+        this.subjectNm = subjectNm;
+    }
+
+    public String getSubjectTitle() {
+        return subjectTitle;
+    }
+
+    public void setSubjectTitle(String subjectTitle) {
+        this.subjectTitle = subjectTitle;
+    }
+
+    public String getSubjectDesc() {
+        return subjectDesc;
+    }
+
+    public void setSubjectDesc(String subjectDesc) {
+        this.subjectDesc = subjectDesc;
+    }
+
+    public String getSubjectKeyword() {
+        return subjectKeyword;
+    }
+
+    public void setSubjectKeyword(String subjectKeyword) {
+        this.subjectKeyword = subjectKeyword;
+    }
+
+    public String getSubjectOpenDate() {
+        return subjectOpenDate;
+    }
+
+    public void setSubjectOpenDate(String subjectOpenDate) {
+        this.subjectOpenDate = subjectOpenDate;
+    }
+
+    public String getSubjectEndDate() {
+        return subjectEndDate;
+    }
+
+    public void setSubjectEndDate(String subjectEndDate) {
+        this.subjectEndDate = subjectEndDate;
+    }
+
+    public String getLecSchedule() {
+        return lecSchedule;
+    }
+
+    public void setLecSchedule(String lecSchedule) {
+        this.lecSchedule = lecSchedule;
+    }
+
+    public String getWeek1() {
+        return week1;
+    }
+
+    public void setWeek1(String week1) {
+        this.week1 = week1;
+    }
+
+    public String getWeek2() {
+        return week2;
+    }
+
+    public void setWeek2(String week2) {
+        this.week2 = week2;
+    }
+
+    public String getWeek3() {
+        return week3;
+    }
+
+    public void setWeek3(String week3) {
+        this.week3 = week3;
+    }
+
+    public String getWeek4() {
+        return week4;
+    }
+
+    public void setWeek4(String week4) {
+        this.week4 = week4;
+    }
+
+    public String getWeek5() {
+        return week5;
+    }
+
+    public void setWeek5(String week5) {
+        this.week5 = week5;
+    }
+
+    public String getWeek6() {
+        return week6;
+    }
+
+    public void setWeek6(String week6) {
+        this.week6 = week6;
+    }
+
+    public String getWeek7() {
+        return week7;
+    }
+
+    public void setWeek7(String week7) {
+        this.week7 = week7;
+    }
+
+    public String getSubjectDiscount() {
+        return subjectDiscount;
+    }
+
+    public void setSubjectDiscount(String subjectDiscount) {
+        this.subjectDiscount = subjectDiscount;
+    }
+
+    public Integer getSubjectPrice() {
+        return subjectPrice;
+    }
+
+    public void setSubjectPrice(Integer subjectPrice) {
+        this.subjectPrice = subjectPrice;
+    }
+
+    public Integer getSubjectRealPrice() {
+        return subjectRealPrice;
+    }
+
+    public void setSubjectRealPrice(Integer subjectRealPrice) {
+        this.subjectRealPrice = subjectRealPrice;
+    }
+
+    public String getSubjectSumnail() {
+        return subjectSumnail;
+    }
+
+    public void setSubjectSumnail(String subjectSumnail) {
+        this.subjectSumnail = subjectSumnail;
+    }
+
+    public String getSubjectIsuse() {
+        return subjectIsuse;
+    }
+
+    public void setSubjectIsuse(String subjectIsuse) {
+        this.subjectIsuse = subjectIsuse;
+    }
+
+    public String getLecTypeChoice() {
+        return lecTypeChoice;
+    }
+
+    public void setLecTypeChoice(String lecTypeChoice) {
+        this.lecTypeChoice = lecTypeChoice;
+    }
+
+    public String getLecGubun() {
+        return lecGubun;
+    }
+
+    public void setLecGubun(String lecGubun) {
+        this.lecGubun = lecGubun;
+    }
+
+    public String getRecGubun() {
+        return recGubun;
+    }
+
+    public void setRecGubun(String recGubun) {
+        this.recGubun = recGubun;
+    }
+
+    public String getPlan() {
+        return plan;
+    }
+
+    public void setPlan(String plan) {
+        this.plan = plan;
+    }
+
+    public Integer getLecCount() {
+        return lecCount;
+    }
+
+    public void setLecCount(Integer lecCount) {
+        this.lecCount = lecCount;
+    }
+
+    public String getLecProcess() {
+        return lecProcess;
+    }
+
+    public void setLecProcess(String lecProcess) {
+        this.lecProcess = lecProcess;
+    }
+
+    public String getRegDt() {
+        return regDt;
+    }
+
+    public void setRegDt(String regDt) {
+        this.regDt = regDt;
+    }
+
+    public String getRegId() {
+        return regId;
+    }
+
+    public void setRegId(String regId) {
+        this.regId = regId;
+    }
+
+    public String getUpdDt() {
+        return updDt;
+    }
+
+    public void setUpdDt(String updDt) {
+        this.updDt = updDt;
+    }
+
+    public String getUpdId() {
+        return updId;
+    }
+
+    public void setUpdId(String updId) {
+        this.updId = updId;
+    }
+
+    public String getBridgeLeccode() {
+        return bridgeLeccode;
+    }
+
+    public void setBridgeLeccode(String bridgeLeccode) {
+        this.bridgeLeccode = bridgeLeccode;
+    }
+
+    public Integer getBseq() {
+        return bseq;
+    }
+
+    public void setBseq(Integer bseq) {
+        this.bseq = bseq;
+    }
+
+    public Integer getJongseq() {
+        return jongseq;
+    }
+
+    public void setJongseq(Integer jongseq) {
+        this.jongseq = jongseq;
+    }
+
+    public String getMstLeccode() {
+        return mstLeccode;
+    }
+
+    public void setMstLeccode(String mstLeccode) {
+        this.mstLeccode = mstLeccode;
+    }
+
+    public String getGubun() {
+        return gubun;
+    }
+
+    public void setGubun(String gubun) {
+        this.gubun = gubun;
+    }
+
+    public Integer getSort() {
+        return sort;
+    }
+
+    public void setSort(Integer sort) {
+        this.sort = sort;
+    }
+
+    public Integer getNum() {
+        return num;
+    }
+
+    public void setNum(Integer num) {
+        this.num = num;
+    }
+
+    public String getLecDate() {
+        return lecDate;
+    }
+
+    public void setLecDate(String lecDate) {
+        this.lecDate = lecDate;
+    }
+
+    public Integer getIdx() {
+        return idx;
+    }
+
+    public void setIdx(Integer idx) {
+        this.idx = idx;
+    }
+
+    public String getRscId() {
+        return rscId;
+    }
+
+    public void setRscId(String rscId) {
+        this.rscId = rscId;
+    }
+
+    public String getBookNm() {
+        return bookNm;
+    }
+
+    public void setBookNm(String bookNm) {
+        this.bookNm = bookNm;
+    }
+
+    public String getFlag() {
+        return flag;
+    }
+
+    public void setFlag(String flag) {
+        this.flag = flag;
+    }
+
+    public String getSubjectBookMemo() {
+        return subjectBookMemo;
+    }
+
+    public void setSubjectBookMemo(String subjectBookMemo) {
+        this.subjectBookMemo = subjectBookMemo;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getUserNm() {
+        return userNm;
+    }
+
+    public void setUserNm(String userNm) {
+        this.userNm = userNm;
+    }
+
+    public String getPhoneNo() {
+        return phoneNo;
+    }
+
+    public void setPhoneNo(String phoneNo) {
+        this.phoneNo = phoneNo;
+    }
+
+    public String getOrderno() {
+        return orderno;
+    }
+
+    public void setOrderno(String orderno) {
+        this.orderno = orderno;
+    }
+
+    public Integer getRealprice() {
+        return realprice;
+    }
+
+    public void setRealprice(Integer realprice) {
+        this.realprice = realprice;
+    }
+
+    public String getPaycode() {
+        return paycode;
+    }
+
+    public void setPaycode(String paycode) {
+        this.paycode = paycode;
+    }
+
+    public String getPayNm() {
+        return payNm;
+    }
+
+    public void setPayNm(String payNm) {
+        this.payNm = payNm;
+    }
+
+    public Integer getOfferercnt() {
+        return offerercnt;
+    }
+
+    public void setOfferercnt(Integer offerercnt) {
+        this.offerercnt = offerercnt;
+    }
+
+    public Integer getNo() {
+        return no;
+    }
+
+    public void setNo(Integer no) {
+        this.no = no;
+    }
+
+    public String getSearchKind() {
+        return searchKind;
+    }
+
+    public void setSearchKind(String searchKind) {
+        this.searchKind = searchKind;
+    }
+
+    public String getSearchForm() {
+        return searchForm;
+    }
+
+    public void setSearchForm(String searchForm) {
+        this.searchForm = searchForm;
+    }
+
+    public String getSearchYear() {
+        return searchYear;
+    }
+
+    public void setSearchYear(String searchYear) {
+        this.searchYear = searchYear;
+    }
+
+    public String getSearchOpenDate() {
+        return searchOpenDate;
+    }
+
+    public void setSearchOpenDate(String searchOpenDate) {
+        this.searchOpenDate = searchOpenDate;
+    }
+
+    public String getSearchEndDate() {
+        return searchEndDate;
+    }
+
+    public void setSearchEndDate(String searchEndDate) {
+        this.searchEndDate = searchEndDate;
+    }
+
+    public String getSearchSubjectIsuse() {
+        return searchSubjectIsuse;
+    }
+
+    public void setSearchSubjectIsuse(String searchSubjectIsuse) {
+        this.searchSubjectIsuse = searchSubjectIsuse;
+    }
+
+    public String getSearchLecProcess() {
+        return searchLecProcess;
+    }
+
+    public void setSearchLecProcess(String searchLecProcess) {
+        this.searchLecProcess = searchLecProcess;
+    }
+
+    public String getSearchType() {
+        return searchType;
+    }
+
+    public void setSearchType(String searchType) {
+        this.searchType = searchType;
+    }
+
+    public String getSearchText() {
+        return searchText;
+    }
+
+    public void setSearchText(String searchText) {
+        this.searchText = searchText;
+    }
+
+    public String getSearchPayYn() {
+        return searchPayYn;
+    }
+
+    public void setSearchPayYn(String searchPayYn) {
+        this.searchPayYn = searchPayYn;
+    }
+
+    public String getSearchOpenPage() {
+        return searchOpenPage;
+    }
+
+    public void setSearchOpenPage(String searchOpenPage) {
+        this.searchOpenPage = searchOpenPage;
+    }
+
+    public String getSearchPayType() {
+        return searchPayType;
+    }
+
+    public void setSearchPayType(String searchPayType) {
+        this.searchPayType = searchPayType;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public String getUpdateFlag() {
+        return updateFlag;
+    }
+
+    public void setUpdateFlag(String updateFlag) {
+        this.updateFlag = updateFlag;
+    }
+
+    public String getBridgeLec() {
+        return bridgeLec;
+    }
+
+    public void setBridgeLec(String bridgeLec) {
+        this.bridgeLec = bridgeLec;
+    }
+
+    public String getBridgeLecs() {
+        return bridgeLecs;
+    }
+
+    public void setBridgeLecs(String bridgeLecs) {
+        this.bridgeLecs = bridgeLecs;
+    }
+}

--- a/src/main/java/com/academy/mapper/IndexMapper.java
+++ b/src/main/java/com/academy/mapper/IndexMapper.java
@@ -1,0 +1,32 @@
+package com.academy.mapper;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import com.academy.index.service.IndexVO;
+
+/**
+ * 인덱스/메뉴 관리 Mapper
+ */
+@Mapper
+public interface IndexMapper {
+
+    // === 메뉴 관리 ===
+    List<IndexVO> selectTopMenuList(IndexVO vo);
+    List<IndexVO> selectLeftMenuList(IndexVO vo);
+    List<IndexVO> selectLeftMenuTree(IndexVO vo);
+
+    // === 메뉴 마스터 관리 ===
+    List<IndexVO> selectMenuList(IndexVO vo);
+    int selectMenuListCount(IndexVO vo);
+    IndexVO selectMenuDetail(IndexVO vo);
+    int insertMenu(IndexVO vo);
+    int updateMenu(IndexVO vo);
+    int deleteMenu(IndexVO vo);
+
+    // === 사이트 메뉴 권한 관리 ===
+    List<IndexVO> selectSiteMenuList(IndexVO vo);
+    int insertSiteMenu(IndexVO vo);
+    int deleteSiteMenu(IndexVO vo);
+}

--- a/src/main/java/com/academy/mapper/LectureOffMapper.java
+++ b/src/main/java/com/academy/mapper/LectureOffMapper.java
@@ -1,0 +1,208 @@
+package com.academy.mapper;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import com.academy.lectureOff.service.LectureOffVO;
+
+/**
+ * 오프라인 강의 관리 Mapper
+ */
+@Mapper
+public interface LectureOffMapper {
+
+    // === 단과 강의 관리 ===
+    /**
+     * 단과 강의 목록 조회
+     */
+    List<LectureOffVO> selectLectureList(LectureOffVO vo);
+
+    /**
+     * 단과 강의 목록 카운트
+     */
+    int selectLectureListCount(LectureOffVO vo);
+
+    /**
+     * 단과 강의 상세 조회
+     */
+    LectureOffVO selectLectureDetail(LectureOffVO vo);
+
+    /**
+     * 단과 강의 등록
+     */
+    int insertLecture(LectureOffVO vo);
+
+    /**
+     * 단과 강의 수정
+     */
+    int updateLecture(LectureOffVO vo);
+
+    /**
+     * 단과 강의 삭제
+     */
+    int deleteLecture(LectureOffVO vo);
+
+    // === 강의 브릿지 관리 ===
+    /**
+     * 강의 브릿지 목록 조회
+     */
+    List<LectureOffVO> selectLectureBridgeList(LectureOffVO vo);
+
+    /**
+     * 강의 브릿지 등록
+     */
+    int insertLectureBridge(LectureOffVO vo);
+
+    /**
+     * 강의 브릿지 삭제
+     */
+    int deleteLectureBridge(LectureOffVO vo);
+
+    /**
+     * 강의 브릿지 전체 삭제 (강의코드 기준)
+     */
+    int deleteLectureBridgeByLeccode(LectureOffVO vo);
+
+    // === 강의 교재 관리 ===
+    /**
+     * 강의 교재 목록 조회
+     */
+    List<LectureOffVO> selectLectureBookList(LectureOffVO vo);
+
+    /**
+     * 교재 검색 목록 조회
+     */
+    List<LectureOffVO> selectBookSearchList(LectureOffVO vo);
+
+    /**
+     * 강의 교재 등록
+     */
+    int insertLectureBook(LectureOffVO vo);
+
+    /**
+     * 강의 교재 삭제
+     */
+    int deleteLectureBook(LectureOffVO vo);
+
+    /**
+     * 강의 교재 전체 삭제 (강의코드 기준)
+     */
+    int deleteLectureBookByLeccode(LectureOffVO vo);
+
+    // === 강의 일정 관리 ===
+    /**
+     * 강의 일정 목록 조회
+     */
+    List<LectureOffVO> selectLectureDateList(LectureOffVO vo);
+
+    /**
+     * 강의 일정 등록
+     */
+    int insertLectureDate(LectureOffVO vo);
+
+    /**
+     * 강의 일정 삭제
+     */
+    int deleteLectureDate(LectureOffVO vo);
+
+    /**
+     * 강의 일정 전체 삭제 (강의코드 기준)
+     */
+    int deleteLectureDateByLeccode(LectureOffVO vo);
+
+    // === 종합반 강의 관리 ===
+    /**
+     * 종합반 강의 목록 조회
+     */
+    List<LectureOffVO> selectJongLectureList(LectureOffVO vo);
+
+    /**
+     * 종합반 강의 목록 카운트
+     */
+    int selectJongLectureListCount(LectureOffVO vo);
+
+    /**
+     * 종합반 강의 상세 조회
+     */
+    LectureOffVO selectJongLectureDetail(LectureOffVO vo);
+
+    /**
+     * 종합반 강의 등록
+     */
+    int insertJongLecture(LectureOffVO vo);
+
+    /**
+     * 종합반 강의 수정
+     */
+    int updateJongLecture(LectureOffVO vo);
+
+    /**
+     * 종합반 강의 삭제
+     */
+    int deleteJongLecture(LectureOffVO vo);
+
+    // === 종합반 강의 구성 관리 ===
+    /**
+     * 종합반 강의 구성 목록 조회 (단과 강의 목록)
+     */
+    List<LectureOffVO> selectJongLectureDetailList(LectureOffVO vo);
+
+    /**
+     * 종합반 강의 구성 등록
+     */
+    int insertJongLectureDetail(LectureOffVO vo);
+
+    /**
+     * 종합반 강의 구성 삭제
+     */
+    int deleteJongLectureDetail(LectureOffVO vo);
+
+    /**
+     * 종합반 강의 구성 전체 삭제 (종합반 SEQ 기준)
+     */
+    int deleteJongLectureDetailByJongseq(LectureOffVO vo);
+
+    // === 선택형 종합반 관리 ===
+    /**
+     * 선택형 종합반 목록 조회
+     */
+    List<LectureOffVO> selectChoiceJongList(LectureOffVO vo);
+
+    /**
+     * 선택형 종합반 등록
+     */
+    int insertChoiceJong(LectureOffVO vo);
+
+    /**
+     * 선택형 종합반 삭제
+     */
+    int deleteChoiceJong(LectureOffVO vo);
+
+    // === 카테고리/과목 조회 ===
+    /**
+     * 카테고리 목록 조회
+     */
+    List<LectureOffVO> selectCategoryList(LectureOffVO vo);
+
+    /**
+     * 과목 목록 조회
+     */
+    List<LectureOffVO> selectSubjectList(LectureOffVO vo);
+
+    /**
+     * 강사 목록 조회
+     */
+    List<LectureOffVO> selectTeacherList(LectureOffVO vo);
+
+    // === 강의코드 생성 ===
+    /**
+     * 다음 강의코드 조회
+     */
+    String selectNextLeccode(LectureOffVO vo);
+
+    /**
+     * 다음 종합반 SEQ 조회
+     */
+    int selectNextJongseq();
+}

--- a/src/main/resources/mapper/index.xml
+++ b/src/main/resources/mapper/index.xml
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.academy.mapper.IndexMapper">
+
+    <!-- TOP 메뉴 목록 조회 -->
+    <select id="selectTopMenuList" parameterType="com.academy.index.service.IndexVO" resultType="com.academy.index.service.IndexVO">
+        SELECT c.MENU_ID AS menuId,
+               c.MENU_NM AS menuNm,
+               c.P_MENUID AS pMenuId,
+               c.MENU_URL AS menuUrl,
+               c.MENU_SEQ AS menuSeq
+          FROM (
+                SELECT b.MENU_ID, b.MENU_NM, b.P_MENUID, b.MENU_URL, b.MENU_SEQ
+                  FROM TB_SG_SITE_MENU a, TB_SG_MENU_MST b
+                 WHERE a.SITE_ID = #{adminRole}
+                   AND a.MENU_ID = b.MENU_ID
+                   AND b.ISUSE = 'Y'
+                   AND b.P_MENUID = #{menuType}
+               ) c
+         ORDER BY c.MENU_SEQ
+    </select>
+
+    <!-- LEFT 메뉴 목록 조회 -->
+    <select id="selectLeftMenuList" parameterType="com.academy.index.service.IndexVO" resultType="com.academy.index.service.IndexVO">
+        SELECT c.MENU_ID AS menuId,
+               c.MENU_NM AS menuNm,
+               c.P_MENUID AS pMenuId,
+               c.MENU_URL AS menuUrl,
+               c.MENU_SEQ AS menuSeq
+          FROM (
+                SELECT b.MENU_ID, b.MENU_NM, b.P_MENUID, b.MENU_URL, b.MENU_SEQ
+                  FROM TB_SG_SITE_MENU a, TB_SG_MENU_MST b
+                 WHERE a.SITE_ID = #{adminRole}
+                   AND a.MENU_ID = b.MENU_ID
+                   AND b.ISUSE = 'Y'
+                   AND b.P_MENUID = #{topMenuId}
+               ) c
+         ORDER BY c.MENU_SEQ
+    </select>
+
+    <!-- LEFT 메뉴 트리 조회 (MySQL용 - 재귀 CTE 사용) -->
+    <select id="selectLeftMenuTree" parameterType="com.academy.index.service.IndexVO" resultType="com.academy.index.service.IndexVO">
+        WITH RECURSIVE menu_tree AS (
+            <!-- 시작 노드 (TOP_MENU_ID 하위) -->
+            SELECT S.SITE_ID, M.MENU_ID, M.MENU_NM, M.MENU_URL, M.MENU_SEQ,
+                   IFNULL(M.P_MENUID, '-1') AS P_MENUID, M.TARGET, 1 AS MENU_LEVEL
+              FROM TB_SG_MENU_MST M
+              JOIN TB_SG_SITE_MENU S ON M.MENU_ID = S.MENU_ID
+             WHERE M.ISUSE = 'Y'
+               AND S.SITE_ID = #{adminRole}
+               AND M.P_MENUID = #{topMenuId}
+
+            UNION ALL
+
+            <!-- 재귀적으로 하위 메뉴 조회 -->
+            SELECT S.SITE_ID, M.MENU_ID, M.MENU_NM, M.MENU_URL, M.MENU_SEQ,
+                   IFNULL(M.P_MENUID, '-1') AS P_MENUID, M.TARGET, MT.MENU_LEVEL + 1
+              FROM TB_SG_MENU_MST M
+              JOIN TB_SG_SITE_MENU S ON M.MENU_ID = S.MENU_ID
+              JOIN menu_tree MT ON M.P_MENUID = MT.MENU_ID AND S.SITE_ID = MT.SITE_ID
+             WHERE M.ISUSE = 'Y'
+        )
+        SELECT SITE_ID AS siteId,
+               MENU_ID AS menuId,
+               MENU_NM AS menuNm,
+               MENU_URL AS menuUrl,
+               MENU_SEQ AS menuSeq,
+               P_MENUID AS pMenuId,
+               TARGET AS target,
+               MENU_LEVEL AS menuLevel
+          FROM menu_tree
+         ORDER BY MENU_SEQ, MENU_ID
+    </select>
+
+    <!-- 메뉴 마스터 목록 조회 -->
+    <select id="selectMenuList" parameterType="com.academy.index.service.IndexVO" resultType="com.academy.index.service.IndexVO">
+        SELECT MENU_ID AS menuId,
+               MENU_NM AS menuNm,
+               P_MENUID AS pMenuId,
+               MENU_URL AS menuUrl,
+               MENU_SEQ AS menuSeq,
+               TARGET AS target,
+               ISUSE AS isuse
+          FROM TB_SG_MENU_MST
+         WHERE 1=1
+        <if test="pMenuId != null and pMenuId != ''">
+           AND P_MENUID = #{pMenuId}
+        </if>
+        <if test="searchKeyword != null and searchKeyword != ''">
+           AND MENU_NM LIKE CONCAT('%', #{searchKeyword}, '%')
+        </if>
+        <if test="isuse != null and isuse != ''">
+           AND ISUSE = #{isuse}
+        </if>
+         ORDER BY P_MENUID, MENU_SEQ, MENU_ID
+         LIMIT #{recordCountPerPage} OFFSET #{firstIndex}
+    </select>
+
+    <!-- 메뉴 마스터 목록 카운트 -->
+    <select id="selectMenuListCount" parameterType="com.academy.index.service.IndexVO" resultType="int">
+        SELECT COUNT(*)
+          FROM TB_SG_MENU_MST
+         WHERE 1=1
+        <if test="pMenuId != null and pMenuId != ''">
+           AND P_MENUID = #{pMenuId}
+        </if>
+        <if test="searchKeyword != null and searchKeyword != ''">
+           AND MENU_NM LIKE CONCAT('%', #{searchKeyword}, '%')
+        </if>
+        <if test="isuse != null and isuse != ''">
+           AND ISUSE = #{isuse}
+        </if>
+    </select>
+
+    <!-- 메뉴 상세 조회 -->
+    <select id="selectMenuDetail" parameterType="com.academy.index.service.IndexVO" resultType="com.academy.index.service.IndexVO">
+        SELECT MENU_ID AS menuId,
+               MENU_NM AS menuNm,
+               P_MENUID AS pMenuId,
+               MENU_URL AS menuUrl,
+               MENU_SEQ AS menuSeq,
+               TARGET AS target,
+               ISUSE AS isuse
+          FROM TB_SG_MENU_MST
+         WHERE MENU_ID = #{menuId}
+    </select>
+
+    <!-- 메뉴 등록 -->
+    <insert id="insertMenu" parameterType="com.academy.index.service.IndexVO">
+        INSERT INTO TB_SG_MENU_MST (
+            MENU_ID, MENU_NM, P_MENUID, MENU_URL, MENU_SEQ, TARGET, ISUSE
+        ) VALUES (
+            #{menuId}, #{menuNm}, #{pMenuId}, #{menuUrl}, #{menuSeq}, #{target}, IFNULL(#{isuse}, 'Y')
+        )
+    </insert>
+
+    <!-- 메뉴 수정 -->
+    <update id="updateMenu" parameterType="com.academy.index.service.IndexVO">
+        UPDATE TB_SG_MENU_MST
+           SET MENU_NM = #{menuNm},
+               P_MENUID = #{pMenuId},
+               MENU_URL = #{menuUrl},
+               MENU_SEQ = #{menuSeq},
+               TARGET = #{target},
+               ISUSE = #{isuse}
+         WHERE MENU_ID = #{menuId}
+    </update>
+
+    <!-- 메뉴 삭제 -->
+    <delete id="deleteMenu" parameterType="com.academy.index.service.IndexVO">
+        DELETE FROM TB_SG_MENU_MST WHERE MENU_ID = #{menuId}
+    </delete>
+
+    <!-- 사이트 메뉴 권한 목록 조회 -->
+    <select id="selectSiteMenuList" parameterType="com.academy.index.service.IndexVO" resultType="com.academy.index.service.IndexVO">
+        SELECT S.SITE_ID AS siteId,
+               S.MENU_ID AS menuId,
+               M.MENU_NM AS menuNm,
+               M.MENU_URL AS menuUrl
+          FROM TB_SG_SITE_MENU S
+          JOIN TB_SG_MENU_MST M ON S.MENU_ID = M.MENU_ID
+         WHERE 1=1
+        <if test="siteId != null and siteId != ''">
+           AND S.SITE_ID = #{siteId}
+        </if>
+        <if test="menuId != null and menuId != ''">
+           AND S.MENU_ID = #{menuId}
+        </if>
+         ORDER BY M.MENU_SEQ
+    </select>
+
+    <!-- 사이트 메뉴 권한 등록 -->
+    <insert id="insertSiteMenu" parameterType="com.academy.index.service.IndexVO">
+        INSERT INTO TB_SG_SITE_MENU (
+            SITE_ID, MENU_ID
+        ) VALUES (
+            #{siteId}, #{menuId}
+        )
+    </insert>
+
+    <!-- 사이트 메뉴 권한 삭제 -->
+    <delete id="deleteSiteMenu" parameterType="com.academy.index.service.IndexVO">
+        DELETE FROM TB_SG_SITE_MENU
+         WHERE SITE_ID = #{siteId}
+        <if test="menuId != null and menuId != ''">
+           AND MENU_ID = #{menuId}
+        </if>
+    </delete>
+
+</mapper>

--- a/src/main/resources/mapper/lectureOff.xml
+++ b/src/main/resources/mapper/lectureOff.xml
@@ -1,0 +1,506 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.academy.mapper.LectureOffMapper">
+
+    <!-- ============================================= -->
+    <!-- 단과 강의 관리 -->
+    <!-- ============================================= -->
+
+    <!-- 단과 강의 목록 조회 -->
+    <select id="selectLectureList" parameterType="com.academy.lectureOff.service.LectureOffVO" resultType="com.academy.lectureOff.service.LectureOffVO">
+        SELECT A.SEQ AS seq,
+               A.LECCODE AS leccode,
+               A.CATEGORY_CD AS categoryCd,
+               A.LEARNING_CD AS learningCd,
+               A.SUBJECT_TITLE AS subjectTitle,
+               A.TEACHER_KEY AS teacherKey,
+               A.LEL_DATE AS lelDate,
+               A.LEC_GUBUN AS lecGubun,
+               A.KIND AS kind,
+               A.FORM AS form,
+               A.LEC_NUM AS lecNum,
+               A.PRICE AS price,
+               A.SALE_PRICE AS salePrice,
+               A.POINT_USER AS pointUser,
+               A.LIMIT_DAY AS limitDay,
+               A.MOBILE AS mobile,
+               A.ORG_PRICE AS orgPrice,
+               A.ISUSE AS isuse,
+               DATE_FORMAT(A.INDATE, '%Y-%m-%d %H:%i:%s') AS indateStr,
+               (SELECT CATEGORY_NM FROM TB_CATEGORY WHERE CATEGORY_CD = A.CATEGORY_CD LIMIT 1) AS categoryNm,
+               (SELECT LEARNING_NM FROM TB_LEARNING WHERE LEARNING_CD = A.LEARNING_CD LIMIT 1) AS learningNm,
+               (SELECT TEACHER_NM FROM TB_TEACHER WHERE TEACHER_KEY = A.TEACHER_KEY LIMIT 1) AS teacherNm
+          FROM TB_OFF_LEC_MST A
+         WHERE 1=1
+        <if test="categoryCd != null and categoryCd != ''">
+           AND A.CATEGORY_CD = #{categoryCd}
+        </if>
+        <if test="learningCd != null and learningCd != ''">
+           AND A.LEARNING_CD = #{learningCd}
+        </if>
+        <if test="teacherKey != null and teacherKey != ''">
+           AND A.TEACHER_KEY = #{teacherKey}
+        </if>
+        <if test="isuse != null and isuse != ''">
+           AND A.ISUSE = #{isuse}
+        </if>
+        <if test="searchKeyword != null and searchKeyword != ''">
+           AND A.SUBJECT_TITLE LIKE CONCAT('%', #{searchKeyword}, '%')
+        </if>
+         ORDER BY A.INDATE DESC, A.SEQ DESC
+         LIMIT #{recordCountPerPage} OFFSET #{firstIndex}
+    </select>
+
+    <!-- 단과 강의 목록 카운트 -->
+    <select id="selectLectureListCount" parameterType="com.academy.lectureOff.service.LectureOffVO" resultType="int">
+        SELECT COUNT(*)
+          FROM TB_OFF_LEC_MST A
+         WHERE 1=1
+        <if test="categoryCd != null and categoryCd != ''">
+           AND A.CATEGORY_CD = #{categoryCd}
+        </if>
+        <if test="learningCd != null and learningCd != ''">
+           AND A.LEARNING_CD = #{learningCd}
+        </if>
+        <if test="teacherKey != null and teacherKey != ''">
+           AND A.TEACHER_KEY = #{teacherKey}
+        </if>
+        <if test="isuse != null and isuse != ''">
+           AND A.ISUSE = #{isuse}
+        </if>
+        <if test="searchKeyword != null and searchKeyword != ''">
+           AND A.SUBJECT_TITLE LIKE CONCAT('%', #{searchKeyword}, '%')
+        </if>
+    </select>
+
+    <!-- 단과 강의 상세 조회 -->
+    <select id="selectLectureDetail" parameterType="com.academy.lectureOff.service.LectureOffVO" resultType="com.academy.lectureOff.service.LectureOffVO">
+        SELECT A.SEQ AS seq,
+               A.LECCODE AS leccode,
+               A.CATEGORY_CD AS categoryCd,
+               A.LEARNING_CD AS learningCd,
+               A.SUBJECT_TITLE AS subjectTitle,
+               A.TEACHER_KEY AS teacherKey,
+               A.LEL_DATE AS lelDate,
+               A.LEC_GUBUN AS lecGubun,
+               A.KIND AS kind,
+               A.FORM AS form,
+               A.LEC_NUM AS lecNum,
+               A.PRICE AS price,
+               A.SALE_PRICE AS salePrice,
+               A.POINT_USER AS pointUser,
+               A.LIMIT_DAY AS limitDay,
+               A.MOBILE AS mobile,
+               A.ORG_PRICE AS orgPrice,
+               A.ISUSE AS isuse,
+               A.INDATE AS indate,
+               A.LEC_INFO AS lecInfo,
+               A.LEC_CONTENT AS lecContent,
+               A.LEC_TIME AS lecTime,
+               A.PLACE AS place,
+               (SELECT CATEGORY_NM FROM TB_CATEGORY WHERE CATEGORY_CD = A.CATEGORY_CD LIMIT 1) AS categoryNm,
+               (SELECT LEARNING_NM FROM TB_LEARNING WHERE LEARNING_CD = A.LEARNING_CD LIMIT 1) AS learningNm,
+               (SELECT TEACHER_NM FROM TB_TEACHER WHERE TEACHER_KEY = A.TEACHER_KEY LIMIT 1) AS teacherNm
+          FROM TB_OFF_LEC_MST A
+         WHERE A.LECCODE = #{leccode}
+    </select>
+
+    <!-- 단과 강의 등록 -->
+    <insert id="insertLecture" parameterType="com.academy.lectureOff.service.LectureOffVO">
+        INSERT INTO TB_OFF_LEC_MST (
+            LECCODE, CATEGORY_CD, LEARNING_CD, SUBJECT_TITLE, TEACHER_KEY,
+            LEL_DATE, LEC_GUBUN, KIND, FORM, LEC_NUM,
+            PRICE, SALE_PRICE, POINT_USER, LIMIT_DAY, MOBILE,
+            ORG_PRICE, ISUSE, INDATE, LEC_INFO, LEC_CONTENT,
+            LEC_TIME, PLACE
+        ) VALUES (
+            #{leccode}, #{categoryCd}, #{learningCd}, #{subjectTitle}, #{teacherKey},
+            #{lelDate}, #{lecGubun}, #{kind}, #{form}, #{lecNum},
+            #{price}, #{salePrice}, #{pointUser}, #{limitDay}, #{mobile},
+            #{orgPrice}, IFNULL(#{isuse}, 'Y'), NOW(), #{lecInfo}, #{lecContent},
+            #{lecTime}, #{place}
+        )
+    </insert>
+
+    <!-- 단과 강의 수정 -->
+    <update id="updateLecture" parameterType="com.academy.lectureOff.service.LectureOffVO">
+        UPDATE TB_OFF_LEC_MST
+           SET CATEGORY_CD = #{categoryCd},
+               LEARNING_CD = #{learningCd},
+               SUBJECT_TITLE = #{subjectTitle},
+               TEACHER_KEY = #{teacherKey},
+               LEL_DATE = #{lelDate},
+               LEC_GUBUN = #{lecGubun},
+               KIND = #{kind},
+               FORM = #{form},
+               LEC_NUM = #{lecNum},
+               PRICE = #{price},
+               SALE_PRICE = #{salePrice},
+               POINT_USER = #{pointUser},
+               LIMIT_DAY = #{limitDay},
+               MOBILE = #{mobile},
+               ORG_PRICE = #{orgPrice},
+               ISUSE = #{isuse},
+               LEC_INFO = #{lecInfo},
+               LEC_CONTENT = #{lecContent},
+               LEC_TIME = #{lecTime},
+               PLACE = #{place}
+         WHERE LECCODE = #{leccode}
+    </update>
+
+    <!-- 단과 강의 삭제 -->
+    <delete id="deleteLecture" parameterType="com.academy.lectureOff.service.LectureOffVO">
+        DELETE FROM TB_OFF_LEC_MST WHERE LECCODE = #{leccode}
+    </delete>
+
+    <!-- ============================================= -->
+    <!-- 강의 브릿지 관리 -->
+    <!-- ============================================= -->
+
+    <!-- 강의 브릿지 목록 조회 -->
+    <select id="selectLectureBridgeList" parameterType="com.academy.lectureOff.service.LectureOffVO" resultType="com.academy.lectureOff.service.LectureOffVO">
+        SELECT A.BSEQ AS bseq,
+               A.LECCODE AS leccode,
+               A.BRIDGE_LECCODE AS bridgeLeccode,
+               B.SUBJECT_TITLE AS subjectTitle,
+               (SELECT TEACHER_NM FROM TB_TEACHER WHERE TEACHER_KEY = B.TEACHER_KEY LIMIT 1) AS teacherNm
+          FROM TB_OFF_LEC_BRIDGE A
+          LEFT JOIN TB_OFF_LEC_MST B ON A.BRIDGE_LECCODE = B.LECCODE
+         WHERE A.LECCODE = #{leccode}
+         ORDER BY A.BSEQ
+    </select>
+
+    <!-- 강의 브릿지 등록 -->
+    <insert id="insertLectureBridge" parameterType="com.academy.lectureOff.service.LectureOffVO">
+        INSERT INTO TB_OFF_LEC_BRIDGE (
+            LECCODE, BRIDGE_LECCODE
+        ) VALUES (
+            #{leccode}, #{bridgeLeccode}
+        )
+    </insert>
+
+    <!-- 강의 브릿지 삭제 -->
+    <delete id="deleteLectureBridge" parameterType="com.academy.lectureOff.service.LectureOffVO">
+        DELETE FROM TB_OFF_LEC_BRIDGE WHERE BSEQ = #{bseq}
+    </delete>
+
+    <!-- 강의 브릿지 전체 삭제 (강의코드 기준) -->
+    <delete id="deleteLectureBridgeByLeccode" parameterType="com.academy.lectureOff.service.LectureOffVO">
+        DELETE FROM TB_OFF_LEC_BRIDGE WHERE LECCODE = #{leccode}
+    </delete>
+
+    <!-- ============================================= -->
+    <!-- 강의 교재 관리 -->
+    <!-- ============================================= -->
+
+    <!-- 강의 교재 목록 조회 -->
+    <select id="selectLectureBookList" parameterType="com.academy.lectureOff.service.LectureOffVO" resultType="com.academy.lectureOff.service.LectureOffVO">
+        SELECT A.IDX AS idx,
+               A.LECCODE AS leccode,
+               A.RSC_ID AS rscId,
+               A.BOOK_NM AS bookNm,
+               A.FLAG AS flag,
+               B.RSC_NM AS rscNm,
+               B.PRICE AS bookPrice
+          FROM TB_OFF_PLUS_CA_BOOK A
+          LEFT JOIN TB_BOOK B ON A.RSC_ID = B.RSC_ID
+         WHERE A.LECCODE = #{leccode}
+         ORDER BY A.IDX
+    </select>
+
+    <!-- 교재 검색 목록 조회 -->
+    <select id="selectBookSearchList" parameterType="com.academy.lectureOff.service.LectureOffVO" resultType="com.academy.lectureOff.service.LectureOffVO">
+        SELECT RSC_ID AS rscId,
+               RSC_NM AS bookNm,
+               PRICE AS bookPrice,
+               ISUSE AS isuse
+          FROM TB_BOOK
+         WHERE ISUSE = 'Y'
+        <if test="searchKeyword != null and searchKeyword != ''">
+           AND RSC_NM LIKE CONCAT('%', #{searchKeyword}, '%')
+        </if>
+         ORDER BY RSC_NM
+         LIMIT 100
+    </select>
+
+    <!-- 강의 교재 등록 -->
+    <insert id="insertLectureBook" parameterType="com.academy.lectureOff.service.LectureOffVO">
+        INSERT INTO TB_OFF_PLUS_CA_BOOK (
+            LECCODE, RSC_ID, BOOK_NM, FLAG
+        ) VALUES (
+            #{leccode}, #{rscId}, #{bookNm}, IFNULL(#{flag}, 'N')
+        )
+    </insert>
+
+    <!-- 강의 교재 삭제 -->
+    <delete id="deleteLectureBook" parameterType="com.academy.lectureOff.service.LectureOffVO">
+        DELETE FROM TB_OFF_PLUS_CA_BOOK WHERE IDX = #{idx}
+    </delete>
+
+    <!-- 강의 교재 전체 삭제 (강의코드 기준) -->
+    <delete id="deleteLectureBookByLeccode" parameterType="com.academy.lectureOff.service.LectureOffVO">
+        DELETE FROM TB_OFF_PLUS_CA_BOOK WHERE LECCODE = #{leccode}
+    </delete>
+
+    <!-- ============================================= -->
+    <!-- 강의 일정 관리 -->
+    <!-- ============================================= -->
+
+    <!-- 강의 일정 목록 조회 -->
+    <select id="selectLectureDateList" parameterType="com.academy.lectureOff.service.LectureOffVO" resultType="com.academy.lectureOff.service.LectureOffVO">
+        SELECT NUM AS num,
+               LECCODE AS leccode,
+               DATE_FORMAT(LEC_DATE, '%Y-%m-%d') AS lecDate
+          FROM TB_OFF_LECTURE_DATE
+         WHERE LECCODE = #{leccode}
+         ORDER BY NUM, LEC_DATE
+    </select>
+
+    <!-- 강의 일정 등록 -->
+    <insert id="insertLectureDate" parameterType="com.academy.lectureOff.service.LectureOffVO">
+        INSERT INTO TB_OFF_LECTURE_DATE (
+            LECCODE, LEC_DATE
+        ) VALUES (
+            #{leccode}, #{lecDate}
+        )
+    </insert>
+
+    <!-- 강의 일정 삭제 -->
+    <delete id="deleteLectureDate" parameterType="com.academy.lectureOff.service.LectureOffVO">
+        DELETE FROM TB_OFF_LECTURE_DATE WHERE NUM = #{num}
+    </delete>
+
+    <!-- 강의 일정 전체 삭제 (강의코드 기준) -->
+    <delete id="deleteLectureDateByLeccode" parameterType="com.academy.lectureOff.service.LectureOffVO">
+        DELETE FROM TB_OFF_LECTURE_DATE WHERE LECCODE = #{leccode}
+    </delete>
+
+    <!-- ============================================= -->
+    <!-- 종합반 강의 관리 -->
+    <!-- ============================================= -->
+
+    <!-- 종합반 강의 목록 조회 -->
+    <select id="selectJongLectureList" parameterType="com.academy.lectureOff.service.LectureOffVO" resultType="com.academy.lectureOff.service.LectureOffVO">
+        SELECT A.JONGSEQ AS jongseq,
+               A.MST_LECCODE AS mstLeccode,
+               A.GUBUN AS gubun,
+               A.JONG_NM AS jongNm,
+               A.JONG_PRICE AS jongPrice,
+               A.JONG_SALE_PRICE AS jongSalePrice,
+               A.ISUSE AS isuse,
+               DATE_FORMAT(A.INDATE, '%Y-%m-%d %H:%i:%s') AS indateStr,
+               (SELECT COUNT(*) FROM TB_OFF_LEC_JONG WHERE JONGSEQ = A.JONGSEQ) AS lecCount
+          FROM TB_OFF_LEC_JONG_MST A
+         WHERE 1=1
+        <if test="gubun != null and gubun != ''">
+           AND A.GUBUN = #{gubun}
+        </if>
+        <if test="isuse != null and isuse != ''">
+           AND A.ISUSE = #{isuse}
+        </if>
+        <if test="searchKeyword != null and searchKeyword != ''">
+           AND A.JONG_NM LIKE CONCAT('%', #{searchKeyword}, '%')
+        </if>
+         ORDER BY A.INDATE DESC, A.JONGSEQ DESC
+         LIMIT #{recordCountPerPage} OFFSET #{firstIndex}
+    </select>
+
+    <!-- 종합반 강의 목록 카운트 -->
+    <select id="selectJongLectureListCount" parameterType="com.academy.lectureOff.service.LectureOffVO" resultType="int">
+        SELECT COUNT(*)
+          FROM TB_OFF_LEC_JONG_MST A
+         WHERE 1=1
+        <if test="gubun != null and gubun != ''">
+           AND A.GUBUN = #{gubun}
+        </if>
+        <if test="isuse != null and isuse != ''">
+           AND A.ISUSE = #{isuse}
+        </if>
+        <if test="searchKeyword != null and searchKeyword != ''">
+           AND A.JONG_NM LIKE CONCAT('%', #{searchKeyword}, '%')
+        </if>
+    </select>
+
+    <!-- 종합반 강의 상세 조회 -->
+    <select id="selectJongLectureDetail" parameterType="com.academy.lectureOff.service.LectureOffVO" resultType="com.academy.lectureOff.service.LectureOffVO">
+        SELECT A.JONGSEQ AS jongseq,
+               A.MST_LECCODE AS mstLeccode,
+               A.GUBUN AS gubun,
+               A.JONG_NM AS jongNm,
+               A.JONG_PRICE AS jongPrice,
+               A.JONG_SALE_PRICE AS jongSalePrice,
+               A.ISUSE AS isuse,
+               A.INDATE AS indate,
+               A.JONG_INFO AS jongInfo,
+               A.JONG_CONTENT AS jongContent
+          FROM TB_OFF_LEC_JONG_MST A
+         WHERE A.JONGSEQ = #{jongseq}
+    </select>
+
+    <!-- 종합반 강의 등록 -->
+    <insert id="insertJongLecture" parameterType="com.academy.lectureOff.service.LectureOffVO">
+        INSERT INTO TB_OFF_LEC_JONG_MST (
+            MST_LECCODE, GUBUN, JONG_NM, JONG_PRICE, JONG_SALE_PRICE,
+            ISUSE, INDATE, JONG_INFO, JONG_CONTENT
+        ) VALUES (
+            #{mstLeccode}, #{gubun}, #{jongNm}, #{jongPrice}, #{jongSalePrice},
+            IFNULL(#{isuse}, 'Y'), NOW(), #{jongInfo}, #{jongContent}
+        )
+        <selectKey keyProperty="jongseq" resultType="int" order="AFTER">
+            SELECT LAST_INSERT_ID()
+        </selectKey>
+    </insert>
+
+    <!-- 종합반 강의 수정 -->
+    <update id="updateJongLecture" parameterType="com.academy.lectureOff.service.LectureOffVO">
+        UPDATE TB_OFF_LEC_JONG_MST
+           SET MST_LECCODE = #{mstLeccode},
+               GUBUN = #{gubun},
+               JONG_NM = #{jongNm},
+               JONG_PRICE = #{jongPrice},
+               JONG_SALE_PRICE = #{jongSalePrice},
+               ISUSE = #{isuse},
+               JONG_INFO = #{jongInfo},
+               JONG_CONTENT = #{jongContent}
+         WHERE JONGSEQ = #{jongseq}
+    </update>
+
+    <!-- 종합반 강의 삭제 -->
+    <delete id="deleteJongLecture" parameterType="com.academy.lectureOff.service.LectureOffVO">
+        DELETE FROM TB_OFF_LEC_JONG_MST WHERE JONGSEQ = #{jongseq}
+    </delete>
+
+    <!-- ============================================= -->
+    <!-- 종합반 강의 구성 관리 -->
+    <!-- ============================================= -->
+
+    <!-- 종합반 강의 구성 목록 조회 (단과 강의 목록) -->
+    <select id="selectJongLectureDetailList" parameterType="com.academy.lectureOff.service.LectureOffVO" resultType="com.academy.lectureOff.service.LectureOffVO">
+        SELECT A.JONGSEQ AS jongseq,
+               A.MST_LECCODE AS mstLeccode,
+               A.SORT AS sort,
+               B.SUBJECT_TITLE AS subjectTitle,
+               B.PRICE AS price,
+               B.SALE_PRICE AS salePrice,
+               (SELECT TEACHER_NM FROM TB_TEACHER WHERE TEACHER_KEY = B.TEACHER_KEY LIMIT 1) AS teacherNm,
+               (SELECT CATEGORY_NM FROM TB_CATEGORY WHERE CATEGORY_CD = B.CATEGORY_CD LIMIT 1) AS categoryNm
+          FROM TB_OFF_LEC_JONG A
+          LEFT JOIN TB_OFF_LEC_MST B ON A.MST_LECCODE = B.LECCODE
+         WHERE A.JONGSEQ = #{jongseq}
+         ORDER BY A.SORT
+    </select>
+
+    <!-- 종합반 강의 구성 등록 -->
+    <insert id="insertJongLectureDetail" parameterType="com.academy.lectureOff.service.LectureOffVO">
+        INSERT INTO TB_OFF_LEC_JONG (
+            JONGSEQ, MST_LECCODE, SORT
+        ) VALUES (
+            #{jongseq}, #{mstLeccode}, #{sort}
+        )
+    </insert>
+
+    <!-- 종합반 강의 구성 삭제 -->
+    <delete id="deleteJongLectureDetail" parameterType="com.academy.lectureOff.service.LectureOffVO">
+        DELETE FROM TB_OFF_LEC_JONG
+         WHERE JONGSEQ = #{jongseq}
+           AND MST_LECCODE = #{mstLeccode}
+    </delete>
+
+    <!-- 종합반 강의 구성 전체 삭제 (종합반 SEQ 기준) -->
+    <delete id="deleteJongLectureDetailByJongseq" parameterType="com.academy.lectureOff.service.LectureOffVO">
+        DELETE FROM TB_OFF_LEC_JONG WHERE JONGSEQ = #{jongseq}
+    </delete>
+
+    <!-- ============================================= -->
+    <!-- 선택형 종합반 관리 -->
+    <!-- ============================================= -->
+
+    <!-- 선택형 종합반 목록 조회 -->
+    <select id="selectChoiceJongList" parameterType="com.academy.lectureOff.service.LectureOffVO" resultType="com.academy.lectureOff.service.LectureOffVO">
+        SELECT A.JONGSEQ AS jongseq,
+               A.JONG_NO AS jongNo,
+               A.LECCODE AS leccode,
+               B.SUBJECT_TITLE AS subjectTitle,
+               (SELECT TEACHER_NM FROM TB_TEACHER WHERE TEACHER_KEY = B.TEACHER_KEY LIMIT 1) AS teacherNm
+          FROM TB_OFF_CHOICE_JONG_NO A
+          LEFT JOIN TB_OFF_LEC_MST B ON A.LECCODE = B.LECCODE
+         WHERE A.JONGSEQ = #{jongseq}
+         ORDER BY A.JONG_NO, A.LECCODE
+    </select>
+
+    <!-- 선택형 종합반 등록 -->
+    <insert id="insertChoiceJong" parameterType="com.academy.lectureOff.service.LectureOffVO">
+        INSERT INTO TB_OFF_CHOICE_JONG_NO (
+            JONGSEQ, JONG_NO, LECCODE
+        ) VALUES (
+            #{jongseq}, #{jongNo}, #{leccode}
+        )
+    </insert>
+
+    <!-- 선택형 종합반 삭제 -->
+    <delete id="deleteChoiceJong" parameterType="com.academy.lectureOff.service.LectureOffVO">
+        DELETE FROM TB_OFF_CHOICE_JONG_NO
+         WHERE JONGSEQ = #{jongseq}
+        <if test="jongNo != null and jongNo != ''">
+           AND JONG_NO = #{jongNo}
+        </if>
+        <if test="leccode != null and leccode != ''">
+           AND LECCODE = #{leccode}
+        </if>
+    </delete>
+
+    <!-- ============================================= -->
+    <!-- 카테고리/과목/강사 조회 -->
+    <!-- ============================================= -->
+
+    <!-- 카테고리 목록 조회 -->
+    <select id="selectCategoryList" parameterType="com.academy.lectureOff.service.LectureOffVO" resultType="com.academy.lectureOff.service.LectureOffVO">
+        SELECT CATEGORY_CD AS categoryCd,
+               CATEGORY_NM AS categoryNm
+          FROM TB_CATEGORY
+         WHERE ISUSE = 'Y'
+         ORDER BY SORT_NO, CATEGORY_NM
+    </select>
+
+    <!-- 과목 목록 조회 -->
+    <select id="selectSubjectList" parameterType="com.academy.lectureOff.service.LectureOffVO" resultType="com.academy.lectureOff.service.LectureOffVO">
+        SELECT LEARNING_CD AS learningCd,
+               LEARNING_NM AS learningNm
+          FROM TB_LEARNING
+         WHERE ISUSE = 'Y'
+        <if test="categoryCd != null and categoryCd != ''">
+           AND CATEGORY_CD = #{categoryCd}
+        </if>
+         ORDER BY SORT_NO, LEARNING_NM
+    </select>
+
+    <!-- 강사 목록 조회 -->
+    <select id="selectTeacherList" parameterType="com.academy.lectureOff.service.LectureOffVO" resultType="com.academy.lectureOff.service.LectureOffVO">
+        SELECT TEACHER_KEY AS teacherKey,
+               TEACHER_NM AS teacherNm
+          FROM TB_TEACHER
+         WHERE ISUSE = 'Y'
+        <if test="learningCd != null and learningCd != ''">
+           AND LEARNING_CD = #{learningCd}
+        </if>
+         ORDER BY TEACHER_NM
+    </select>
+
+    <!-- ============================================= -->
+    <!-- 강의코드 생성 -->
+    <!-- ============================================= -->
+
+    <!-- 다음 강의코드 조회 -->
+    <select id="selectNextLeccode" parameterType="com.academy.lectureOff.service.LectureOffVO" resultType="string">
+        SELECT CONCAT('OFF', DATE_FORMAT(NOW(), '%Y%m%d'),
+                      LPAD(IFNULL(MAX(CAST(SUBSTRING(LECCODE, 12) AS UNSIGNED)), 0) + 1, 4, '0'))
+          FROM TB_OFF_LEC_MST
+         WHERE LECCODE LIKE CONCAT('OFF', DATE_FORMAT(NOW(), '%Y%m%d'), '%')
+    </select>
+
+    <!-- 다음 종합반 SEQ 조회 -->
+    <select id="selectNextJongseq" resultType="int">
+        SELECT IFNULL(MAX(JONGSEQ), 0) + 1 FROM TB_OFF_LEC_JONG_MST
+    </select>
+
+</mapper>


### PR DESCRIPTION
Implemented `IndexApi` with RESTful endpoints for managing menus and site permissions. Added `IndexMapper`, `IndexService`, and `IndexVO` to support database interactions and data handling for top/left menus, menu trees, and permissions. Introduced detailed MyBatis mapper XMLs for CRUD operations and queries.